### PR TITLE
Informed sampling multistart/goal support, BIT* MoveIt! and infinite problem support

### DIFF
--- a/src/ompl/base/goals/src/GoalStates.cpp
+++ b/src/ompl/base/goals/src/GoalStates.cpp
@@ -88,6 +88,7 @@ void ompl::base::GoalStates::sampleGoal(base::State *st) const
     samplePosition_ = samplePosition_ % states_.size();
     // Get the next state.
     si_->copyState(st, states_[samplePosition_]);
+    // Increment the counter. Do NOT roll over incase a new state is added before sampleGoal is called again.
     samplePosition_++;
 }
 

--- a/src/ompl/base/samplers/InformedStateSampler.h
+++ b/src/ompl/base/samplers/InformedStateSampler.h
@@ -71,10 +71,10 @@ namespace ompl
             {
             }
 
-            /** \brief Sample uniformly in the subset of the state space whose heuristic solution estimates are less than the provided cost. Returns false if such a state was not found. */
+            /** \brief Sample uniformly in the subset of the state space whose heuristic solution estimates are less than the provided cost, i.e. in the interval [0, maxCost). Returns false if such a state was not found in the specified number of iterations. */
             virtual bool sampleUniform(State *statePtr, const Cost &maxCost) = 0;
 
-            /** \brief Sample uniformly in the subset of the state space whose heuristic solution estimates are between the provided costs. Returns false if such a state was not found.  */
+            /** \brief Sample uniformly in the subset of the state space whose heuristic solution estimates are between the provided costs, [minCost, maxCost). Returns false if such a state was not found in the specified number of iterations. */
             virtual bool sampleUniform(State *statePtr, const Cost &minCost, const Cost &maxCost) = 0;
 
             /** \brief Whether the sampler can provide a measure of the informed subset */
@@ -87,6 +87,7 @@ namespace ompl
             virtual double getInformedMeasure(const Cost &minCost, const Cost &maxCost) const;
 
             /** \brief A helper function to calculate the heuristic estimate of the solution cost for a given state using the optimization objective stored in the problem definition. */
+            /** \todo With the future invention of a heuristic class, this should move.  */
             virtual Cost heuristicSolnCost(const State *statePtr) const;
 
         protected:

