### PR TITLE
BIT*: Correct k-nearest version

### DIFF
--- a/src/ompl/geometric/planners/bitstar/BITstar.h
+++ b/src/ompl/geometric/planners/bitstar/BITstar.h
@@ -74,6 +74,13 @@ namespace ompl
             goes onto consider \e complex solutions when that proves incorrect. It accomplishes this by using
             heuristics to search in order of decreasing potential solution quality.
 
+            Both a k-nearest and r-disc version are available, with the k-nearest selected by default. In general,
+            the r-disc variant considers more connections than the k-nearest. For a small number of specific planning
+            problems, this results in it finding solutions slower than k-nearest (hence the default choice).
+            It is recommended that you try both variants, with the r-disc version being recommended *if* it finds an
+            initial solution in a suitable amount of time (which it probably will). The difference in this number of
+            connections considered is a RGG theory question, and certainly merits further review.
+
             This implementation of BIT* can handle multiple starts, multiple goals, a variety of optimization objectives
             (e.g., path length), and with \ref gBITstarSetJustInTimeSampling "just-in-time sampling", infinite problem domains.
             Note that for some of optimization  objectives, the user must specify a suitable heuristic and that when
@@ -263,6 +270,9 @@ namespace ompl
             /** \brief A pair of vertices, i.e., an edge. */
             typedef std::pair<VertexPtr, VertexPtr> VertexPtrPair;
 
+            /** \brief A pair of const vertices, i.e., an edge. */
+            typedef std::pair<VertexConstPtr, VertexConstPtr> VertexConstPtrPair;
+
             /** \brief The OMPL::NearestNeighbors structure. */
             typedef boost::shared_ptr< NearestNeighbors<VertexPtr> > VertexPtrNNPtr;
 
@@ -279,7 +289,7 @@ namespace ompl
             void newBatch();
 
             /** \brief Update the list of free samples */
-            void updateSamples(const VertexPtr& vertex);
+            void updateSamples(const VertexConstPtr& vertex);
 
             /** \brief Prune the problem. Returns true if pruning was done. */
             virtual bool prune();
@@ -306,7 +316,7 @@ namespace ompl
             void pruneSamples();
 
             /** \brief Checks an edge for collision. A wrapper to SpaceInformation->checkMotion that tracks number of collision checks. */
-            bool checkEdge(const VertexPtrPair& edge);
+            bool checkEdge(const VertexConstPtrPair& edge);
 
             /** \brief Actually remove a sample from its NN struct.*/
             void dropSample(VertexPtr oldSample);
@@ -326,50 +336,50 @@ namespace ompl
             /** \brief Add a vertex to the graph */
             void addVertex(const VertexPtr& newVertex, const bool& removeFromFree);
 
-            /** \brief Get the nearest samples from the freeStateNN_ using the appropriate "near" definition (i.e., k or r). */
-            void nearestSamples(const VertexPtr& vertex, std::vector<VertexPtr>* neighbourSamples);
+            /** \brief Get the nearest samples from the freeStateNN_ using the appropriate "near" definition (i.e., k or r). If using k-nearest, returns the target k, otherwise returns 0u. */
+            unsigned int nearestSamples(const VertexPtr& vertex, std::vector<VertexPtr>* neighbourSamples);
 
-            /** \brief Get the nearest samples from the vertexNN_ using the appropriate "near" definition (i.e., k or r). */
-            void nearestVertices(const VertexPtr& vertex, std::vector<VertexPtr>* neighbourVertices);
+            /** \brief Get the nearest samples from the vertexNN_ using the appropriate "near" definition (i.e., k or r). If using k-nearest, returns the target k, otherwise returns 0u. */
+            unsigned int nearestVertices(const VertexPtr& vertex, std::vector<VertexPtr>* neighbourVertices);
             ///////////////////////////////////////////////////////////////////
 
             ///////////////////////////////////////////////////////////////////
             //Helper functions for sorting queues/nearest-neighbour structures and the related calculations.
             /** \brief The distance function used for nearest neighbours. Calculates the distance directionally from the given state to all the other states (can be used on states either in our out of the graph).*/
