### PR TITLE
Margin free cost comparisons

### DIFF
--- a/src/ompl/base/OptimizationObjective.h
+++ b/src/ompl/base/OptimizationObjective.h
@@ -80,7 +80,7 @@ namespace ompl
             /** \brief Get the description of this optimization objective */
             const std::string& getDescription() const;
 
-            /** \brief Verify that our objective is satisfied already and we can stop planning */
+            /** \brief Check if the the given cost \e c satisfies the specified cost objective, meaning we may stop planning. */
             virtual bool isSatisfied(Cost c) const;
 
             /** \brief Returns the cost threshold currently being checked for objective satisfaction */
@@ -89,7 +89,7 @@ namespace ompl
             /** \brief Set the cost threshold for objective satisfaction. When a path is found with a cost better than the cost threshold, the objective is considered satisfied. */
             void setCostThreshold(Cost c);
 
-            /** \brief Check whether the the cost \e c1 is considered better than the cost \e c2. By default, this returns true only if c1 is less by at least some threshold amount, for numerical robustness. */
+            /** \brief Check whether the the cost \e c1 is considered better than the cost \e c2. By default, this returns true if if c1 is less than c2. */
             virtual bool isCostBetterThan(Cost c1, Cost c2) const;
 
             /** \brief Compare whether cost \e c1 and cost \e c2 are equivalent. By default defined as !isCostBetterThan(c1, c2) && !isCostBetterThan(c2, c1), as if c1 is not better than c2, and c2 is not better than c1, then they are equal. */