--- a/src/ompl/base/samplers/informed/PathLengthDirectInfSampler.h
+++ b/src/ompl/base/samplers/informed/PathLengthDirectInfSampler.h
@@ -52,29 +52,31 @@ namespace ompl
 {
     namespace base
     {
-        /** \brief An informed sampler for problems seeking to minimize path length.
+        /**
+            @anchor gPathLengthDirectInfSampler
 
-        @par Short description
-        It focuses the search to the subset of a problem that can improve a current solution, which is a prolate hyperspheroid (PHS)
-        (a special type of an hyperellipsoid) and can be sampled directly.
-        Doing so considers all homotopy classes that can provide a better solution while guaranteeing a non-zero probability
-        of improving a solution regardless of the size of the planning domain, the number of state dimensions, and how close
-        the current solution is to the theoretical minimum.
-        Currently only implemented for problems with a single goal in R^n (i.e., RealVectorStateSpace), SE(2) (i.e., SE2StateSpace), and SE(3) (i.e., SE3StateSpace).
-        Until an initial solution is found, this sampler simply passes-through to a uniform distribution over the entire state space.
+            PathLengthDirectInfSampler is a method to generate uniform samples in the subset of a problem that could provide a shorter path from start to goal.
+            This subset is a prolate hyperspheroid (PHS), a special type of an hyperellipsoid) and can be sampled directly.
 
-        @par Associated publications:
+            Informed sampling is a method to focus search which continuing to consider all homotopy classes that can provide a better solution.
+            Directly sampling the informed subset guarantees a non-zero probability of improving a solution regardless of the size of the planning domain,
+            the number of state dimensions, and how close the current solution is to the theoretical minimum.
 
-        J D. Gammell, S. S. Srinivasa, T. D. Barfoot, "Informed RRT*: Optimal Sampling-based
-        Path Planning Focused via Direct Sampling of an Admissible Ellipsoidal Heuristic." In Proceedings
-        of the IEEE/RSJ International Conference on Intelligent Robots and Systems (IROS). Chicago, IL, USA,
-        14-18 Sept. 2014.
-        DOI: <a href="http://dx.doi.org/10.1109/IROS.2014.6942976">10.1109/IROS.2014.6942976</a>.
-        <a href="http://www.youtube.com/watch?v=d7dX5MvDYTc">Illustration video</a>.
-        <a href="http://www.youtube.com/watch?v=nsl-5MZfwu4">Short description video</a>.
+            Currently only implemented for problems in R^n (i.e., RealVectorStateSpace), SE(2) (i.e., SE2StateSpace), and SE(3) (i.e., SE3StateSpace).
+            Until an initial solution is found, this sampler simply passes-through to a uniform distribution over the entire state space.
 
-        \todo
-        - Handle other types of goals? */
+            @par Associated publication:
+
+            J D. Gammell, S. S. Srinivasa, T. D. Barfoot, "Informed RRT*: Optimal Sampling-based
+            Path Planning Focused via Direct Sampling of an Admissible Ellipsoidal Heuristic." In Proceedings
+            of the IEEE/RSJ International Conference on Intelligent Robots and Systems (IROS). Chicago, IL, USA,
+            14-18 Sept. 2014.
+            DOI: <a href="http://dx.doi.org/10.1109/IROS.2014.6942976">10.1109/IROS.2014.6942976</a>.
+            <a href="http://www.youtube.com/watch?v=d7dX5MvDYTc">Illustration video</a>.
+            <a href="http://www.youtube.com/watch?v=nsl-5MZfwu4">Short description video</a>.
+        */
+
+        /** \brief An informed sampler for problems seeking to minimize path length.*/
         class PathLengthDirectInfSampler : public InformedSampler
         {
         public:

--- a/src/ompl/base/samplers/informed/PathLengthDirectInfSampler.h
+++ b/src/ompl/base/samplers/informed/PathLengthDirectInfSampler.h
@@ -45,6 +45,9 @@
 // We inherit from InformedStateSampler
 #include "ompl/base/samplers/InformedStateSampler.h"
 
+// For std::list
+#include <list>
+
 namespace ompl
 {
     namespace base
@@ -80,35 +83,71 @@ namespace ompl
             PathLengthDirectInfSampler(const ProblemDefinitionPtr probDefn, unsigned int maxNumberCalls);
             virtual ~PathLengthDirectInfSampler();
 
-            /** \brief Sample uniformly in the subset of the state space whose heuristic solution estimates are less than the provided cost. */
-            bool sampleUniform(State *statePtr, const Cost &maxCost);
+            /** \brief Sample uniformly in the subset of the state space whose heuristic solution estimates are less than the provided cost, i.e. in the interval [0, maxCost). Returns false if such a state was not found in the specified number of iterations. */
+            virtual bool sampleUniform(State *statePtr, const Cost &maxCost);
 
-            /** \brief Sample uniformly in the subset of the state space whose heuristic solution estimates are between the provided costs. */
-            bool sampleUniform(State *statePtr, const Cost &minCost, const Cost &maxCost);
+            /** \brief Sample uniformly in the subset of the state space whose heuristic solution estimates are between the provided costs, [minCost, maxCost). Returns false if such a state was not found in the specified number of iterations. */
+            virtual bool sampleUniform(State *statePtr, const Cost &minCost, const Cost &maxCost);
 
             /** \brief Whether the sampler can provide a measure of the informed subset */
-            bool hasInformedMeasure() const;
+            virtual bool hasInformedMeasure() const;
 
-            /** \brief The measure of the subset of the state space defined by the current solution cost that is being searched. Does not consider problem boundaries but returns the measure of the entire space if no solution has been found. */
+            /** \brief The measure of the subset of the state space defined by the current solution cost that is being searched. Does not consider problem boundaries but returns the measure of the entire space if no solution has been found. In the case of multiple goals, this measure assume each individual subset is independent, therefore the resulting measure will be an overestimate if any of the subsets overlap. */
             virtual double getInformedMeasure(const Cost &currentCost) const;
 
             /** \brief A helper function to calculate the heuristic estimate of the solution cost for the informed subset of a given state. */
             virtual Cost heuristicSolnCost(const State *statePtr) const;
 
         private:
+            /** \brief A constant pointer to ProlateHyperspheroid */
+            typedef boost::shared_ptr<const ompl::ProlateHyperspheroid> ProlateHyperspheroidCPtr;
+
             // Helper functions:
+            // High level
             /** \brief Sample uniformly in the subset of the state space whose heuristic solution estimates are less than the provided cost using a persistent iteration counter */
-            bool sampleUniform(State *statePtr, const Cost &maxCost, unsigned int *iterPtr);
+            bool sampleUniform(State *statePtr, const Cost &maxCost, unsigned int *iters);
 
-            /** \brief Sample uniformly in the subset of the \e infinite state space whose heuristic solution estimates are less than the provided cost, i.e., ignores the bounds of the state space. */
-            void sampleUniformIgnoreBounds(State *statePtr, const Cost &maxCost);
+            /** \brief Sample from the bounds of the problem and keep the sample if it passes the given test. Meant to be used with isInAnyPhs and phsPtr->isInPhs() */
+            bool sampleBoundsRejectPhs(State* statePtr, unsigned int *iters);
 
-            /** \brief Sample uniformly in the subset of the \e infinite state space whose heuristic solution estimates are between the provided costs, i.e., ignores the bounds of the state space. */
-            void sampleUniformIgnoreBounds(State *statePtr, const Cost &minCost, const Cost &maxCost);
+            /** \brief Sample from the given PHS and return true if the sample is within the boundaries of the problem (i.e., it \e may be kept). */
+            bool samplePhsRejectBounds(State *statePtr, unsigned int *iters);
+
+            // Low level
+            /** \brief Extract the informed subspace from a state pointer */
+            std::vector<double> getInformedSubstate(const State *statePtr) const;
+
+            /** \brief Create a full vector with any uninformed subspaces filled with a uniform random state. Expects the state* to be allocated */
+            void createFullState(State * statePtr, const std::vector<double> &informedVector);
+
+            /** \brief Iterate through the list of PHSs and update each one to the new max cost as well as the sum of their measures. Will remove any PHSs that cannot improve a better solution and in that case update the number of goals. */
+            void updatePhsDefinitions(const Cost &maxCost);
+
+            /** \brief Select a random PHS from the list of PHSs. The probability of sampling chosing a PHS is it's measure relative to the total measure of all PHSs. Bypasses if only one PHS exists. */
+            ompl::ProlateHyperspheroidPtr randomPhsPtr();
+
+            /** \brief Probabilistically decide whether to keep a given sample drawn directly from a PHS. If a sample is in K PHSs, it returns true with probability 1/K. */
+            bool keepSample(const std::vector<double>& informedVector);
+
+            /** \brief Iterate through the list of PHSs and return true if the sample is in any of them */
+            bool isInAnyPhs(const std::vector<double>& informedVector) const;
+
+            /** \brief Return true if the sample is in the specified PHS. Really just a wrapper to aid with boost::bind */
+            bool isInPhs(const ProlateHyperspheroidCPtr &phsCPtr, const std::vector<double> &informedVector) const;
+
+            /** \brief Iterate through the list of PHSs and return the number of PHSs that the sample is in */
+            unsigned int numberOfPhsInclusions(const std::vector<double>& informedVector) const;
+
+
+
+
 
             // Variables
-            /** \brief The prolate hyperspheroid description of the sub problem */
-            ompl::ProlateHyperspheroidPtr phsPtr_;
+            /** \brief The prolate hyperspheroid description of the sub problems. One per goal state. */
+            std::list<ompl::ProlateHyperspheroidPtr> listPhsPtrs_;
+
+            /** \brief The summed measure of all the start-goal pairs */
+            double summedMeasure_;
 
             /** \brief The index of the subspace of a compound StateSpace for which we can do informed sampling. Unused if the StateSpace is not compound. */
             unsigned int informedIdx_;

--- a/src/ompl/base/samplers/informed/RejectionInfSampler.h
+++ b/src/ompl/base/samplers/informed/RejectionInfSampler.h
@@ -58,17 +58,14 @@ namespace ompl
             {
             }
 
-            /** \brief Sample uniformly in the subset of the state space whose heuristic solution estimates are less than the provided cost. */
-            bool sampleUniform(State *statePtr, const Cost &maxCost);
+            /** \brief Sample uniformly in the subset of the state space whose heuristic solution estimates are less than the provided cost, i.e. in the interval [0, maxCost). Returns false if such a state was not found in the specified number of iterations. */
+            virtual bool sampleUniform(State *statePtr, const Cost &maxCost);
 
-            /** \brief Sample uniformly in the subset of the state space whose heuristic solution estimates are between the provided costs. */
-            bool sampleUniform(State *statePtr, const Cost &minCost, const Cost &maxCost);
+            /** \brief Sample uniformly in the subset of the state space whose heuristic solution estimates are between the provided costs, [minCost, maxCost). Returns false if such a state was not found in the specified number of iterations. */
+            virtual bool sampleUniform(State *statePtr, const Cost &minCost, const Cost &maxCost);
 
             /** \brief Whether the sampler can provide a measure of the informed subset */
-            bool hasInformedMeasure() const;
-
-            /** \brief The measure of the subset of the state space defined by the current solution cost that is being searched. As rejection sampling has no closed-form knowledge of the informed subset, the measure of the informed space is always the measure of the entire space. */
-            virtual double getInformedMeasure() const;
+            virtual bool hasInformedMeasure() const;
 
             /** \brief The measure of the subset of the state space defined by the current solution cost that is being searched. As rejection sampling has no closed-form knowledge of the informed subset, the measure of the informed space is always the measure of the entire space. */
             virtual double getInformedMeasure(const Cost &/*currentCost*/) const;

--- a/src/ompl/base/samplers/informed/src/PathLengthDirectInfSampler.cpp
+++ b/src/ompl/base/samplers/informed/src/PathLengthDirectInfSampler.cpp
@@ -37,17 +37,23 @@
 #include "ompl/base/samplers/informed/PathLengthDirectInfSampler.h"
 #include "ompl/util/Exception.h"
 #include "ompl/base/OptimizationObjective.h"
-#include "ompl/base/goals/GoalState.h"
+//For ompl::base::GoalSampleableRegion, which both GoalState and GoalStates derive from:
+#include "ompl/base/goals/GoalSampleableRegion.h"
 #include "ompl/base/StateSpace.h"
 #include "ompl/base/spaces/RealVectorStateSpace.h"
 
 // For boost::make_shared
 #include <boost/make_shared.hpp>
+// For std::vector
+#include <vector>
 
 namespace ompl
 {
     namespace base
     {
+        /////////////////////////////////////////////////////////////////////////////////////////////
+        //Public functions:
+
         // The direct ellipsoid sampling class for path-length:
         PathLengthDirectInfSampler::PathLengthDirectInfSampler(const ProblemDefinitionPtr probDefn, unsigned int maxNumberCalls)
           : InformedSampler(probDefn, maxNumberCalls),
@@ -55,25 +61,30 @@ namespace ompl
             uninformedIdx_(0u)
         {
             // Variables
-            // The foci of the ellipse as State* s
-            State *startFocusState;
-            State *goalFocusState;
-            // The foci of the ellipse as std::vectors
-            std::vector<double> startFocusVector;
-            std::vector<double> goalFocusVector;
+            // The number of start states
+            unsigned int numStarts;
+            // The number of goal states
+            unsigned numGoals;
+            // The foci of the PHSs as a std::vector of states. Goals must be nonconst, as we need to allocate them (unfortunately):
+            std::vector<const State*> startStates;
+            std::vector<State*> goalStates;
 
-            // Sanity check the problem.
-            if (probDefn_->getStartStateCount() != 1u)
+            if (probDefn_->getGoal()->hasType(ompl::base::GOAL_SAMPLEABLE_REGION) == false)
             {
-                throw Exception("PathLengthDirectInfSampler: The direct path-length informed sampler currently only supports 1 start state.");
+                throw Exception("PathLengthDirectInfSampler: The direct path-length informed sampler currently only supports goals that can be cast to a sampleable goal region (i.e., are countable sets).");
             }
 
-            if (probDefn_->getGoal()->hasType(GOAL_STATE) == false)
-            {
-                throw Exception("PathLengthDirectInfSampler: The direct path-length informed sampler currently only supports goals that can be cast to goal states.");
-            }
+            /// Note: We don't check that there is a cost-to-go heuristic set in the optimization objective, as this direct sampling is only for Euclidean distance.
 
-            /// \todo We don't check for the cost-to-go heuristic in the optimization objective, as this direct sampling is for Euclidean distance.
+            // Store the number of starts and goals
+            numStarts = probDefn_->getStartStateCount();
+            numGoals = probDefn_->getGoal()->as<ompl::base::GoalSampleableRegion>()->maxSampleCount();
+
+            // Sanity check that there is atleast one of each
+            if (numStarts < 1u || numGoals < 1u)
+            {
+                throw Exception("PathLengthDirectInfSampler: There must be at least 1 start and and 1 goal state when the informed sampler is created.");
+            }
 
             // Check that the provided statespace is compatible and extract the necessary indices.
             // The statespace must either be R^n or SE(2) or SE(3)
@@ -134,7 +145,6 @@ namespace ompl
                 }
             }
 
-
             // Create a sampler for the whole space that we can use if we have no information
             baseSampler_ = InformedSampler::space_->allocDefaultStateSampler();
 
@@ -142,10 +152,6 @@ namespace ompl
             if (InformedSampler::space_->isCompound() == false)
             {
                 // It is not.
-
-                // Store the foci
-                startFocusState = probDefn_->getStartState(0u);
-                goalFocusState = probDefn_->getGoal()->as<GoalState>()->getState();
 
                 // The informed subspace is the full space
                 informedSubSpace_ = InformedSampler::space_;
@@ -156,9 +162,7 @@ namespace ompl
             }
             else
             {
-                // Store the foci
-                startFocusState = probDefn_->getStartState(0u)->as<CompoundState>()->components[informedIdx_];
-                goalFocusState = probDefn_->getGoal()->as<GoalState>()->getState()->as<CompoundState>()->components[informedIdx_];
+                // It is
 
                 // Get a pointer to the informed subspace...
                 informedSubSpace_ = InformedSampler::space_->as<CompoundStateSpace>()->getSubspace(informedIdx_);
@@ -170,17 +174,62 @@ namespace ompl
                 uninformedSubSampler_ = uninformedSubSpace_->allocDefaultStateSampler();
             }
 
-            // Now extract the foci of the ellipse
-            informedSubSpace_->copyToReals(startFocusVector, startFocusState);
-            informedSubSpace_->copyToReals(goalFocusVector, goalFocusState);
+            // Store the foci, first the starts:
+            for (unsigned int i = 0u; i < numStarts; ++i)
+            {
+                startStates.push_back(probDefn_->getStartState(i));
+            }
 
-            // Create the definition of the PHS
-            phsPtr_ = boost::make_shared<ProlateHyperspheroid>(informedSubSpace_->getDimension(), &startFocusVector[0], &goalFocusVector[0]);
+
+            // Extract the state of each goal one and place into the goal vector!
+            for (unsigned int i = 0u; i < numGoals; ++i)
+            {
+                // Allocate a state onto the back of the vector:
+                goalStates.push_back(InformedSampler::space_->allocState());
+
+                // Now sample a goal into that state:
+                probDefn_->getGoal()->as<ompl::base::GoalSampleableRegion>()->sampleGoal(goalStates.back());
+            }
+
+            // Now, iterate create a PHS for each start-goal pair
+            // Each start
+            for (unsigned int i = 0u; i < numStarts; ++i)
+            {
+                // Variable
+                // The start as a vector
+                std::vector<double> startFocusVector = getInformedSubstate(startStates.at(i));
+
+                // Each goal
+                for (unsigned int j = 0u; j < numGoals; ++ j)
+                {
+                    // Variable
+                    // The goal as a vector
+                    std::vector<double> goalFocusVector = getInformedSubstate(goalStates.at(j));
+
+                    // Create the definition of the PHS
+                    listPhsPtrs_.push_back(boost::make_shared<ProlateHyperspheroid>(informedSubSpace_->getDimension(), &startFocusVector[0], &goalFocusVector[0]));
+                }
+            }
+
+            // Finally deallocate the states in the goal state vector:
+            for (unsigned int i = 0u; i < numGoals; ++i)
+            {
+                // Free the state in the vector:
+                InformedSampler::space_->freeState(goalStates.at(i));
+            }
+
+            if (listPhsPtrs_.size() > 100u)
+            {
+                OMPL_WARN("PathLengthDirectInfSampler: Rejection sampling is used in order to maintain uniform density in the presence of overlapping informed subsets. At some number of independent subsets, this will become prohibitively expensive. Current number of independent subsets: %d", listPhsPtrs_.size());
+            }
         }
+
+
 
         PathLengthDirectInfSampler::~PathLengthDirectInfSampler()
         {
         }
+
 
 
         bool PathLengthDirectInfSampler::sampleUniform(State *statePtr, const Cost &maxCost)
@@ -213,8 +262,14 @@ namespace ompl
                 // Did we find a sample?
                 if (foundSample == true)
                 {
-                    // We did, but that was only inside the bigger PHS, we need to assure it's outside the smaller one which occurs if the minCost is *better* than that of the sample:
-                    foundSample = InformedSampler::opt_->isCostBetterThan(minCost, heuristicSolnCost(statePtr));
+                    // We did, but it only satisfied the upper bound. Check that it meets the lower bound.
+
+                    // Variables
+                    // The cost of the sample we found
+                    Cost sampledCost = heuristicSolnCost(statePtr);
+
+                    // Check if the sample's cost is greater than or equal to the lower bound
+                    foundSample = InformedSampler::opt_->isCostEquivalentTo(minCost, sampledCost) || InformedSampler::opt_->isCostBetterThan(minCost, sampledCost);
                 }
                 // No else, no sample was found.
             }
@@ -236,10 +291,18 @@ namespace ompl
         {
             // Variable
             // The measure of the informed set
-            double informedMeasure;
+            double informedMeasure = 0.0;
 
-            // The informed measure is then the measure of the PHS for the given cost:
-            informedMeasure = phsPtr_->getPhsMeasure(currentCost.value());
+            // The informed measure is then the sum of the measure of the individual PHSs for the given cost:
+            for (std::list<ompl::ProlateHyperspheroidPtr>::const_iterator phsIter = listPhsPtrs_.begin(); phsIter != listPhsPtrs_.end(); ++phsIter)
+            {
+                //It is nonsensical for a PHS to have a transverse diameter less than the distance between its foci, so skip those that do
+                if (currentCost.value() > (*phsIter)->getMinTransverseDiameter())
+                {
+                    informedMeasure = informedMeasure + (*phsIter)->getPhsMeasure(currentCost.value());
+                }
+                //No else, this value is better than this ellipse. It will get removed later.
+            }
 
             // And if the space is compound, further multiplied by the measure of the uniformed subspace
             if (InformedSampler::space_->isCompound() == true)
@@ -253,6 +316,29 @@ namespace ompl
 
 
 
+        Cost PathLengthDirectInfSampler::heuristicSolnCost(const State *statePtr) const
+        {
+            // Variable
+            // The raw data in the state
+            std::vector<double> rawData = getInformedSubstate(statePtr);
+            // The Cost, infinity to start
+            Cost minCost = InformedSampler::opt_->infiniteCost();
+
+            // Iterate over the separate subsets and return the minimum
+            for (std::list<ompl::ProlateHyperspheroidPtr>::const_iterator phsIter = listPhsPtrs_.begin(); phsIter != listPhsPtrs_.end(); ++phsIter)
+            {
+                /** \todo Use a heuristic function for the full solution cost defined in OptimizationObjective or some new Heuristic class once said function is defined. */
+                minCost = InformedSampler::opt_->betterCost(minCost, Cost((*phsIter)->getPathLength(&rawData[0])));
+            }
+
+            return minCost;
+        }
+        /////////////////////////////////////////////////////////////////////////////////////////////
+
+
+
+        /////////////////////////////////////////////////////////////////////////////////////////////
+        //Private functions:
         bool PathLengthDirectInfSampler::sampleUniform(State *statePtr, const Cost &maxCost, unsigned int *iters)
         {
             // Variable
@@ -261,7 +347,7 @@ namespace ompl
 
             //Whether we successfully returnes
             // Check if a solution path has been found
-            if (std::isfinite(maxCost.value()) == false)
+            if (InformedSampler::opt_->isFinite(maxCost) == false)
             {
                 // We don't have a solution yet, we sample from our basic sampler instead...
                 baseSampler_->sampleUniform(statePtr);
@@ -274,53 +360,22 @@ namespace ompl
             }
             else // We have a solution
             {
-                // Set the new transverse diameter
-                phsPtr_->setTransverseDiameter(maxCost.value());
+                // Update the definitions of the PHSs
+                updatePhsDefinitions(maxCost);
 
-                // Check whether the problem domain (i.e., StateSpace) or PHS has the smaller measure. Sample the smaller directly and reject from the larger.
-                if (informedSubSpace_->getMeasure() <= phsPtr_->getPhsMeasure())
+                // Sample from the PHSs.
+
+                // When the summed measure of the PHSes are suitably large, it makes more sense to just sample from the entire planning space and keep the sample if it lies in any PHS
+                // Check if the average measure is greater than half the domain's measure. Half is an arbitrary number.
+                if (informedSubSpace_->getMeasure() < summedMeasure_/static_cast<double>(listPhsPtrs_.size()))
                 {
-                    // The PHS is larger than the subspace, just sample from the subspace directly.
-
-                    // Spend numIters_ iterations trying to find an informed sample:
-                    for (/* Provided iteration counter */; *iters < InformedSampler::numIters_ && foundSample == false; ++(*iters))
-                    {
-                        // Variable
-                        // The informed subset of the sample as a vector
-                        std::vector<double> informedVector(informedSubSpace_->getDimension());
-
-                        // Generate a random sample
-                        baseSampler_->sampleUniform(statePtr);
-
-                        // Is there an extra "uninformed" subspace to trim off before comparing to the PHS?
-                        if (InformedSampler::space_->isCompound() == false)
-                        {
-                            // No, space_ == informedSubSpace_
-                            informedSubSpace_->copyToReals(informedVector, statePtr);
-                        }
-                        else
-                        {
-                            // Yes, we need to do some work to extract the subspace
-                            informedSubSpace_->copyToReals(informedVector, statePtr->as<CompoundState>()->components[informedIdx_]);
-                        }
-
-                        // Check if the informed state is in the PHS, if it is we've found a sample
-                        foundSample = phsPtr_->isInPhs(&informedVector[0]);
-                    }
+                    // The measure is large, sample from the entire world and keep if it's in any PHS
+                    foundSample = sampleBoundsRejectPhs(statePtr, iters);
                 }
                 else
                 {
-                    // The PHS has a smaller volume than the subspace.
-
-                    // Spend numIters_ iterations trying to find an sample that is within the bounds:
-                    for (/* Provided iteration counter */; *iters < InformedSampler::numIters_ && foundSample == false; ++(*iters))
-                    {
-                        // Sample the PHS irrespective of boundary
-                        sampleUniformIgnoreBounds(statePtr, maxCost);
-
-                        // Check if in the problem:
-                        foundSample = InformedSampler::space_->satisfiesBounds(statePtr);
-                    }
+                    // The measure is sufficiently small that we will directly sample the PHSes, with the weighting given by their relative measures
+                    foundSample = samplePhsRejectBounds(statePtr, iters);
                 }
             }
 
@@ -330,17 +385,96 @@ namespace ompl
 
 
 
-        void PathLengthDirectInfSampler::sampleUniformIgnoreBounds(State *statePtr, const Cost &maxCost)
+        bool PathLengthDirectInfSampler::sampleBoundsRejectPhs(State* statePtr, unsigned int *iters)
         {
             // Variable
-            // The informed subset of the sample as a vector
-            std::vector<double> informedVector(informedSubSpace_->getDimension());
+            // Whether we've found a sample:
+            bool foundSample  = false;
 
-            // Set the new transverse diameter
-            phsPtr_->setTransverseDiameter(maxCost.value());
+            // Spend numIters_ iterations trying to find an informed sample:
+            while (foundSample == false && *iters < InformedSampler::numIters_)
+            {
+                // Generate a random sample
+                baseSampler_->sampleUniform(statePtr);
 
-            // Sample the ellipse
-            rng_.uniformProlateHyperspheroid(phsPtr_, &informedVector[0]);
+                // The informed substate
+                std::vector<double> informedVector = getInformedSubstate(statePtr);
+
+                // Check if the informed state is in any PHS.
+                foundSample = isInAnyPhs(informedVector);
+
+                // Increment the provided counter
+                ++(*iters);
+            }
+
+            // successful?
+            return foundSample;
+        }
+
+
+
+        bool PathLengthDirectInfSampler::samplePhsRejectBounds(State *statePtr, unsigned int *iters)
+        {
+            // Variable
+            // Whether we were successful in creating an informed sample. Initially not:
+            bool foundSample = false;
+
+            // Due to the possibility of overlap between multiple PHSs, we keep a sample with a probability of 1/K, where K is the number of PHSs the sample is in.
+            while (foundSample == false && *iters < InformedSampler::numIters_)
+            {
+                // Variables
+                // The informed subset of the sample as a vector
+                std::vector<double> informedVector(informedSubSpace_->getDimension());
+                // The random PHS in use for this sample.
+                ProlateHyperspheroidCPtr phsCPtr = randomPhsPtr();
+
+                // Use the PHS to get a sample in the informed subspace irrespective of boundary
+                rng_.uniformProlateHyperspheroid(phsCPtr, &informedVector[0]);
+
+                // Keep with probability 1/K
+                foundSample = keepSample(informedVector);
+
+                //If we're keeping it, then check if the state is in the problem domain:
+                if (foundSample == true)
+                {
+                    // Turn into a state of our full space
+                    createFullState(statePtr, informedVector);
+
+                    // Return if the resulting state is in the problem:
+                    foundSample = InformedSampler::space_->satisfiesBounds(statePtr);
+                }
+                // No else
+            }
+
+            // Successful?
+            return foundSample;
+        }
+
+
+
+        std::vector<double> PathLengthDirectInfSampler::getInformedSubstate(const State *statePtr) const
+        {
+            // Variable
+            // The raw data in the state
+            std::vector<double> rawData(informedSubSpace_->getDimension());
+
+            // Get the raw data
+            if (InformedSampler::space_->isCompound() == false)
+            {
+                informedSubSpace_->copyToReals(rawData, statePtr);
+            }
+            else
+            {
+                informedSubSpace_->copyToReals(rawData, statePtr->as<CompoundState>()->components[informedIdx_]);
+            }
+
+            return rawData;
+        }
+
+
+
+        void PathLengthDirectInfSampler::createFullState(State * statePtr, const std::vector<double> &informedVector)
+        {
 
             // If there is an extra "uninformed" subspace, we need to add that to the state before converting the raw vector representation into a state....
             if (InformedSampler::space_->isCompound() == false)
@@ -370,46 +504,175 @@ namespace ompl
             }
         }
 
-        void PathLengthDirectInfSampler::sampleUniformIgnoreBounds(State *statePtr, const Cost &minCost, const Cost &maxCost)
+
+
+        void PathLengthDirectInfSampler::updatePhsDefinitions(const Cost &maxCost)
         {
-            // Sample from the larger PHS until the sample does not lie within the smaller PHS.
-            // Since volume in a sphere/spheroid is proportionately concentrated near the surface, this isn't horribly inefficient, though a direct method would be better
-
             // Variable
-            // Whether we were successful in creating an informed sample. Initially not:
-            bool foundSample = false;
+            // The iterator for the list:
+            std::list<ompl::ProlateHyperspheroidPtr>::iterator phsIter = listPhsPtrs_.begin();
 
-            // Spend numIters_ iterations trying to find an sample that is within the bounds:
-            for (unsigned int i = 0u; i < InformedSampler::numIters_ && foundSample == false; ++i)
+            // Iterate over the list of PHSs, updating the summed measure
+            // Reset the sum
+            summedMeasure_ = 0.0;
+            while (phsIter != listPhsPtrs_.end())
             {
-                // Get a sample inside the large PHS:
-                sampleUniformIgnoreBounds(statePtr, maxCost);
+                // Check if the specific PHS can ever be better than the given maxCost, i.e., if the distance between the foci is less than the current max cost
+                if ((*phsIter)->getMinTransverseDiameter() < maxCost.value())
+                {
+                    // It can improve the solution, or it's the only PHS we have, update it
 
-                // Check if it is also outside the smaller PHS, which occurs if the minCost is *better* than that of the sample:
-                foundSample = InformedSampler::opt_->isCostBetterThan(minCost, heuristicSolnCost(statePtr));
+                    // Update the transverse diameter
+                    (*phsIter)->setTransverseDiameter(maxCost.value());
+
+                    // Increment the summed measure of the ellipses.
+                    summedMeasure_ = summedMeasure_ + (*phsIter)->getPhsMeasure();
+
+                    // Increment the iterator
+                    ++phsIter;
+                }
+                else if (listPhsPtrs_.size() > 1u)
+                {
+                    // It can't, and it is not the last PHS, remove it
+
+                    // Remove the iterator to delete from the list, this returns the next:
+                    /// \todo Make sure this doesn't cause problems for JIT sampling?
+                    phsIter = listPhsPtrs_.erase(phsIter);
+                }
+                else
+                {
+                    // It can't, but it's the last PHS, so we can't remove it.
+
+                    // Make sure it's transverse diameter is set to something:
+                    (*phsIter)->setTransverseDiameter((*phsIter)->getMinTransverseDiameter());
+
+                    // Set the summed measure to 0.0 (as a degenerate PHS is a line):
+                    summedMeasure_ = 0.0;
+
+                    // Increment the iterator so we move past this to the end.
+                    ++phsIter;
+                }
             }
         }
 
 
-        Cost PathLengthDirectInfSampler::heuristicSolnCost(const State *statePtr) const
+
+        ompl::ProlateHyperspheroidPtr PathLengthDirectInfSampler::randomPhsPtr()
         {
             // Variable
-            // The raw data in the state
-            std::vector<double> rawData(informedSubSpace_->getDimension());
+            // The return value
+            ompl::ProlateHyperspheroidPtr rval;
 
-            // Get the raw data
-            if (InformedSampler::space_->isCompound() == false)
+            // If we only have one PHS, this can be simplified:
+            if (listPhsPtrs_.size() == 1u)
             {
-                informedSubSpace_->copyToReals(rawData, statePtr);
+                // One PHS, keep this simple.
+
+                // Return it
+                rval = listPhsPtrs_.front();
             }
             else
             {
-                informedSubSpace_->copyToReals(rawData, statePtr->as<CompoundState>()->components[informedIdx_]);
+                // We have more than one PHS to consider
+
+                // Variables
+                // A randomly generated number in the interval [0,1]
+                double randDbl = rng_.uniform01();
+                // The running measure
+                double runningRelativeMeasure = 0.0;
+
+                // The probability of using each PHS is weighted by it's measure. Therefore, if we iterate up the list of PHSs, the first one who's relative measure is greater than the PHS randomly selected
+                for (std::list<ompl::ProlateHyperspheroidPtr>::const_iterator phsIter = listPhsPtrs_.begin(); phsIter != listPhsPtrs_.end() && static_cast<bool>(rval) == false; ++phsIter)
+                {
+                    // Update the running measure
+                    runningRelativeMeasure = runningRelativeMeasure + (*phsIter)->getPhsMeasure()/summedMeasure_;
+
+                    // Check if it's now greater than the proportion of the summed measure
+                    if (runningRelativeMeasure > randDbl)
+                    {
+                        // It is, return this PHS:
+                        rval = *phsIter;
+                    }
+                    // No else, continue
+                }
             }
 
-            // Calculate and return the length
-            return Cost(phsPtr_->getPathLength(&rawData[0]));
+            // Return
+            return rval;
         }
 
+
+
+        bool PathLengthDirectInfSampler::keepSample(const std::vector<double>& informedVector)
+        {
+            // Variable
+            // The return value, do we keep this sample? Start true.
+            bool keep = true;
+
+            // Is there more than 1 goal?
+            if (listPhsPtrs_.size() > 1u)
+            {
+                // There is, do work
+
+                // Variable
+                // The number of PHSs the sample is in
+                unsigned int numIn = numberOfPhsInclusions(informedVector);
+                // The random number between [0,1]
+                double randDbl = rng_.uniform01();
+
+                // Keep the sample if the random number is less than 1/K
+                keep = (randDbl <= 1.0/static_cast<double>(numIn));
+            }
+            // No else, keep is true by default.
+
+            return keep;
+        }
+
+
+
+        bool PathLengthDirectInfSampler::isInAnyPhs(const std::vector<double>& informedVector) const
+        {
+            // Variable
+            // The return value, whether the given state is in any PHS
+            bool inPhs = false;
+
+            // Iterate over the list, stopping as soon as we get our first true
+            for (std::list<ompl::ProlateHyperspheroidPtr>::const_iterator phsIter = listPhsPtrs_.begin(); phsIter != listPhsPtrs_.end() && inPhs == false; ++ phsIter)
+            {
+                inPhs = isInPhs(*phsIter, informedVector);
+            }
+
+            return inPhs;
+        }
+
+
+
+        bool PathLengthDirectInfSampler::isInPhs(const ProlateHyperspheroidCPtr &phsCPtr, const std::vector<double> &informedVector) const
+        {
+            return phsCPtr->isInPhs(&informedVector[0]);
+        }
+
+
+
+        unsigned int PathLengthDirectInfSampler::numberOfPhsInclusions(const std::vector<double>& informedVector) const
+        {
+            // Variable
+            // The return value, the number of PHSs the vector is in
+            unsigned int numInclusions = 0u;
+
+            // Iterate over the list counting
+            for (std::list<ompl::ProlateHyperspheroidPtr>::const_iterator phsIter = listPhsPtrs_.begin(); phsIter != listPhsPtrs_.end(); ++ phsIter)
+            {
+                // Conditionally increment
+                if ((*phsIter)->isInPhs(&informedVector[0]) == true)
+                {
+                    ++numInclusions;
+                }
+                // No else
+            }
+
+            return numInclusions;
+        }
+        /////////////////////////////////////////////////////////////////////////////////////////////
     }; // base
 };  // ompl

--- a/src/ompl/base/samplers/informed/src/RejectionInfSampler.cpp
+++ b/src/ompl/base/samplers/informed/src/RejectionInfSampler.cpp
@@ -75,14 +75,20 @@ namespace ompl
             // Spend numIters_ iterations trying to find an informed sample:
             for (unsigned int i = 0u; i < InformedSampler::numIters_ && foundSample == false; ++i)
             {
-                // Call the helper function for the larger PHS. It will move our iteration counter:
+                // Call the helper function for the larger cost. It will move our iteration counter:
                 foundSample = sampleUniform(statePtr, maxCost, &i);
 
                 // Did we find a sample?
                 if (foundSample == true)
                 {
-                    // We did, but that was only inside the bigger PHS, we need to assure it's outside the smaller one which occurs if the minCost is *better* than that of the sample:
-                    foundSample = InformedSampler::opt_->isCostBetterThan(minCost, heuristicSolnCost(statePtr));
+                    // We did, but it only satisfied the upper bound. Check that it meets the lower bound.
+
+                    // Variables
+                    // The cost of the sample we found:
+                    Cost sampledCost = InformedSampler::heuristicSolnCost(statePtr);
+
+                    // Check if the sample's cost is greater than or equal to the lower bound
+                    foundSample = InformedSampler::opt_->isCostEquivalentTo(minCost, sampledCost) || InformedSampler::opt_->isCostBetterThan(minCost, sampledCost);
                 }
                 // No else, no sample was found.
             }
@@ -94,11 +100,6 @@ namespace ompl
         bool RejectionInfSampler::hasInformedMeasure() const
         {
             return false;
-        }
-
-        double RejectionInfSampler::getInformedMeasure() const
-        {
-            return InformedSampler::space_->getMeasure();
         }
 
         double RejectionInfSampler::getInformedMeasure(const Cost &/*currentCost*/) const

--- a/src/ompl/geometric/planners/bitstar/BITstar.h
+++ b/src/ompl/geometric/planners/bitstar/BITstar.h
@@ -68,19 +68,25 @@ namespace ompl
     {
         /**
             @anchor gBITstar
-            @par Short description
-            BIT* (Batch Informed Trees) is an anytime asymptotically optimal sampling-based
-            motion planning algorithm that extends Lifelong Planning A* (LPA*) techniques to continuous planning
-            problems. BIT* accomplishes this by processing batches of samples with a heuristic.
-            In doing so, it strikes a balance between algorithms like RRT* and FMT*.
 
-            @par Associated publications:
+            \ref gBITstar "BIT*" (Batch Informed Trees) is an \e anytime asymptotically optimal sampling-based
+            planning algorithm. It approaches problems by assuming that a \e simple solution exists and only
+            goes onto consider \e complex solutions when that proves incorrect. It accomplishes this by using
+            heuristics to search in order of decreasing potential solution quality.
 
-            J.D. Gammell, S. S. Srinivasa, T.D. Barfoot, "BIT*: Batch Informed Trees."
-            In Proceedings of the Information-based Grasp and Manipulation Planning Workshop at
-            Robotics: Science and Systems (RSS). Berkeley, CA, USA, 13 July 2014.
-            <a href="http://asrl.utias.utoronto.ca/~tdb/bib/gammell_rss14.pdf">Extended Abstract</a>.
-            <a href="http://asrl.utias.utoronto.ca/~tdb/bib/gammell_rss14_poster.pdf">Poster</a>.
+            This implementation of BIT* can handle multiple starts, multiple goals, a variety of optimization objectives
+            (e.g., path length), and with \ref gBITstarSetJustInTimeSampling "just-in-time sampling", infinite problem domains.
+            Note that for some of optimization  objectives, the user must specify a suitable heuristic and that when
+            this heuristic is not specified, it will use the conservative/always admissible \e zero-heuristic.
+
+            This implementation also includes some new advancements, including the ability to prioritize exploration until an
+            initial solution is found (\ref gBITstarSetDelayRewiringUntilInitialSolution "Delayed rewiring"), the ability to generate
+            samples only when necessary (\ref gBITstarSetJustInTimeSampling "Just-in-time sampling"), and the ability to periodically
+            remove samples that have yet to be connected to the graph (\ref gBITstarSetDropSamplesOnPrune "Sample dropping"). With
+            just-in-time sampling, BIT* can even solve planning problems with infinite state space boundaries, i.e., (-inf, inf).
+
+
+            @par Associated publication:
 
             J D. Gammell, S. S. Srinivasa, T. D. Barfoot, "Batch Informed Trees (BIT*): Sampling-based
             Optimal Planning via the Heuristically Guided Search of Implicit Random Geometric Graphs,"
@@ -90,7 +96,7 @@ namespace ompl
             <a href="http://www.youtube.com/watch?v=MRzSfLpNBmA">Illustration video</a>.
 
             \todo
-            - Make k-nearest RGG calculation correct.
+            - Make the k-nearest variant correct. Right now the search considers the k-nearest samples \e and the k-nearest vertices. It should find the combined k-nearest "samples & vertices".
         */
         /** \brief Batch Informed Trees (BIT*)*/
         class BITstar : public ompl::base::Planner
@@ -178,12 +184,6 @@ namespace ompl
             /** \brief Get whether a k-nearest search is being used.*/
             bool getKNearest() const;
 
-            /** \brief Enable tracking of failed edges. This currently is too expensive to be useful.*/
-            void setUseFailureTracking(bool trackFailures);
-
-            /** \brief Get whether a failed edge list is in use.*/
-            bool getUseFailureTracking() const;
-
             /** \brief Enable "strict sorting" of the edge queue.
             Rewirings can change the position in the queue of an edge.
             When strict sorting is enabled, the effected edges are resorted
@@ -210,19 +210,42 @@ namespace ompl
             /** \brief Get the fractional change in the solution cost necessary for pruning to occur. */
             double getPruneThresholdFraction() const;
 
-            /** \brief Drop unconnected samples on pruning. */
+            /** @anchor gBITstarSetDelayRewiringUntilInitialSolution \brief Delay the consideration of rewiring edges until
+            an initial solution is found. When multiple batches are required to find an initial solution, this can improve the time
+            required to do so, by delaying improvements in the cost-to-come to a connected vertex. As the rewiring edges are considered
+            once an initial solution is found, this has no effect on the theoretical asymptotic optimality of the planner. */
+            void setDelayRewiringUntilInitialSolution(bool delayRewiring);
+
+            /** \brief Get whether BIT* is delaying rewiring until a solution is found. */
+            bool getDelayRewiringUntilInitialSolution() const;
+
+            /** @anchor gBITstarSetJustInTimeSampling \brief Delay the generation of samples until they are \e necessary. This only works when using an
+            r-disc connection scheme, and is currently only implemented for problems seeking to minimize path length. This helps reduce the complexity of
+            nearest-neighbour look ups, and can be particularly beneficial in unbounded planning problems where selecting an appropriate bounding box is difficult.
+            With JIT sampling enabled, BIT* can solve planning problems whose state space has \e infinite \e boundaries. When enumerating outgoing edges from
+            a vertex, BIT* uses JIT sampling to assure that the area within r of the vertex has been sampled during this batch. This is done in a way that
+            maintains uniform sample distribution and has no effect on the theoretical asymptotic optimality of the planner. */
+            void setJustInTimeSampling(bool useJit);
+
+            /** \brief Get whether we're using just-in-time sampling */
+            bool getJustInTimeSampling() const;
+
+            /** @anchor gBITstarSetDropSamplesOnPrune \brief Drop \e all unconnected samples when pruning, regardless of their heuristic value.
+            This provides a method for BIT* to remove samples that have not been connected to the graph and may be beneficial in problems where
+            portions of the free space are unreachable (i.e., disconnected). BIT* calculates the connection radius for each batch from the underlying
+            uniform distribution of states. The resulting larger connection radius may be detrimental in areas where the graph is dense, but maintains
+            the theoretical asymptotic optimality of the planner.
+            */
             void setDropSamplesOnPrune(bool dropSamples);
 
             /** \brief Get whether unconnected samples are dropped on pruning. */
             bool getDropSamplesOnPrune() const;
 
-            /** \brief Delay considering rewiring edges until an initial solution is found. This improves
-            the time required to find an initial solution when doing so requires multiple batches and has
-            no effects on theoretical asymptotic optimality (as the rewiring edges are eventually considered). */
-            void setDelayRewiringUntilInitialSolution(bool delayRewiring);
+            /** \brief Enable tracking of failed edges. This currently is too expensive to be useful.*/
+            void setUseFailureTracking(bool trackFailures);
 
-            /** \brief Get whether BIT* is delaying rewiring until a solution is found. */
-            bool getDelayRewiringUntilInitialSolution() const;
+            /** \brief Get whether a failed edge list is in use.*/
+            bool getUseFailureTracking() const;
 
             /** \brief Stop the planner each time a solution improvement is found. Useful
             for examining the intermediate solutions found by BIT*. */
@@ -275,8 +298,7 @@ namespace ompl
             /** \brief Adds any new goals or starts that have appeared in the problem definition to the list of vertices and the queue. Creates a new informed sampler. Returns true if new starts/goals are created. */
             void updateStartAndGoalStates(const base::PlannerTerminationCondition& ptc);
 
-            /** \brief Prune the starts and goals that have a solution heuristic that is not less than bestCost_
-                \todo In the case where you are adding both starts \e and goals while BIT* is running, an earlier pruned start/goal may preclude a good solution upon addition of a new goal/start. */
+            /** \brief Prune the starts and goals that have a solution heuristic that is not less than bestCost_ */
             void pruneStartsGoals();
 
             /** \brief Prune all samples with a solution heuristic that is not less than the bestCost_ */
@@ -285,7 +307,7 @@ namespace ompl
             /** \brief Checks an edge for collision. A wrapper to SpaceInformation->checkMotion that tracks number of collision checks. */
             bool checkEdge(const VertexPtrPair& edge);
 
-            /** \brief Actually remove a sample from its NN struct: */
+            /** \brief Actually remove a sample from its NN struct.*/
             void dropSample(VertexPtr oldSample);
 
             /** \brief Add an edge from the edge queue to the tree. Will add the state to the vertex queue if it's new to the tree or otherwise replace the parent. Updates solution information if the solution improves. */
@@ -345,8 +367,8 @@ namespace ompl
             /** \brief The true cost of an edge, including collisions.*/
             ompl::base::Cost trueEdgeCost(const VertexPtrPair& edgePair) const;
 
-            /** \brief Calculate the max req'd cost to define a neighbourhood around a state. I.e., For path-length problems, the cost equivalent of +2*r. */
-            ompl::base::Cost neighbourhoodCost() const;
+            /** \brief Calculate the max req'd cost to define a neighbourhood around a state. Currently only implemented for path-length problems, for which the neighbourhood cost is the f-value of the vertex plus 2r. */
+            ompl::base::Cost neighbourhoodCost(const VertexPtr& vertex) const;
 
             /** \brief Compare whether cost a is worse than cost b by checking whether b is better than a. */
             bool isCostWorseThan(const ompl::base::Cost& a, const ompl::base::Cost& b) const;
@@ -378,8 +400,8 @@ namespace ompl
             /** \brief Initialize the nearest-neighbour terms */
             void initializeNearestTerms();
 
-            /** \brief Update the appropriate nearest-neighbour terms, r_ and k_ */
-            virtual void updateNearestTerms();
+            /** \brief Update the appropriate nearest-neighbour terms, r_ and k_. Can optionally perform this calculation with or without considering the "future" samples to be added in this batch. */
+            virtual void updateNearestTerms(bool plusFutureSamples);
 
             /** \brief Calculate the r for r-disc nearest neighbours, a function of the current graph */
             double calculateR(unsigned int N) const;
@@ -487,6 +509,9 @@ namespace ompl
 
 
             //Variables -- Make sure every one is configured in setup() and reset in clear():
+            /** \brief An instance of a random number generator */
+            ompl::RNG                                                rng_;
+
             /** \brief State sampler */
             ompl::base::InformedSamplerPtr                           sampler_;
 
@@ -498,6 +523,12 @@ namespace ompl
 
             /** \brief The goal states of the problem as vertices */
             std::list<VertexPtr>                                     goalVertices_;
+
+            /** \brief Any start states of the problem that have been pruned */
+            std::list<VertexPtr>                                     prunedStartVertices_;
+
+            /** \brief Any goal states of the problem that have been pruned */
+            std::list<VertexPtr>                                     prunedGoalVertices_;
 
             /** \brief The goal vertex of the current best solution */
             VertexPtr                                                curGoalVertex_;
@@ -513,9 +544,6 @@ namespace ompl
 
             /** \brief The number of states (vertices or samples) that were generated from a uniform distribution. Only valid when refreshSamplesOnPrune_ is true, in which case it's used to calculate the RGG term of the uniform subgraph.*/
             unsigned int                                             numUniformStates_;
-
-            /** \brief The resulting sampling density for a batch */
-            double                                                   sampleDensity_;
 
             /** \brief The current r-disc RGG connection radius */
             double                                                   r_;
@@ -605,9 +633,6 @@ namespace ompl
             /** \brief The number of samples per batch (param) */
             unsigned int                                             samplesPerBatch_;
 
-            /** \brief Track edges that have been checked and failed so they never reenter the queue. (param) */
-            bool                                                     useFailureTracking_;
-
             /** \brief Option to use k-nearest search for rewiring (param) */
             bool                                                     useKNearest_;
 
@@ -617,11 +642,17 @@ namespace ompl
             /** \brief The fractional decrease in solution cost required to trigger pruning (param) */
             double                                                   pruneFraction_;
 
+            /** \brief Whether to delay rewiring until a solution is found (param) */
+            bool                                                     delayRewiring_;
+
+            /** \brief Whether to use just-in-time sampling (param) */
+            bool                                                     useJustInTimeSampling_;
+
             /** \brief Whether to refresh (i.e., forget) unconnected samples on pruning (param) */
             bool                                                     dropSamplesOnPrune_;
 
-            /** \brief Whether to delay rewiring until a solution is found (param) */
-            bool                                                     delayRewiring_;
+            /** \brief Track edges that have been checked and failed so they never reenter the queue. (param) */
+            bool                                                     useFailureTracking_;
 
             /** \brief Whether to stop the planner as soon as the path changes (param) */
             bool                                                     stopOnSolnChange_;

--- a/src/ompl/geometric/planners/bitstar/datastructures/Vertex.h
+++ b/src/ompl/geometric/planners/bitstar/datastructures/Vertex.h
@@ -160,6 +160,9 @@ namespace ompl
             /** \brief Mark the vertex as pruned. */
             void markPruned();
 
+            /** \brief Mark the vertex as unpruned. */
+            void markUnpruned();
+
             /** \brief Mark the given vertex as a \e failed connection from this vertex */
             void markAsFailedChild(const VertexConstPtr& failedChild);
 

--- a/src/ompl/geometric/planners/bitstar/datastructures/src/IntegratedQueue.cpp
+++ b/src/ompl/geometric/planners/bitstar/datastructures/src/IntegratedQueue.cpp
@@ -641,7 +641,7 @@ namespace ompl
         {
             //Threshold should always be g_t(x_g)
             //As the sample is in the graph (and therefore could be part of g_t), prune iff g^(v) + h^(v) > g_t(x_g)
-            //g^(v) + h^(v) <= g_t(x_g)
+            //g^(v) + h^(v) >= g_t(x_g)
             return this->isCostWorseThan(lowerBoundHeuristicVertexFunc_(state), costThreshold_);
         }
 
@@ -1366,7 +1366,7 @@ namespace ompl
                         //Remove myself from the nearest neighbour structure:
                         vertexNN->remove(oldVertex);
 
-                        //Finally, mark as pruned. This is a lock that can never be undone and prevents accessing anything about the vertex.
+                        //Finally, mark as pruned. This is a lock that prevents accessing anything about the vertex.
                         oldVertex->markPruned();
                     }
                     else

--- a/src/ompl/geometric/planners/bitstar/datastructures/src/Vertex.cpp
+++ b/src/ompl/geometric/planners/bitstar/datastructures/src/Vertex.cpp
@@ -426,6 +426,13 @@ namespace ompl
 
 
 
+        void BITstar::Vertex::markUnpruned()
+        {
+            isPruned_ = false;
+        }
+
+
+
         void BITstar::Vertex::markAsFailedChild(const VertexConstPtr& failedChild)
         {
             this->assertNotPruned();

--- a/src/ompl/geometric/planners/bitstar/datastructures/src/Vertex.cpp
+++ b/src/ompl/geometric/planners/bitstar/datastructures/src/Vertex.cpp
@@ -510,6 +510,7 @@ namespace ompl
         {
             if (isPruned_ == true)
             {
+                std::cout << std::endl << "vId: " << vId_  << std::endl;
                 throw ompl::Exception("Attempting to access a pruned vertex.");
             }
         }

--- a/src/ompl/geometric/planners/rrt/InformedRRTstar.h
+++ b/src/ompl/geometric/planners/rrt/InformedRRTstar.h
@@ -48,12 +48,12 @@ namespace ompl
 
         /**
             @anchor gInformedRRTstar
-            @par Short description
-            Run RRTstar with an informed strategy that uses the existence of a solution to define a subproblem that contains all possibly better solutions.
-            The search is limited to this subproblem by pruning the graph, generating samples only in this subproblem (directly if available, e.g., path length)
-            and using the size of this subproblem to calculate the connection terms (if available, e.g., path length)
 
-            @par Associated publications:
+            Run \ref gRRTstar "RRT*" with an informed search strategy that uses heuristics to only consider subproblem that could provide a better solution.
+            The search is limited to this subproblem by pruning the graph, generating samples only in this subproblem (directly if available, e.g., \ref gPathLengthDirectInfSampler "path length")
+            and, when available, using the measure of this subproblem to calculate the connection terms (e.g., path length)
+
+            @par Associated publication:
 
             J D. Gammell, S. S. Srinivasa, T. D. Barfoot, "Informed RRT*: Optimal Sampling-based
             Path Planning Focused via Direct Sampling of an Admissible Ellipsoidal Heuristic." In Proceedings

--- a/src/ompl/util/ProlateHyperspheroid.h
+++ b/src/ompl/util/ProlateHyperspheroid.h
@@ -75,8 +75,11 @@ namespace ompl
         /** \brief Transform a point from a sphere to PHS. The return variable \e phs is expected to already exist.  */
         void transform(const double sphere[], double phs[]) const;
 
-        /** \brief Check if the given point lies within the PHS */
+        /** \brief Check if the given point lies \e in the PHS. */
         bool isInPhs(const double point[]) const;
+
+        /** \brief Check if the given point lies \e on the PHS. */
+        bool isOnPhs(const double point[]) const;
 
         /** \brief The dimension of the PHS */
         unsigned int getPhsDimension(void) const;

--- a/src/ompl/util/RandomNumbers.h
+++ b/src/ompl/util/RandomNumbers.h
@@ -161,7 +161,7 @@ namespace ompl
         DOI: <a href="http://dx.doi.org/10.1109/IROS.2014.6942976">10.1109/IROS.2014.6942976</a>.
         <a href="http://www.youtube.com/watch?v=d7dX5MvDYTc">Illustration video</a>.
         <a href="http://www.youtube.com/watch?v=nsl-5MZfwu4">Short description video</a>. */
-        void uniformProlateHyperspheroidSurface(const ProlateHyperspheroidPtr &phsPtr, double value[]);
+        void uniformProlateHyperspheroidSurface(const boost::shared_ptr<const ProlateHyperspheroid> &phsPtr, double value[]);
 
         /** \brief Uniform random sampling of a prolate hyperspheroid, a special symmetric type of
         n-dimensional ellipse. The return variable \e value is expected to already exist.
@@ -172,7 +172,7 @@ namespace ompl
         DOI: <a href="http://dx.doi.org/10.1109/IROS.2014.6942976">10.1109/IROS.2014.6942976</a>.
         <a href="http://www.youtube.com/watch?v=d7dX5MvDYTc">Illustration video</a>.
         <a href="http://www.youtube.com/watch?v=nsl-5MZfwu4">Short description video</a>. */
-        void uniformProlateHyperspheroid(const ProlateHyperspheroidPtr &phsPtr, double value[]);
+        void uniformProlateHyperspheroid(const boost::shared_ptr<const ProlateHyperspheroid>  &phsPtr, double value[]);
 #endif
 
     private:

--- a/src/ompl/util/src/ProlateHyperspheroid.cpp
+++ b/src/ompl/util/src/ProlateHyperspheroid.cpp
@@ -146,7 +146,18 @@ bool ompl::ProlateHyperspheroid::isInPhs(const double point[]) const
         throw Exception ("The transverse diameter has not been set");
     }
 
-    return (getPathLength(point) <= dataPtr_->transverseDiameter_);
+    return (getPathLength(point) < dataPtr_->transverseDiameter_);
+}
+
+bool ompl::ProlateHyperspheroid::isOnPhs(const double point[]) const
+{
+    if (dataPtr_->isTransformUpToDate_ == false)
+    {
+        // The transform is not up to date until the transverse diameter has been set
+        throw Exception ("The transverse diameter has not been set");
+    }
+
+    return (getPathLength(point) == dataPtr_->transverseDiameter_);
 }
 
 unsigned int ompl::ProlateHyperspheroid::getPhsDimension(void) const

--- a/src/ompl/util/src/RandomNumbers.cpp
+++ b/src/ompl/util/src/RandomNumbers.cpp
@@ -348,7 +348,7 @@ void ompl::RNG::uniformInBall(double r, unsigned int n, double value[])
 }
 
 #if OMPL_HAVE_EIGEN3