-            double nnDistance(const VertexPtr& a, const VertexPtr& b) const;
+            double nnDistance(const VertexConstPtr& a, const VertexConstPtr& b) const;
             ///////////////////////////////////////////////////////////////////
 
             ///////////////////////////////////////////////////////////////////
             //Helper functions for various heuristics.
             /** \brief Calculates a heuristic estimate of the cost of a solution constrained to pass through a vertex, independent of the current cost-to-come. I.e., combines the heuristic estimates of the cost-to-come and cost-to-go. */
-            ompl::base::Cost lowerBoundHeuristicVertex(const VertexPtr& edgePair) const;
+            ompl::base::Cost lowerBoundHeuristicVertex(const VertexConstPtr& vertex) const;
 
             /** \brief Calculates a heuristic estimate of the cost of a solution constrained to pass through a vertex, dependent on the current cost-to-come. I.e., combines the current cost-to-come with a heuristic estimate of the cost-to-go. */
-            ompl::base::Cost currentHeuristicVertex(const VertexPtr& edgePair) const;
+            ompl::base::Cost currentHeuristicVertex(const VertexConstPtr& vertex) const;
 
             /** \brief Calculates a heuristic estimate of the cost of a solution constrained to go through an edge, independent of the cost-to-come of the parent state. I.e., combines the heuristic estimates of the cost-to-come, edge cost, and cost-to-go. */
-            ompl::base::Cost lowerBoundHeuristicEdge(const VertexPtrPair& edgePair) const;
+            ompl::base::Cost lowerBoundHeuristicEdge(const VertexConstPtrPair& edgePair) const;
 
             /** \brief Calculates a heuristic estimate of the cost of a solution constrained to go through an edge, dependent on the cost-to-come of the parent state. I.e., combines the current cost-to-come with heuristic estimates of the edge cost, and cost-to-go. */
-            ompl::base::Cost currentHeuristicEdge(const VertexPtrPair& edgePair) const;
+            ompl::base::Cost currentHeuristicEdge(const VertexConstPtrPair& edgePair) const;
 
             /** \brief Calculates a heuristic estimate of the cost of a path to the \e target of an edge, dependent on the cost-to-come of the parent state. I.e., combines the current cost-to-come with heuristic estimates of the edge cost. */
-            ompl::base::Cost currentHeuristicEdgeTarget(const VertexPtrPair& edgePair) const;
+            ompl::base::Cost currentHeuristicEdgeTarget(const VertexConstPtrPair& edgePair) const;
 
             /** \brief Calculate a heuristic estimate of the cost-to-come for a Vertex */
-            ompl::base::Cost costToComeHeuristic(const VertexPtr& vertex) const;
+            ompl::base::Cost costToComeHeuristic(const VertexConstPtr& vertex) const;
 
             /** \brief Calculate a heuristic estimate of the cost an edge between two Vertices */
-            ompl::base::Cost edgeCostHeuristic(const VertexPtrPair& edgePair) const;
+            ompl::base::Cost edgeCostHeuristic(const VertexConstPtrPair& edgePair) const;
 
             /** \brief Calculate a heuristic estimate of the cost-to-go for a Vertex */
-            ompl::base::Cost costToGoHeuristic(const VertexPtr& vertex) const;
+            ompl::base::Cost costToGoHeuristic(const VertexConstPtr& vertex) const;
 
             /** \brief The true cost of an edge, including collisions.*/
-            ompl::base::Cost trueEdgeCost(const VertexPtrPair& edgePair) const;
+            ompl::base::Cost trueEdgeCost(const VertexConstPtrPair& edgePair) const;
 
             /** \brief Calculate the max req'd cost to define a neighbourhood around a state. Currently only implemented for path-length problems, for which the neighbourhood cost is the f-value of the vertex plus 2r. */
-            ompl::base::Cost neighbourhoodCost(const VertexPtr& vertex) const;
+            ompl::base::Cost neighbourhoodCost(const VertexConstPtr& vertex) const;
 
             /** \brief Compare whether cost a is worse than cost b by checking whether b is better than a. */
             bool isCostWorseThan(const ompl::base::Cost& a, const ompl::base::Cost& b) const;

--- a/src/ompl/geometric/planners/bitstar/BITstar.h
+++ b/src/ompl/geometric/planners/bitstar/BITstar.h
@@ -249,12 +249,6 @@ namespace ompl
             /** \brief Get whether unconnected samples are dropped on pruning. */
             bool getDropSamplesOnPrune() const;
 
