### PR TITLE
in the SteeredControlSampler Class, SpaceInformation pointer not assigned

### DIFF
--- a/src/ompl/control/SteeredControlSampler.h
+++ b/src/ompl/control/SteeredControlSampler.h
@@ -57,6 +57,8 @@ namespace ompl
             /** \brief Constructor takes the state space to construct samples for as argument */
             SteeredControlSampler(const SpaceInformation *si) : DirectedControlSampler(si)
             {
+                this->si_=si;
+
             }
 
             virtual ~SteeredControlSampler()


### PR DESCRIPTION
By trying to implement a Steer function I bumped in this debug message:

```
Reading symbols from /media/data/omplapp/build/Release/bin/demo_RigidBodyPlanningWithSteering...done.
(gdb) run
Starting program: /media/data/omplapp/build/Release/bin/demo_RigidBodyPlanningWithSteering
warning: no loadable sections found in added symbol-file system-supplied DSO at 0x7ffff7ffa000
[Thread debugging using libthread_db enabled]
Using host libthread_db library "/lib/x86_64-linux-gnu/libthread_db.so.1".
OMPL version: 0.15.0
POSQ Steer function activated
Warning: Assuming propagation will always have between 1 and 10 steps
         at line 56 in /media/data/omplapp/ompl/src/ompl/control/src/SpaceInformation.cpp
Warning: The propagation step size is assumed to be 0.157129
         at line 66 in /media/data/omplapp/ompl/src/ompl/control/src/SpaceInformation.cpp
[New Thread 0x7ffff575b700 (LWP 13402)]
Info:    RRT: Starting planning with 1 states already in datastructure

Program received signal SIGSEGV, Segmentation fault.
0x00007ffff7b0291e in boost::shared_ptr<ompl::control::StatePropagator>::operator-> (this=0xa0)
    at /usr/include/boost/smart_ptr/shared_ptr.hpp:418
418            BOOST_ASSERT(px != 0);
(gdb) bt
#0  0x00007ffff7b0291e in boost::shared_ptr<ompl::control::StatePropagator>::operator-> (this=0xa0)
    at /usr/include/boost/smart_ptr/shared_ptr.hpp:418
#1  0x00007ffff7b28fd0 in ompl::control::SteeredControlSampler::sampleTo (this=0x479140,
    control=0x4792b0, source=0x475020, dest=0x479210)
    at /media/data/omplapp/ompl/src/ompl/control/SteeredControlSampler.h:69
#2  0x00007ffff7b290cc in ompl::control::SteeredControlSampler::sampleTo (this=0x479140,
    control=0x4792b0, previous=0x4750c0, source=0x475020, dest=0x479210)
    at /media/data/omplapp/ompl/src/ompl/control/SteeredControlSampler.h:76
#3  0x00007ffff7aaecad in ompl::control::RRT::solve (this=0x46fae0, ptc=...)
    at /media/data/omplapp/ompl/src/ompl/control/planners/rrt/src/RRT.cpp:144
#4  0x00007ffff78af559 in ompl::base::Planner::solve (this=0x46fae0, solveTime=10)
    at /media/data/omplapp/ompl/src/ompl/base/src/Planner.cpp:132
#5  0x00007ffff7b25bc8 in ompl::control::SimpleSetup::solve (this=0x7fffffffdbf0, time=10)
    at /media/data/omplapp/ompl/src/ompl/control/src/SimpleSetup.cpp:113
#6  0x000000000044278c in planWithSimpleSetup ()
    at /media/data/omplapp/ompl/demos/RigidBodyPlanningWithSteering.cpp:248
#7  0x0000000000442a0f in main ()
    at /media/data/omplapp/ompl/demos/RigidBodyPlanningWithSteering.cpp:269
```

The SpaceInformation *si_ was not assigned in the constructor.