--- a/src/ompl/base/objectives/src/MaximizeMinClearanceObjective.cpp
+++ b/src/ompl/base/objectives/src/MaximizeMinClearanceObjective.cpp
@@ -52,7 +52,7 @@ ompl::base::Cost ompl::base::MaximizeMinClearanceObjective::stateCost(const Stat
 
 bool ompl::base::MaximizeMinClearanceObjective::isCostBetterThan(Cost c1, Cost c2) const
 {
-    return c1.value() > c2.value() + magic::BETTER_PATH_COST_MARGIN;
+    return c1.value() > c2.value();
 }
 
 ompl::base::Cost ompl::base::MaximizeMinClearanceObjective::identityCost() const

--- a/src/ompl/base/src/OptimizationObjective.cpp
+++ b/src/ompl/base/src/OptimizationObjective.cpp
@@ -70,7 +70,7 @@ void ompl::base::OptimizationObjective::setCostThreshold(Cost c)
 
 bool ompl::base::OptimizationObjective::isCostBetterThan(Cost c1, Cost c2) const
 {
-    return (c1.value() + magic::BETTER_PATH_COST_MARGIN) < c2.value();
+    return c1.value() < c2.value();
 }
 
 bool ompl::base::OptimizationObjective::isCostEquivalentTo(Cost c1, Cost c2) const

--- a/src/ompl/geometric/planners/bitstar/BITstar.h
+++ b/src/ompl/geometric/planners/bitstar/BITstar.h
@@ -321,14 +321,8 @@ namespace ompl
             /** \brief Calculate the max req'd cost to define a neighbourhood around a state. I.e., For path-length problems, the cost equivalent of +2*r. */
             ompl::base::Cost neighbourhoodCost() const;
 
-            /** \brief Compare whether cost a is better than cost b. Ignores the tolerances used by OptimizationObjective::isCostBetterThan */
-            bool isCostBetterThan(const ompl::base::Cost& a, const ompl::base::Cost& b) const;
-
             /** \brief Compare whether cost a is worse than cost b by checking whether b is better than a. */
             bool isCostWorseThan(const ompl::base::Cost& a, const ompl::base::Cost& b) const;
-
-            /** \brief Compare whether cost a and cost b are equivalent by checking that neither a or b is better than the other. */
-            bool isCostEquivalentTo(const ompl::base::Cost& a, const ompl::base::Cost& b) const;
 
             /** \brief Compare whether cost a and cost b are not equivalent by checking if either a or b is better than the other. */
             bool isCostNotEquivalentTo(const ompl::base::Cost& a, const ompl::base::Cost& b) const;
@@ -338,12 +332,6 @@ namespace ompl
 
             /** \brief Compare whether cost a is worse or equivalent to cost b by checking that a is not better than b. */
             bool isCostWorseThanOrEquivalentTo(const ompl::base::Cost& a, const ompl::base::Cost& b) const;
-
-            /** \brief Returns whether the cost is finite or not. By default calls std::isfinite on Cost::value(). */
-            bool isFinite(const ompl::base::Cost& cost) const;
-
-            /** \brief The better of two costs.*/
-            ompl::base::Cost betterCost(const ompl::base::Cost& a, const ompl::base::Cost& b) const;
 
             /** \brief Combine 3 costs */
             ompl::base::Cost combineCosts(const ompl::base::Cost& a, const ompl::base::Cost& b, const ompl::base::Cost& c) const;

--- a/src/ompl/geometric/planners/bitstar/datastructures/IntegratedQueue.h
+++ b/src/ompl/geometric/planners/bitstar/datastructures/IntegratedQueue.h
@@ -427,15 +427,9 @@ namespace ompl
             ////////////////////////////////
 
             ////////////////////////////////
-            //Overloads since OptimizationObjective::isCostBetterThan() is broken (it compares to within a very small tolerance...)
-            /** \brief Compare whether cost a is better than cost b. Ignores the tolerances used by OptimizationObjective::isCostBetterThan */
-            bool isCostBetterThan(const ompl::base::Cost& a, const ompl::base::Cost& b) const;
-
+            //Cost helpers
             /** \brief Compare whether cost a is worse than cost b by checking whether b is better than a. */
             bool isCostWorseThan(const ompl::base::Cost& a, const ompl::base::Cost& b) const;
-
-            /** \brief Compare whether cost a and cost b are equivalent by checking that neither a or b is better than the other. */
-            bool isCostEquivalentTo(const ompl::base::Cost& a, const ompl::base::Cost& b) const;
 
             /** \brief Compare whether cost a and cost b are not equivalent by checking if either a or b is better than the other. */
             bool isCostNotEquivalentTo(const ompl::base::Cost& a, const ompl::base::Cost& b) const;

--- a/src/ompl/geometric/planners/bitstar/datastructures/src/IntegratedQueue.cpp
+++ b/src/ompl/geometric/planners/bitstar/datastructures/src/IntegratedQueue.cpp
@@ -841,7 +841,7 @@ namespace ompl
             {
                 //By virtue of the vertex expansion rules, the token will always sit at the front of a group of equivalent cost vertices (that is to say, all vertices with the same cost get expanded at the same time)
                 //Therefore, the vertex is expanded if it's cost is strictly better than the token.
-                return this->isCostBetterThan(lkupIter->second->first, vertexToExpand_->first);
+                return opt_->isCostBetterThan(lkupIter->second->first, vertexToExpand_->first);
             }
         }
 
@@ -1553,7 +1553,7 @@ namespace ompl
         bool BITstar::IntegratedQueue::vertexQueueComparison(const ompl::base::Cost& lhs, const ompl::base::Cost& rhs) const
         {
             //lhs < rhs?
-            return this->isCostBetterThan(lhs, rhs);
+            return opt_->isCostBetterThan(lhs, rhs);
         }
 
 
@@ -1563,17 +1563,17 @@ namespace ompl
             bool lhsLTrhs;
 
             //Get if LHS is less than RHS.