-            /** \brief Enable tracking of failed edges. This currently is too expensive to be useful.*/
-            void setUseFailureTracking(bool trackFailures);
-
-            /** \brief Get whether a failed edge list is in use.*/
-            bool getUseFailureTracking() const;
-
             /** \brief Stop the planner each time a solution improvement is found. Useful
             for examining the intermediate solutions found by BIT*. */
             void setStopOnSolnImprovement(bool stopOnChange);
@@ -556,6 +550,12 @@ namespace ompl
             /** \brief The integrated queue of vertices to expand and edges to process ordered on "f-value", i.e., estimated solution cost. Remaining vertex queue "size" and edge queue size are accessible via vertexQueueSizeProgressProperty and edgeQueueSizeProgressProperty, respectively. */
             IntegratedQueuePtr                                       intQueue_;
 
+            /** \brief A copy of the new samples from this batch */
+            std::vector<VertexPtr>                                   newSamples_;
+
+            /** \brief A copy of the vertices recycled into samples during this batch */
+            std::vector<VertexPtr>                                   recycledSamples_;
+
             /** \brief The number of states (vertices or samples) that were generated from a uniform distribution. Only valid when refreshSamplesOnPrune_ is true, in which case it's used to calculate the RGG term of the uniform subgraph.*/
             unsigned int                                             numUniformStates_;
 
@@ -667,9 +667,6 @@ namespace ompl
 
             /** \brief Whether to refresh (i.e., forget) unconnected samples on pruning (param) */
             bool                                                     dropSamplesOnPrune_;
-
-            /** \brief Track edges that have been checked and failed so they never reenter the queue. (param) */
-            bool                                                     useFailureTracking_;
 
             /** \brief Whether to stop the planner as soon as the path changes (param) */
             bool                                                     stopOnSolnChange_;

--- a/src/ompl/geometric/planners/bitstar/BITstar.h
+++ b/src/ompl/geometric/planners/bitstar/BITstar.h
@@ -69,17 +69,18 @@ namespace ompl
         /**
             @anchor gBITstar
 
-            \ref gBITstar "BIT*" (Batch Informed Trees) is an \e anytime asymptotically optimal sampling-based
+            \ref gBITstar "BIT*" (Batch Informed Trees) is an \e anytime almost surely asymptotically optimal sampling-based
             planning algorithm. It approaches problems by assuming that a \e simple solution exists and only
             goes onto consider \e complex solutions when that proves incorrect. It accomplishes this by using
             heuristics to search in order of decreasing potential solution quality.
 
-            Both a k-nearest and r-disc version are available, with the k-nearest selected by default. In general,
-            the r-disc variant considers more connections than the k-nearest. For a small number of specific planning
-            problems, this results in it finding solutions slower than k-nearest (hence the default choice).
+            Both a k-nearest and r-disc version are available, with the k-nearest selected by default.
             It is recommended that you try both variants, with the r-disc version being recommended *if* it finds an
-            initial solution in a suitable amount of time (which it probably will). The difference in this number of
-            connections considered is a RGG theory question, and certainly merits further review.
+            initial solution in a suitable amount of time (which it probably will). In general, both variants work,
+            but for a small number of problems the calculation of the radius in the r-disc version appears to be too
+            small and does not create an implicit graph that is sufficiently dense (hence the default choice).
+            This is a question of the random geometric graph theory underpinning this type of almost surely asymptotically
+            optimal planner and certainly merits further review.
 
             This implementation of BIT* can handle multiple starts, multiple goals, a variety of optimization objectives
             (e.g., path length), and with \ref gBITstarSetJustInTimeSampling "just-in-time sampling", infinite problem domains.

--- a/src/ompl/geometric/planners/bitstar/datastructures/IntegratedQueue.h
+++ b/src/ompl/geometric/planners/bitstar/datastructures/IntegratedQueue.h
@@ -92,26 +92,23 @@ namespace ompl
         public:
             ////////////////////////////////
             //Data typedefs:
-            /** \brief A typedef for a pair of vertices, i.e., an edge */
-            typedef std::pair<VertexPtr, VertexPtr> VertexPtrPair;
-
             /** \brief A typedef for a pair of costs, i.e., the edge sorting key */
             typedef std::pair<ompl::base::Cost, ompl::base::Cost> CostPair;
