### PR TITLE
update homebrew for travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -22,6 +22,9 @@ install:
   - if [ "$TRAVIS_OS_NAME" = "osx"   ]; then brew install boost-python ode eigen; fi
 
 script:
+  # update homebrew
+  - brew update
+
   # Create build directory
   - mkdir build
   - cd build


### PR DESCRIPTION
Travis' homebrew uses boost 1.56, though homebrew users will be generally on boost 1.58
By updating brew, this will more accurately reflect the average homebrew install