### PR TITLE
Fixed omplapp issue with BITstar

### DIFF
--- a/src/ompl/geometric/planners/bitstar/src/BITstar.cpp
+++ b/src/ompl/geometric/planners/bitstar/src/BITstar.cpp
@@ -128,7 +128,7 @@ namespace ompl
 
             //Register my setting callbacks
             Planner::declareParam<double>("rewire_factor", this, &BITstar::setRewireFactor, &BITstar::getRewireFactor, "1.0:0.01:3.0");
-            Planner::declareParam<unsigned int>("samples_per_batch", this, &BITstar::setSamplesPerBatch, &BITstar::getSamplesPerBatch, "1u:1u:1000000u");
+            Planner::declareParam<unsigned int>("samples_per_batch", this, &BITstar::setSamplesPerBatch, &BITstar::getSamplesPerBatch, "1:1:1000000");
 
             //More advanced setting callbacks that aren't necessary to be exposed to Python. Uncomment if desired.
             //Planner::declareParam<bool>("use_strict_queue_ordering", this, &BITstar::setStrictQueueOrdering, &BITstar::getStrictQueueOrdering, "0,1");


### PR DESCRIPTION
With the current BITstar code, the following error appears when trying to run omplapp gui:

    Traceback (most recent call last):
      File "../../gui/ompl_app.py", line 53, in <module>
        ompl.initializePlannerLists()
      File "/home/jvgomez/Desktop/omplapp/ompl/py-bindings/ompl/__init__.py", line 107, in     initializePlannerLists
        ompl.geometric.planners = ompl.PlanningAlgorithms(ompl.geometric)
      File "/home/jvgomez/Desktop/omplapp/ompl/py-bindings/ompl/__init__.py", line 30, in __init__
        self.addPlanner(obj2)
      File "/home/jvgomez/Desktop/omplapp/ompl/py-bindings/ompl/__init__.py", line 89, in addPlanner
        print r, int(r)
    ValueError: invalid literal for int() with base 10: '1u'

This PR solves this issue. Furthermore, it is now consistent with other planners.