-
-            /** \brief A typedef for the nearest-neighbour struct */
-            typedef boost::shared_ptr< NearestNeighbors<VertexPtr> > VertexPtrNNPtr;
             ////////////////////////////////
 
             ////////////////////////////////
             //Function typedefs:
             /** \brief A boost::function definition of a heuristic function for a vertex. */
-            typedef boost::function<ompl::base::Cost (const VertexPtr&)> VertexHeuristicFunc;
+            typedef boost::function<ompl::base::Cost (const VertexConstPtr&)> VertexHeuristicFunc;
 
             /** \brief A boost::function definition of a heuristic function for an edge. */
-            typedef boost::function<ompl::base::Cost (const VertexPtrPair&)> EdgeHeuristicFunc;
+            typedef boost::function<ompl::base::Cost (const VertexConstPtrPair&)> EdgeHeuristicFunc;
+
+            /** \brief A boost::function definition for the distance between two vertices. */
+            typedef boost::function<double (const VertexConstPtr&, const VertexConstPtr&)> DistanceFunc;
 
             /** \brief A boost::function definition for the neighbourhood of a vertex . */
-            typedef boost::function<void (const VertexPtr&, std::vector<VertexPtr>*)> NeighbourhoodFunc;
+            typedef boost::function<unsigned int (const VertexPtr&, std::vector<VertexPtr>*)> NeighbourhoodFunc;
             ////////////////////////////////
 
 
@@ -120,7 +117,7 @@ namespace ompl
             //Public functions:
             /** \brief Construct an integrated queue. */
             //boost::make_shared can only take 9 arguments, so be careful:
-            IntegratedQueue(const ompl::base::OptimizationObjectivePtr& opt, const NeighbourhoodFunc& nearSamplesFunc, const NeighbourhoodFunc& nearVerticesFunc, const VertexHeuristicFunc& lowerBoundHeuristicVertex, const VertexHeuristicFunc& currentHeuristicVertex, const EdgeHeuristicFunc& lowerBoundHeuristicEdge, const EdgeHeuristicFunc& currentHeuristicEdge, const EdgeHeuristicFunc& currentHeuristicEdgeTarget);
+            IntegratedQueue(const ompl::base::OptimizationObjectivePtr& opt, const DistanceFunc& distanceFunc, const NeighbourhoodFunc& nearSamplesFunc, const NeighbourhoodFunc& nearVerticesFunc, const VertexHeuristicFunc& lowerBoundHeuristicVertex, const VertexHeuristicFunc& currentHeuristicVertex, const EdgeHeuristicFunc& lowerBoundHeuristicEdge, const EdgeHeuristicFunc& currentHeuristicEdge, const EdgeHeuristicFunc& currentHeuristicEdgeTarget);
 
             virtual ~IntegratedQueue();
 
@@ -284,73 +281,6 @@ namespace ompl
             typedef boost::unordered_map<BITstar::VertexId, EdgeQueueIterList> VertexIdToEdgeQueueIterListUMap;
             ////////////////////////////////
 
