### PR TITLE
BIT*: Infinite problem domain fix

### DIFF
--- a/src/ompl/geometric/planners/bitstar/BITstar.h
+++ b/src/ompl/geometric/planners/bitstar/BITstar.h
@@ -96,6 +96,7 @@ namespace ompl
             <a href="http://www.youtube.com/watch?v=MRzSfLpNBmA">Illustration video</a>.
 
             \todo
+            - Implement approximate solution support.
             - Make the k-nearest variant correct. Right now the search considers the k-nearest samples \e and the k-nearest vertices. It should find the combined k-nearest "samples & vertices".
         */
         /** \brief Batch Informed Trees (BIT*)*/


### PR DESCRIPTION
A much better default-way for `BIT*` to handle the "size" of the first batch of an infinite planning problem. Instead of assuming unit measure, estimates it as that of a (hyper)cube proportional to the distance between start and goal. Provides some relation to the order-of-magnitude of the problem, and moves the `std::isfinite` check on the measure to just `setup`.