### PR TITLE
Allow TRRT to use other optimization objectives

### DIFF
--- a/src/ompl/geometric/planners/rrt/src/TRRT.cpp
+++ b/src/ompl/geometric/planners/rrt/src/TRRT.cpp
@@ -104,11 +104,9 @@ void ompl::geometric::TRRT::setup(void)
         OMPL_INFORM("%s: No optimization objective specified.", getName().c_str());
         usingDefaultObjective = true;
     }
-    else if (!boost::dynamic_pointer_cast<
-             base::MechanicalWorkOptimizationObjective>(pdef_->getOptimizationObjective()))
+    else 
     {
-        OMPL_INFORM("%s: TRRT was supplied an inappropriate optimization objective; it can only handle types of ompl::base::MechanicalWorkOptimizationObjective.", getName().c_str());
-        usingDefaultObjective = true;
+        usingDefaultObjective = false;
     }
 
     if (usingDefaultObjective)


### PR DESCRIPTION
It appears that when OMPL had its cost framework revamped, TRRT was changed to only allow the Mechanical Work Optimization Objective to be used. This removes that restriction, which could cause a user to make a mistake and use the wrong objective, but it also allows other correct cost functions to be used like this example in the [ompl_rviz_viewer](https://github.com/davetcoleman/ompl_rviz_viewer/blob/lightening_framework/include/ompl_rviz_viewer/cost_map_optimization_objective.h)  - CostMapOptimizationObjective that gets its cost from an image.