-            ////////////////////////////////
-            //Member variables:
-
-            /** \brief My optimization objective. */
-            ompl::base::OptimizationObjectivePtr                     opt_;
-
-            /** \brief The function to find nearby samples. */
-            NeighbourhoodFunc                                        nearSamplesFunc_;
-
-            /** \brief The function to find nearby samples. */
-            NeighbourhoodFunc                                        nearVerticesFunc_;
-
-            /** \brief The lower-bounding heuristic for a vertex. */
-            VertexHeuristicFunc                                      lowerBoundHeuristicVertexFunc_;
-
-            /** \brief The current heuristic for a vertex. */
-            VertexHeuristicFunc                                      currentHeuristicVertexFunc_;
-
-            /** \brief The lower-bounding heuristic for an edge. */
-            EdgeHeuristicFunc                                        lowerBoundHeuristicEdgeFunc_;
-
-            /** \brief The current heuristic for an edge. */
-            EdgeHeuristicFunc                                        currentHeuristicEdgeFunc_;
-
-            /** \brief The current heuristic to the end of an edge. */
-            EdgeHeuristicFunc                                        currentHeuristicEdgeTargetFunc_;
-
-            /** \brief Whether to use failure tracking or not */
-            bool                                                     useFailureTracking_;
-
-            /** \brief Whether to delay rewiring until an initial solution is found or not */
-            bool                                                     delayRewiring_;
-
-            /** \brief Whether to use parent lookup tables or not */
-            bool                                                     outgoingLookupTables_;
-
-            /** \brief Whether to use child lookup tables or not */
-            bool                                                     incomingLookupTables_;
-
-            /** \brief The underlying queue of vertices. Sorted by vertexQueueComparison. */
-            CostToVertexMMap                                         vertexQueue_;
-
-            /** \brief The next vertex in the expansion queue to expand*/
-            VertexQueueIter                                          vertexToExpand_;
-
-            /** \brief The underlying queue of edges. Sorted by edgeQueueComparison. */
-            CostToVertexPtrPairMMap                                  edgeQueue_;
-
-            /** \brief A lookup from vertex to iterator in the vertex queue */
-            VertexIdToVertexQueueIterUMap                            vertexIterLookup_;
-
-            /** \brief A unordered map from a vertex to all the edges in the queue emanating from the vertex: */
-            VertexIdToEdgeQueueIterListUMap                          outgoingEdges_;
-
-            /** \brief A unordered map from a vertex to all the edges in the queue leading into the vertex: */
-            VertexIdToEdgeQueueIterListUMap                          incomingEdges_;
-
-            /** \brief A list of vertices that we will need to process when resorting the queue: */
-            std::list<VertexPtr>                                     resortVertices_;
-
-            /** \brief The maximum heuristic value allowed for vertices/edges in the queue.*/
-            ompl::base::Cost                                         costThreshold_;
-
-            /** \brief Whether the problem has a solution */
-            bool                                                     hasSolution_;
-            ////////////////////////////////
-
 
             ////////////////////////////////
             //High level primitives:
@@ -365,6 +295,9 @@ namespace ompl
 
             /** \brief Attempt to add an edge to the queue. Checks that the edge meets the queueing condition and that it is not in the failed set (if appropriate). */
             void queueupEdge(const VertexPtr& parent, const VertexPtr& child);
+
+            /** \brief Given two subsets containing (up to) the k-nearest members of each, finds the k-nearest of the union */
+            void processKNearest(unsigned int k, const VertexConstPtr& vertex, std::vector<VertexPtr>* kNearSamples, std::vector<VertexPtr>* kNearVertices);
             ////////////////////////////////
 
 
@@ -436,6 +369,77 @@ namespace ompl
 
             /** \brief Compare whether cost a is worse or equivalent to cost b by checking that a is not better than b. */
             bool isCostWorseThanOrEquivalentTo(const ompl::base::Cost& a, const ompl::base::Cost& b) const;