-void ompl::RNG::uniformProlateHyperspheroidSurface(const ProlateHyperspheroidPtr &phsPtr, double value[])
+void ompl::RNG::uniformProlateHyperspheroidSurface(const boost::shared_ptr<const ProlateHyperspheroid>  &phsPtr, double value[])
 {
     // Variables
     // The spherical point as a std::vector
@@ -361,7 +361,7 @@ void ompl::RNG::uniformProlateHyperspheroidSurface(const ProlateHyperspheroidPtr
     phsPtr->transform(&sphere[0], value);
 }
 
-void ompl::RNG::uniformProlateHyperspheroid(const ProlateHyperspheroidPtr &phsPtr, double value[])
+void ompl::RNG::uniformProlateHyperspheroid(const boost::shared_ptr<const ProlateHyperspheroid>  &phsPtr, double value[])
 {
     // Variables
     // The spherical point as a std::vector


### PR DESCRIPTION
This is the last PR I had in my queue. It's a couple things.

1. Support for multiple starts/goals in `PathLengthDirectInfSampler`,
2. Support for the MoveIt! workflow in `BIT*`,
3. Support for planning problems with infinite bounds in `BIT*`,
4. A couple other new ideas for `BIT*`, and
5. Documentation updates for `PathLengthDirectInfSampler,` `InformedRRT*` and `BIT*` to support the upcoming release.

Will rebase when it's ready to go.