### PR TITLE
Fixed missing const of operator() in two comparator structs, ...

### DIFF
--- a/src/ompl/datastructures/DynamicSSSP.h
+++ b/src/ompl/datastructures/DynamicSSSP.h
@@ -264,7 +264,7 @@ namespace ompl
             {
             }
 
-            bool operator()(std::size_t id1, std::size_t id2)
+            bool operator()(std::size_t id1, std::size_t id2) const
             {
                 return (cost_[id1] < cost_[id2]);
             }

--- a/src/ompl/geometric/planners/rrt/LBTRRT.h
+++ b/src/ompl/geometric/planners/rrt/LBTRRT.h
@@ -224,7 +224,7 @@ namespace ompl
                 {
                 }
 
-                bool operator() (const Motion *motionA, const Motion *motionB)
+                bool operator() (const Motion *motionA, const Motion *motionB) const
                 {
                     return motionA->costLb_ < motionB->costLb_;
                 }


### PR DESCRIPTION
… which caused errors when compiling with Visual Studio 2015.