+            ////////////////////////////////
+
+
+
+            ////////////////////////////////
+            //Member variables:
+            /** \brief My optimization objective. */
+            ompl::base::OptimizationObjectivePtr                     opt_;
+
+            /** \brief The distance function */
+            DistanceFunc                                             distanceFunc_;
+
+            /** \brief The function to find nearby samples. */
+            NeighbourhoodFunc                                        nearSamplesFunc_;
+
+            /** \brief The function to find nearby samples. */
+            NeighbourhoodFunc                                        nearVerticesFunc_;
+
+            /** \brief The lower-bounding heuristic for a vertex. */
+            VertexHeuristicFunc                                      lowerBoundHeuristicVertexFunc_;
+
+            /** \brief The current heuristic for a vertex. */
+            VertexHeuristicFunc                                      currentHeuristicVertexFunc_;
+
+            /** \brief The lower-bounding heuristic for an edge. */
+            EdgeHeuristicFunc                                        lowerBoundHeuristicEdgeFunc_;
+
+            /** \brief The current heuristic for an edge. */
+            EdgeHeuristicFunc                                        currentHeuristicEdgeFunc_;
+
+            /** \brief The current heuristic to the end of an edge. */
+            EdgeHeuristicFunc                                        currentHeuristicEdgeTargetFunc_;
+
+            /** \brief Whether to use failure tracking or not */
+            bool                                                     useFailureTracking_;
+
+            /** \brief Whether to delay rewiring until an initial solution is found or not */
+            bool                                                     delayRewiring_;
+
+            /** \brief Whether to use parent lookup tables or not */
+            bool                                                     outgoingLookupTables_;
+
+            /** \brief Whether to use child lookup tables or not */
+            bool                                                     incomingLookupTables_;
+
+            /** \brief The underlying queue of vertices. Sorted by vertexQueueComparison. */
+            CostToVertexMMap                                         vertexQueue_;
+
+            /** \brief The next vertex in the expansion queue to expand*/
+            VertexQueueIter                                          vertexToExpand_;
+
+            /** \brief The underlying queue of edges. Sorted by edgeQueueComparison. */
+            CostToVertexPtrPairMMap                                  edgeQueue_;
+
+            /** \brief A lookup from vertex to iterator in the vertex queue */
+            VertexIdToVertexQueueIterUMap                            vertexIterLookup_;
+
+            /** \brief A unordered map from a vertex to all the edges in the queue emanating from the vertex: */
+            VertexIdToEdgeQueueIterListUMap                          outgoingEdges_;
+
+            /** \brief A unordered map from a vertex to all the edges in the queue leading into the vertex: */
+            VertexIdToEdgeQueueIterListUMap                          incomingEdges_;
+
+            /** \brief A list of vertices that we will need to process when resorting the queue: */
+            std::list<VertexPtr>                                     resortVertices_;
+
+            /** \brief The maximum heuristic value allowed for vertices/edges in the queue.*/
+            ompl::base::Cost                                         costThreshold_;
+
+            /** \brief Whether the problem has a solution */
+            bool                                                     hasSolution_;
             ////////////////////////////////
         }; //class: IntegratedQueue
     } //geometric

--- a/src/ompl/geometric/planners/bitstar/datastructures/Vertex.h
+++ b/src/ompl/geometric/planners/bitstar/datastructures/Vertex.h
@@ -154,6 +154,24 @@ namespace ompl
             /** \brief Mark the vertex as old. */
             void markOld();
 
+            /** \brief Returns true if the vertex has been expanded towards samples. */
+            bool hasBeenExpandedToSamples() const;
+
+            /** \brief Mark the vertex as expanded towards samples. */
+            void markExpandedToSamples();
+
+            /** \brief Mark the vertex as not expanded towards samples. */
+            void markUnexpandedToSamples();
+
+            /** \brief Returns true if the vertex has been expanded towards vertices. */
+            bool hasBeenExpandedToVertices() const;
+
+            /** \brief Mark the vertex as expanded towards vertices. */
+            void markExpandedToVertices();
+
+            /** \brief Mark the vertex as not expanded towards vertices. */
+            void markUnexpandedToVertices();
+
             /** \brief Whether the vertex has been pruned */
             bool isPruned() const;
 
@@ -174,9 +192,6 @@ namespace ompl
             void updateCostAndDepth(bool cascadeUpdates = true);
 
         private:
-            /** \brief The type of container used to store the failed children */
-            typedef boost::unordered_set<BITstar::VertexId>             FailedIdUSet;
-
             /** \brief The vertex ID */
             BITstar::VertexId                                           vId_;
 
@@ -192,8 +207,14 @@ namespace ompl
             /** \brief Whether the vertex is a root */
             bool                                                     isRoot_;
 
-            /** \brief Whether the vertex is a new. Vertices are new until marked old. */
+            /** \brief Whether the vertex is new. */
             bool                                                     isNew_;
+
+            /** \brief Whether the vertex had been expanded to samples. */
+            bool                                                     hasBeenExpandedToSamples_;
+
+            /** \brief Whether the vertex has been expanded to vertices. */
+            bool                                                     hasBeenExpandedToVertices_;
 
             /** \brief Whether the vertex is pruned. Vertices throw if any member function other than isPruned() is access after they are pruned. */
             bool                                                     isPruned_;
@@ -212,9 +233,6 @@ namespace ompl
 
             /** \brief The child states as weak pointers, such that the ownership loop is broken and a state can be deleted once it's children are.*/
             std::vector<VertexWeakPtr>                           childWPtrs_;
