### PR TITLE
Fixed uninitialized shared pointer bug

### DIFF
--- a/src/ompl/geometric/src/SimpleSetup.cpp
+++ b/src/ompl/geometric/src/SimpleSetup.cpp
@@ -165,7 +165,7 @@ const std::string ompl::geometric::SimpleSetup::getSolutionPlannerName(void) con
 {
     if (pdef_)
     {
-        const ompl::base::PathPtr path; // convert to a generic path ptr
+        const ompl::base::PathPtr path(new PathGeometric(si_)); // convert to a generic path ptr
         ompl::base::PlannerSolution solution(path); // a dummy solution
 
         // Get our desired solution


### PR DESCRIPTION
It is required that the path pointer be initialized because in the constructor for PlannerSolution it calls `path->lenght()` here: https://github.com/ompl/ompl/blob/master/src/ompl/base/ProblemDefinition.h#L76
