### PR TITLE
Fix for 2dcircles_optimize

### DIFF
--- a/src/ompl/base/OptimizationObjective.h
+++ b/src/ompl/base/OptimizationObjective.h
@@ -80,7 +80,7 @@ namespace ompl
             /** \brief Get the description of this optimization objective */
             const std::string& getDescription() const;
 
-            /** \brief Check if the the given cost \e c satisfies the specified cost objective, meaning we may stop planning. */
+            /** \brief Check if the the given cost \e c satisfies the specified cost objective, defined as \e better \e than the specified threshold. */
             virtual bool isSatisfied(Cost c) const;
 
             /** \brief Returns the cost threshold currently being checked for objective satisfaction */

--- a/src/ompl/geometric/planners/rrt/src/RRTstar.cpp
+++ b/src/ompl/geometric/planners/rrt/src/RRTstar.cpp
@@ -120,6 +120,7 @@ void ompl::geometric::RRTstar::clear()
 
     lastGoalMotion_ = NULL;
     goalMotions_.clear();
+    startMotion_ = NULL;
 
     iterations_ = 0;
     bestCost_ = base::Cost(std::numeric_limits<double>::quiet_NaN());
@@ -447,11 +448,12 @@ ompl::base::PlannerStatus ompl::geometric::RRTstar::solve(const base::PlannerTer
                         std::vector<const base::State *> spath;
                         Motion *intermediate_solution = solution->parent; // Do not include goal state to simplify code.
 
-                        do
+                        //Push back until we find the start, but not the start itself
+                        while (intermediate_solution->parent != NULL)
                         {
                             spath.push_back(intermediate_solution->state);
                             intermediate_solution = intermediate_solution->parent;
-                        } while (intermediate_solution->parent != 0); // Do not include the start state.
+                        }
 
                         intermediateSolutionCallback(this, spath, bestCost_);
                     }

--- a/tests/geometric/2d/2dcircles_optimize.cpp
+++ b/tests/geometric/2d/2dcircles_optimize.cpp
@@ -89,7 +89,7 @@ protected:
 
         // define an objective that is met the moment the solution is found
         base::PathLengthOptimizationObjective *opt = new base::PathLengthOptimizationObjective(si);
-        opt->setCostThreshold(base::Cost(std::numeric_limits<double>::infinity()));
+        opt->setCostThreshold(opt->infiniteCost());
         pdef->setOptimizationObjective(base::OptimizationObjectivePtr(opt));
 
         /* instantiate motion planner */
@@ -97,7 +97,7 @@ protected:
         planner->setProblemDefinition(pdef);
         planner->setup();
 
-        std::size_t nt = std::min<std::size_t>(5, circles.getQueryCount());
+        std::size_t nt = std::min<std::size_t>(6, circles.getQueryCount());
 
         // run a simple test first
         if (nt > 0)
@@ -116,11 +116,13 @@ protected:
             const Circles2D::Query &q = circles.getQuery(i);
             setupProblem(q, si, pdef);
 
+            base::Cost min_cost(std::sqrt(std::pow(q.goalX_ - q.startX_, 2.0) + std::pow(q.goalY_ - q.startY_, 2.0))); //The straight-line cost
+
             planner->clear();
             pdef->clearSolutionPaths();
 
             // we change the optimization objective so the planner runs until the first solution
-            opt->setCostThreshold(base::Cost(std::numeric_limits<double>::infinity()));
+            opt->setCostThreshold(opt->infiniteCost());
 
             time::point start = time::now();
             bool solved = planner->solve(solutionTime);
@@ -152,13 +154,20 @@ protected:
                 }
                 time_spent = time::seconds(time::now() - start);
               }
-              BOOST_CHECK(opt->isCostBetterThan(prev_cost, ini_cost));
+              BOOST_CHECK(!opt->isCostBetterThan(ini_cost, prev_cost));
 
               pdef->clearSolutionPaths();
               // we change the optimization objective so the planner can achieve the objective
               opt->setCostThreshold(ini_cost);
               if (planner->solve(DT_SOLUTION_TIME))
-                  BOOST_CHECK(pdef->hasOptimizedSolution());
+              {
+                  path = static_cast<geometric::PathGeometric*>(pdef->getSolutionPath().get());
+                  prev_cost  = path->cost(pdef->getOptimizationObjective());
+                  BOOST_CHECK(pdef->hasOptimizedSolution() || opt->isCostEquivalentTo(ini_cost, prev_cost));
+              }
+
+              // make sure not better than the minimum
+              BOOST_CHECK(!opt->isCostBetterThan(prev_cost, min_cost));
             }
         }
     }


### PR DESCRIPTION
I was able to replicate the errors in 2dcircles_optimize **with** the old margin in the comparison. They appear to occur because, sometimes, the planner simply doesn't find a better solution than the initial one.

This code relaxes tests enough that it will pass in the situations. Whether that is too much of a relaxation is an open question.

Will rebase once it's ready to go.