### PR TITLE
Various Small Changes to SPARS implementation

### DIFF
--- a/src/ompl/geometric/planners/prm/SPARS.h
+++ b/src/ompl/geometric/planners/prm/SPARS.h
@@ -357,6 +357,12 @@ namespace ompl
             /** \brief Returns the average valence of the spanner graph */
             double averageValence() const;
 
+            /** \brief Print debug information about planner */
+            void printDebug(std::ostream &out = std::cout) const;
+
+            /** \brief Returns true if we have reached the iteration failures limit, \e maxFailures_  */
+            bool reachedFailureLimit() const;
+
         protected:
 
             /** \brief Attempt to add a single sample to the roadmap. */
@@ -427,9 +433,6 @@ namespace ompl
 
             /** \brief Returns true if we have reached the iteration failures limit, \e maxFailures_ or if a solution was added */
             bool reachedTerminationCriterion() const;
-
-            /** \brief Returns true if we have reached the iteration failures limit, \e maxFailures_  */
-            bool reachedFailureLimit() const;
 
             /** \brief Given two milestones from the same connected component, construct a path connecting them and set it as the solution */
             base::PathPtr constructSolution(const SparseVertex start, const SparseVertex goal) const;

--- a/src/ompl/geometric/planners/prm/src/SPARS.cpp
+++ b/src/ompl/geometric/planners/prm/src/SPARS.cpp
@@ -303,7 +303,7 @@ ompl::base::PlannerStatus ompl::geometric::SPARS::solve(const base::PlannerTermi
     addedSolution_ = false;
     resetFailures();
     base::PathPtr sol;
-    base::PlannerTerminationCondition ptcOrFail = 
+    base::PlannerTerminationCondition ptcOrFail =
         base::plannerOrTerminationCondition(ptc, base::PlannerTerminationCondition(boost::bind(&SPARS::reachedFailureLimit, this)));
     boost::thread slnThread(boost::bind(&SPARS::checkForSolution, this, ptcOrFail, boost::ref(sol)));
 
@@ -663,6 +663,22 @@ double ompl::geometric::SPARS::averageValence() const
         degree += (double)boost::out_degree(v, s_);
     degree /= (double)boost::num_vertices(s_);
     return degree;
+}
+
+void ompl::geometric::SPARS::printDebug(std::ostream &out) const
+{
+    out << "SPARS Debug Output: " << std::endl;
+    out << "  Settings: " << std::endl;
+    out << "    Max Failures: " << getMaxFailures() << std::endl;
+    out << "    Dense Delta Fraction: " << getDenseDeltaFraction() << std::endl;
+    out << "    Sparse Delta Fraction: " << getSparseDeltaFraction() << std::endl;
+    out << "    Stretch Factor: " << getStretchFactor() << std::endl;
+    out << "  Status: " << std::endl;
+    out << "    Milestone Count: " << milestoneCount() << std::endl;
+    out << "    Guard Count: " << guardCount() << std::endl;
+    out << "    Iterations: " << getIterations() << std::endl;
+    out << "    Average Valence: " << averageValence() << std::endl;
+    out << "    Consecutive Failures: " << consecutiveFailures_ << std::endl;
 }
 
 void ompl::geometric::SPARS::getSparseNeighbors(base::State *inState, std::vector<SparseVertex> &graphNeighborhood)


### PR DESCRIPTION
I'm not sure what the rule is on suggesting cosmetic changes to other's algorithms, I won't be offended if these are not good ideas.
- Made clearQuery() also clear solutions paths - this is the most important change. This function claims it allows you to use the same sparse graph for different planning problems, but it neglects to remove past solutions from the ProblemDefinition
- Added debug output function
- Made reachedFailureLimits() test public so that the graph can be pre-generated without a plan and still have a stopping condition