-
-            /** \brief The unordered set of failed child vertices*/
-            FailedIdUSet                                              failedVIds_;
 
 
             /** \brief A helper function to check that the vertex is not pruned and throw if so */

--- a/src/ompl/geometric/planners/bitstar/datastructures/src/Vertex.cpp
+++ b/src/ompl/geometric/planners/bitstar/datastructures/src/Vertex.cpp
@@ -52,13 +52,14 @@ namespace ompl
             state_( si_->allocState() ),
             isRoot_(root),
             isNew_(true),
+            hasBeenExpandedToSamples_(false),
+            hasBeenExpandedToVertices_(false),
             isPruned_(false),
             depth_(0u),
             parentSPtr_( VertexPtr() ),
             edgeCost_( opt_->infiniteCost() ),
             cost_( opt_->infiniteCost() ),
-            childWPtrs_(),
-            failedVIds_()
+            childWPtrs_()
         {
             if (this->isRoot() == true)
             {
@@ -410,6 +411,60 @@ namespace ompl
 
 
 
+        bool BITstar::Vertex::hasBeenExpandedToSamples() const
+        {
+            this->assertNotPruned();
+
+            return hasBeenExpandedToSamples_;
+        }
+
+
+
+        void BITstar::Vertex::markExpandedToSamples()
+        {
+            this->assertNotPruned();
+
+            hasBeenExpandedToSamples_ = true;
+        }
+
+
+
+        void BITstar::Vertex::markUnexpandedToSamples()
+        {
+            this->assertNotPruned();
+
+            hasBeenExpandedToSamples_ = false;
+        }
+
+
+
+        bool BITstar::Vertex::hasBeenExpandedToVertices() const
+        {
+            this->assertNotPruned();
+
+            return hasBeenExpandedToVertices_;
+        }
+
+
+
+        void BITstar::Vertex::markExpandedToVertices()
+        {
+            this->assertNotPruned();
+
+            hasBeenExpandedToVertices_ = true;
+        }
+
+
+
+        void BITstar::Vertex::markUnexpandedToVertices()
+        {
+            this->assertNotPruned();
+
+            hasBeenExpandedToVertices_ = false;
+        }
+
+
+
         bool BITstar::Vertex::isPruned() const
         {
             return isPruned_;
@@ -429,25 +484,6 @@ namespace ompl
         void BITstar::Vertex::markUnpruned()
         {
             isPruned_ = false;
-        }
-
-
-
-        void BITstar::Vertex::markAsFailedChild(const VertexConstPtr& failedChild)
-        {
-            this->assertNotPruned();
-
-            failedVIds_.insert( failedChild->getId() );
-        }
-
-
-
-        bool BITstar::Vertex::hasAlreadyFailed(const VertexConstPtr& potentialChild) const
-        {
-            this->assertNotPruned();
-
-            //Return true if there is more than 0 of this pointer.
-            return failedVIds_.count( potentialChild->getId() ) > 0u;
         }
         /////////////////////////////////////////////////////////////////////////////////////////////
 

--- a/src/ompl/geometric/planners/rrt/src/InformedRRTstar.cpp
+++ b/src/ompl/geometric/planners/rrt/src/InformedRRTstar.cpp
@@ -43,11 +43,17 @@ ompl::geometric::InformedRRTstar::InformedRRTstar(const base::SpaceInformationPt
     setName("InformedRRTstar");
 
     //Configure RRTstar to be InformedRRT*:
+    setAdmissibleCostToCome(true);
     setInformedSampling(true);
     setTreePruning(true);
     setPrunedMeasure(true);
 
+    //Disable conflicting options
+    setSampleRejection(false);
+    setNewStateRejection(false);
+
     //Remove those parameters:
+    params_.remove("use_admissible_heuristic");
     params_.remove("informed_sampling");
     params_.remove("pruned_measure");
     params_.remove("tree_pruning");


### PR DESCRIPTION
It turns out that the regression bug was a weird and subtle timing-related thing in my private experimental code. I rebased a commit to update a description in the header file though, and it won't let me reopen the previous commit.

The description was:
> The existing k-nearest version of BIT* is only an approximation. This is a version that is correct. Also cleaned up some other things while I was in there.

This is only changes to BIT* and a cosmetic change to Informed RRT*, so hopefully it'll be easy to merge?