### PR TITLE
SPARStwo: Prevent close start and goal states from throwing an exception

### DIFF
--- a/src/ompl/geometric/planners/prm/src/SPARStwo.cpp
+++ b/src/ompl/geometric/planners/prm/src/SPARStwo.cpp
@@ -153,8 +153,12 @@ bool ompl::geometric::SPARStwo::haveSolution(const std::vector<Vertex> &starts, 
 
             if (same_component && g->isStartGoalPairValid(stateProperty_[goal], stateProperty_[start]))
             {
-                solution = constructSolution(start, goal);
-                return true;
+                // Make sure that the start and goal aren't so close together that they find the same vertex
+                if (start != goal)
+                {
+                    solution = constructSolution(start, goal);
+                    return true;
+                }
             }
         }
     return false;


### PR DESCRIPTION
This prevents `constructSolution()` from throwing an exception:

```
    if (prev[goal] == goal)
        throw Exception(name_, "Could not find solution path");
```
