### PR TITLE
Fix `pow` signature matching problem in OS X/clang

### DIFF
--- a/src/ompl/geometric/planners/fmt/src/FMT.cpp
+++ b/src/ompl/geometric/planners/fmt/src/FMT.cpp
@@ -53,7 +53,7 @@ ompl::geometric::FMT::FMT(const base::SpaceInformationPtr &si)
     , numSamples_(1000)
     , radiusMultiplier_(1.1)
 {
-    freeSpaceVolume_ = std::pow(si_->getMaximumExtent() / std::sqrt(si_->getStateDimension()), si_->getStateDimension());
+    freeSpaceVolume_ = std::pow(si_->getMaximumExtent() / std::sqrt(si_->getStateDimension()), (int)si_->getStateDimension());
     lastGoalMotion_ = NULL;
 
     specs_.approximateSolutions = false;


### PR DESCRIPTION
because the parameters for std::pow is (double, unsigned int), it fails to search matching signature of `pow` in OS X/clang. this patch fixes it to search (double, int) signature correctly.