-            lhsLTrhs = this->isCostBetterThan(lhs.first, rhs.first);
+            lhsLTrhs = opt_->isCostBetterThan(lhs.first, rhs.first);
 
             //If it's not, it could be equal
             if (lhsLTrhs == false)
             {
                 //If RHS is also NOT less than LHS, than they're equal and we need to check the second key
-                if (this->isCostBetterThan(rhs.first, lhs.first) == false)
+                if (opt_->isCostBetterThan(rhs.first, lhs.first) == false)
                 {
                     //lhs == rhs
                     //Compare their second values
-                    lhsLTrhs = this->isCostBetterThan( lhs.second, rhs.second );
+                    lhsLTrhs = opt_->isCostBetterThan( lhs.second, rhs.second );
                 }
                 //No else: lhs > rhs
             }
@@ -1584,25 +1584,10 @@ namespace ompl
 
 
 
-        bool BITstar::IntegratedQueue::isCostBetterThan(const ompl::base::Cost& a, const ompl::base::Cost& b) const
-        {
-            return a.value() < b.value();
-        }
-
-
-
         bool BITstar::IntegratedQueue::isCostWorseThan(const ompl::base::Cost& a, const ompl::base::Cost& b) const
         {
             //If b is better than a, then a is worse than b
-            return this->isCostBetterThan(b, a);
-        }
-
-
-
-        bool BITstar::IntegratedQueue::isCostEquivalentTo(const ompl::base::Cost& a, const ompl::base::Cost& b) const
-        {
-            //If a is not better than b, and b is not better than a, then they are equal
-            return !this->isCostBetterThan(a,b) && !this->isCostBetterThan(b,a);
+            return opt_->isCostBetterThan(b, a);
         }
 
 
@@ -1610,7 +1595,7 @@ namespace ompl
         bool BITstar::IntegratedQueue::isCostNotEquivalentTo(const ompl::base::Cost& a, const ompl::base::Cost& b) const
         {
             //If a is better than b, or b is better than a, then they are not equal
-            return this->isCostBetterThan(a,b) || this->isCostBetterThan(b,a);
+            return opt_->isCostBetterThan(a,b) || opt_->isCostBetterThan(b,a);
         }
 
 
@@ -1618,7 +1603,7 @@ namespace ompl
         bool BITstar::IntegratedQueue::isCostBetterThanOrEquivalentTo(const ompl::base::Cost& a, const ompl::base::Cost& b) const
         {
             //If b is not better than a, then a is better than, or equal to, b
-            return !this->isCostBetterThan(b, a);
+            return !opt_->isCostBetterThan(b, a);
         }
 
 
@@ -1626,7 +1611,7 @@ namespace ompl
         bool BITstar::IntegratedQueue::isCostWorseThanOrEquivalentTo(const ompl::base::Cost& a, const ompl::base::Cost& b) const
         {
             //If a is not better than b, than a is worse than, or equal to, b
-            return !this->isCostBetterThan(a,b);
+            return !opt_->isCostBetterThan(a,b);
         }
         /////////////////////////////////////////////////////////////////////////////////////////////
 

--- a/src/ompl/tools/config/MagicConstants.h
+++ b/src/ompl/tools/config/MagicConstants.h
@@ -87,11 +87,6 @@ namespace ompl
             of the space */
         static const double STD_DEV_AS_SPACE_EXTENT_FRACTION = 0.1;
 
-        /** \brief When running algorithms such as  RRT*, rewire updates are made when the cost of a path appears better than the cost of another.
-            The minimum margin for a path to be better than another one is specified by this parameter. This is used to avoid
-            numerical issues that can otherwise arise. */
-        static const double BETTER_PATH_COST_MARGIN = std::numeric_limits<double>::epsilon() * 1e3;
-
         /** \brief When multiple attempts are needed to generate valid
             samples, this value defines the default number of
             attempts */


### PR DESCRIPTION
These are the changes for option (1) as in Issue [#156](https://bitbucket.org/ompl/ompl/issues/156), moving the margin into only `isSatisfied`. I made the change faithful to the previous behaviour, though I am somewhat surprised to notice that the margin actually makes it harder to satisfy the specified threshold.