### PR TITLE
Extended FMT: add resampling strategy if FMT is not able to find a solution.

### DIFF
--- a/src/ompl/geometric/planners/fmt/FMT.h
+++ b/src/ompl/geometric/planners/fmt/FMT.h
@@ -83,7 +83,7 @@ namespace ompl
 
            J. A. Starek, J. V. Gomez, E. Schmerling, L. Janson, L. Moreno, and M. Pavone,
            An Asymptotically-Optimal Sampling-Based Algorithm for Bi-directional Motion Planning,
-           inIEEE/RSJ International Conference on Intelligent Robots Systems, 2015.
+           in IEEE/RSJ International Conference on Intelligent Robots Systems, 2015.
            [[PDF]](http://arxiv.org/pdf/1507.07602.pdf)
         */
         /** @brief Asymptotically Optimal Fast Marching Tree algorithm developed

--- a/src/ompl/geometric/planners/fmt/FMT.h
+++ b/src/ompl/geometric/planners/fmt/FMT.h
@@ -73,10 +73,18 @@ namespace ompl
            memory requirements to O(n logn), but as samples tend to infinity this
            bound tend to O(n).
 
+           It also implements the resampling strategy (extended FMT) included in the
+           BiDirectional FMT* paper.
+
            @par External documentation
            L. Janson, E. Schmerling, A. Clark, M. Pavone. Fast marching tree: a fast marching sampling-based method for optimal motion planning in many dimensions. The International Journal of Robotics Research, 34(7):883-921, 2015.
            DOI: [10.1177/0278364915577958](http://dx.doi.org/10.1177/0278364915577958)<br>
            [[PDF]](http://arxiv.org/pdf/1306.3532.pdf)
+
+           J. A. Starek, J. V. Gomez, E. Schmerling, L. Janson, L. Moreno, and M. Pavone,
+           An Asymptotically-Optimal Sampling-Based Algorithm for Bi-directional Motion Planning,
+           inIEEE/RSJ International Conference on Intelligent Robots Systems, 2015.
+           [[PDF]](http://arxiv.org/pdf/1507.07602.pdf)
         */
         /** @brief Asymptotically Optimal Fast Marching Tree algorithm developed
             by L. Janson and M. Pavone. */
@@ -176,7 +184,7 @@ namespace ompl
             }
 
            /** \brief Activates the cost to go heuristics when ordering the heap */
-           void setHeuristics (bool h)
+           void setHeuristics(bool h)
            {
                heuristics_ = h;
            }
@@ -187,6 +195,18 @@ namespace ompl
             {
                 return heuristics_;
             }
+
+           /** \brief Activates the extended FMT*: adding new samples if planner does not finish successfully. */
+           void setExtendedFMT(bool e)
+           {
+               extendedFMT_ = e;
+           }
+
+           /** \brief Returns true if the extended FMT* is activated. */
+           bool getExtendedFMT() const
+           {
+               return extendedFMT_;
+           }
 
         protected:
             /** \brief Representation of a motion
@@ -294,6 +314,12 @@ namespace ompl
                         return hcost_;
                     }
 
+                    /** \brief Get the children of the motion */
+                    std::vector<Motion*>& getChildren()
+                    {
+                        return children_;
+                    }
+
                 protected:
 
                     /** \brief The state contained by the motion */
@@ -313,6 +339,9 @@ namespace ompl
 
                     /** \brief Contains the connections attempted FROM this node */
                     std::set<Motion*> collChecksDone_;
+
+                    /** \brief The set of motions descending from the current motion */
+                    std::vector<Motion*> children_;
             };
 
             /** \brief Comparator used to order motions in a binary heap */
@@ -376,8 +405,7 @@ namespace ompl
             void saveNeighborhood(Motion *m);
 
             /** \brief Trace the path from a goal state back to the start state
-                and save the result as a solution in the Problem Definiton.
-             */
+                and save the result as a solution in the Problem Definiton. */
             void traceSolutionPathThroughTree(Motion *goalMotion);
 
             /** \brief Complete one iteration of the main loop of the FMT* algorithm:
@@ -387,6 +415,14 @@ namespace ompl
                 them into Open. Remove motion z from Open, and update z to be the
                 current lowest cost-to-come node in Open */
             bool expandTreeFromNode(Motion **z);
+
+            /** \brief For a motion m, updates the stored neighborhoods of all its neighbors by
+                by inserting m (maintaining the cost-based sorting). Computes the nearest neighbors
+                if there is no stored neighborhood. */
+            void updateNeighborhood(Motion *m, const std::vector<Motion *> nbh);
+
+            /** \brief Returns the best parent and the connection cost in the neighborhood of a motion m. */
+            Motion* getBestParent(Motion *m, std::vector<Motion*> &neighbors, base::Cost &cMin);
 
             /** \brief A binary heap for storing explored motions in
                 cost-to-come sorted order */
@@ -451,6 +487,25 @@ namespace ompl
 
             /** \brief Goal state caching to accelerate cost to go heuristic computation */
             base::State* goalState_;
+
+            /** \brief Add new samples if the tree was not able to find a solution. */
+            bool extendedFMT_;
+
+            // For sorting a list of costs and getting only their sorted indices
+            struct CostIndexCompare
+            {
+                CostIndexCompare(const std::vector<base::Cost>& costs,
+                                 const base::OptimizationObjective &opt) :
+                    costs_(costs), opt_(opt)
+                {}
+                bool operator()(unsigned i, unsigned j)
+                {
+                    return opt_.isCostBetterThan(costs_[i],costs_[j]);
+                }
+                const std::vector<base::Cost>& costs_;
+                const base::OptimizationObjective &opt_;
+            };
+
         };
     }
 }

--- a/src/ompl/geometric/planners/fmt/src/FMT.cpp
+++ b/src/ompl/geometric/planners/fmt/src/FMT.cpp
@@ -586,8 +586,8 @@ bool ompl::geometric::FMT::expandTreeFromNode(Motion **z)
 
                 // Add x to Open
                 Open_new.push_back(x);
-                // Remove x from Unvisited and add to Open
-                x->setSetType(Motion::SET_OPEN);
+                // Remove x from Unvisited
+                x->setSetType(Motion::SET_CLOSED);
             }
         } // An optimal connection from Open to x was found
     } // For each node near z and in set Unvisited, try to connect it to set Open

--- a/src/ompl/geometric/planners/fmt/src/FMT.cpp
+++ b/src/ompl/geometric/planners/fmt/src/FMT.cpp
@@ -532,6 +532,7 @@ bool ompl::geometric::FMT::expandTreeFromNode(Motion **z)
 
     // For each node near z and in set Unvisited, attempt to connect it to set Open
     std::vector<Motion*> yNear;
+    std::vector<Motion*> Open_new;
     const unsigned int xNearSize = xNear.size();
     for (unsigned int i = 0 ; i < xNearSize; ++i)
     {
@@ -584,7 +585,7 @@ bool ompl::geometric::FMT::expandTreeFromNode(Motion **z)
                 yMin->getChildren().push_back(x);
 
                 // Add x to Open
-                Open_.insert(x);
+                Open_new.push_back(x);
                 // Remove x from Unvisited and add to Open
                 x->setSetType(Motion::SET_OPEN);
             }
@@ -594,6 +595,15 @@ bool ompl::geometric::FMT::expandTreeFromNode(Motion **z)
     // Update Open
     Open_.pop();
     (*z)->setSetType(Motion::SET_CLOSED);
+
+    // Add the nodes in Open_new to Open
+    unsigned int openNewSize = Open_new.size();
+    for (unsigned int i = 0; i < openNewSize; ++i)
+    {
+        Open_.insert(Open_new[i]);
+        Open_new[i]->setSetType(Motion::SET_OPEN);
+    }
+    Open_new.clear();
 
     if (Open_.empty())
     {

--- a/src/ompl/geometric/planners/fmt/src/FMT.cpp
+++ b/src/ompl/geometric/planners/fmt/src/FMT.cpp
@@ -59,6 +59,7 @@ ompl::geometric::FMT::FMT(const base::SpaceInformationPtr &si)
     , cacheCC_(true)
     , heuristics_(false)
     , radiusMultiplier_(1.1)
+    , extendedFMT_(true)
 {
     // An upper bound on the free space volume is the total space volume; the free fraction is estimated in sampleFree
     freeSpaceVolume_ = si_->getStateSpace()->getMeasure();
@@ -70,7 +71,9 @@ ompl::geometric::FMT::FMT(const base::SpaceInformationPtr &si)
     ompl::base::Planner::declareParam<unsigned int>("num_samples", this, &FMT::setNumSamples, &FMT::getNumSamples, "10:10:1000000");
     ompl::base::Planner::declareParam<double>("radius_multiplier", this, &FMT::setRadiusMultiplier, &FMT::getRadiusMultiplier, "0.1:0.05:50.");
     ompl::base::Planner::declareParam<bool>("nearest_k", this, &FMT::setNearestK, &FMT::getNearestK, "0,1");
+    ompl::base::Planner::declareParam<bool>("cache_cc", this, &FMT::setCacheCC, &FMT::getCacheCC, "0,1");
     ompl::base::Planner::declareParam<bool>("heuristics", this, &FMT::setHeuristics, &FMT::getHeuristics, "0,1");
+    ompl::base::Planner::declareParam<bool>("extended_fmt", this, &FMT::setExtendedFMT, &FMT::getExtendedFMT, "0,1");
 }
 
 ompl::geometric::FMT::~FMT()
@@ -91,6 +94,8 @@ void ompl::geometric::FMT::setup()
         {
             OMPL_INFORM("%s: No optimization objective specified. Defaulting to optimizing path length.", getName().c_str());
             opt_.reset(new base::PathLengthOptimizationObjective(si_));
+            // Store the new objective in the problem def'n
+            pdef_->setOptimizationObjective(opt_);
         }
         Open_.getComparisonOperator().opt_ = opt_.get();
         Open_.getComparisonOperator().heuristics_ = heuristics_;
@@ -337,11 +342,123 @@ ompl::base::PlannerStatus ompl::geometric::FMT::solve(const base::PlannerTermina
     Motion *z = initMotion; // z <-- xinit
     saveNeighborhood(z);
 
-    while (!ptc && !(plannerSuccess = goal->isSatisfied(z->getState())))
+    while (!ptc)
     {
+        if ((plannerSuccess = goal->isSatisfied(z->getState())))
+            break;
+
         successfulExpansion = expandTreeFromNode(&z);
-        if (!successfulExpansion)
-            return base::PlannerStatus(false, false);
+
+        if (!extendedFMT_ && !successfulExpansion)
+            break;
+        else if (extendedFMT_ && !successfulExpansion)
+        {
+            //Apply RRT*-like connections: sample and connect samples to tree
+            std::vector<Motion*>       nbh;
+            std::vector<base::Cost>    costs;
+            std::vector<base::Cost>    incCosts;
+            std::vector<std::size_t>   sortedCostIndices;
+
+            // our functor for sorting nearest neighbors
+            CostIndexCompare compareFn(costs, *opt_);
+
+            Motion *m = new Motion(si_);
+            while (!ptc && Open_.empty())
+            {
+                sampler_->sampleUniform(m->getState());
+
+                if (!si_->isValid(m->getState()))
+                    continue;
+
+                if (nearestK_)
+                    nn_->nearestK(m, NNk_, nbh);
+                else
+                    nn_->nearestR(m, NNr_, nbh);
+
+                // Get neighbours in the tree.
+                std::vector<Motion*> yNear;
+                yNear.reserve(nbh.size());
+                for (std::size_t j = 0; j < nbh.size(); ++j)
+                {
+                    if (nbh[j]->getSetType() == Motion::SET_CLOSED)
+                    {
+                        if (nearestK_)
+                        {
+                            // Only include neighbors that are mutually k-nearest
+                            // Relies on NN datastructure returning k-nearest in sorted order
+                            const base::Cost connCost = opt_->motionCost(nbh[j]->getState(), m->getState());
+                            const base::Cost worstCost = opt_->motionCost(neighborhoods_[nbh[j]].back()->getState(), nbh[j]->getState());
+
+                            if (opt_->isCostBetterThan(worstCost, connCost))
+                                continue;
+                            else
+                                yNear.push_back(nbh[j]);
+                        }
+                        else
+                            yNear.push_back(nbh[j]);
+                    }
+                }
+
+                // Sample again if the new sample does not connect to the tree.
+                if (yNear.empty())
+                    continue;
+
+                // cache for distance computations
+                //
+                // Our cost caches only increase in size, so they're only
+                // resized if they can't fit the current neighborhood
+                if (costs.size() < yNear.size())
+                {
+                    costs.resize(yNear.size());
+                    incCosts.resize(yNear.size());
+                    sortedCostIndices.resize(yNear.size());
+                }
+
+                // Finding the nearest neighbor to connect to
+                // By default, neighborhood states are sorted by cost, and collision checking
+                // is performed in increasing order of cost
+                //
+                // calculate all costs and distances
+                for (std::size_t i = 0 ; i < yNear.size(); ++i)
+                {
+                    incCosts[i] = opt_->motionCost(yNear[i]->getState(), m->getState());
+                    costs[i] = opt_->combineCosts(yNear[i]->getCost(), incCosts[i]);
+                }
+
+                // sort the nodes
+                //
+                // we're using index-value pairs so that we can get at
+                // original, unsorted indices
+                for (std::size_t i = 0; i < yNear.size(); ++i)
+                    sortedCostIndices[i] = i;
+                std::sort(sortedCostIndices.begin(), sortedCostIndices.begin() + yNear.size(),
+                          compareFn);
+
+               // collision check until a valid motion is found
+               for (std::vector<std::size_t>::const_iterator i = sortedCostIndices.begin();
+                    i != sortedCostIndices.begin() + yNear.size();
+                    ++i)
+               {
+                   if (si_->checkMotion(yNear[*i]->getState(), m->getState()))
+                   {
+                       m->setParent(yNear[*i]);
+                       yNear[*i]->getChildren().push_back(m);
+                       const base::Cost incCost = opt_->motionCost(yNear[*i]->getState(), m->getState());
+                       m->setCost(opt_->combineCosts(yNear[*i]->getCost(), incCost));
+                       m->setHeuristicCost(opt_->motionCostHeuristic(m->getState(), goalState_));
+                       m->setSetType(Motion::SET_OPEN);
+
+                       nn_->add(m);
+                       saveNeighborhood(m);
+                       updateNeighborhood(m,nbh);
+
+                       Open_.insert(m);
+                       z = m;
+                       break;
+                   }
+               }
+            } // while (!ptc && Open_.empty())
+        } // else if (extendedFMT_ && !successfulExpansion)
     } // While not at goal
 
     if (plannerSuccess)
@@ -406,7 +523,7 @@ bool ompl::geometric::FMT::expandTreeFromNode(Motion **z)
                 if (opt_->isCostBetterThan(worstCost, connCost))
                     continue;
                 else
-                    xNear.push_back(zNeighborhood[i]);
+                    xNear.push_back(x);
             }
             else
                 xNear.push_back(x);
@@ -415,7 +532,6 @@ bool ompl::geometric::FMT::expandTreeFromNode(Motion **z)
 
     // For each node near z and in set Unvisited, attempt to connect it to set Open
     std::vector<Motion*> yNear;
-    std::vector<Motion*> Open_new;
     const unsigned int xNearSize = xNear.size();
     for (unsigned int i = 0 ; i < xNearSize; ++i)
     {
@@ -433,21 +549,8 @@ bool ompl::geometric::FMT::expandTreeFromNode(Motion **z)
         }
 
         // Find the lowest cost-to-come connection from Open to x
-        Motion *yMin = nullptr;
         base::Cost cMin(std::numeric_limits<double>::infinity());
-        const unsigned int yNearSize = yNear.size();
-        for (unsigned int j = 0; j < yNearSize; ++j)
-        {
-            const base::State *yState = yNear[j]->getState();
-            const base::Cost dist = opt_->motionCost(yState, x->getState());
-            const base::Cost cNew = opt_->combineCosts(yNear[j]->getCost(), dist);
-
-            if (opt_->isCostBetterThan(cNew, cMin))
-            {
-                yMin = yNear[j];
-                cMin = cNew;
-            }
-        }
+        Motion *yMin = getBestParent(x, yNear, cMin);
         yNear.clear();
 
         // If an optimal connection from Open to x was found
@@ -478,10 +581,12 @@ bool ompl::geometric::FMT::expandTreeFromNode(Motion **z)
                 x->setParent(yMin);
                 x->setCost(cMin);
                 x->setHeuristicCost(opt_->motionCostHeuristic(x->getState(), goalState_));
+                yMin->getChildren().push_back(x);
+
                 // Add x to Open
-                Open_new.push_back(x);
-                // Remove x from Unvisited
-                x->setSetType(Motion::SET_CLOSED);
+                Open_.insert(x);
+                // Remove x from Unvisited and add to Open
+                x->setSetType(Motion::SET_OPEN);
             }
         } // An optimal connection from Open to x was found
     } // For each node near z and in set Unvisited, try to connect it to set Open
@@ -490,18 +595,10 @@ bool ompl::geometric::FMT::expandTreeFromNode(Motion **z)
     Open_.pop();
     (*z)->setSetType(Motion::SET_CLOSED);
 
-    // Add the nodes in H_new to H
-    unsigned int openNewSize = Open_new.size();
-    for (unsigned int i = 0; i < openNewSize; i++)
-    {
-        Open_.insert(Open_new[i]);
-        Open_new[i]->setSetType(Motion::SET_OPEN);
-    }
-    Open_new.clear();
-
     if (Open_.empty())
     {
-        OMPL_INFORM("Open is empty before path was found --> no feasible path exists");
+        if(!extendedFMT_)
+            OMPL_INFORM("Open is empty before path was found --> no feasible path exists");
         return false;
     }
 
@@ -509,4 +606,75 @@ bool ompl::geometric::FMT::expandTreeFromNode(Motion **z)
     *z = Open_.top()->data;
 
     return true;
+}
+
+ompl::geometric::FMT::Motion* ompl::geometric::FMT::getBestParent(Motion *m, std::vector<Motion*> &neighbors, base::Cost &cMin)
+{
+    Motion *min = nullptr;
+    const unsigned int neighborsSize = neighbors.size();
+    for (unsigned int j = 0; j < neighborsSize; ++j)
+    {
+        const base::State *s = neighbors[j]->getState();
+        const base::Cost dist = opt_->motionCost(s, m->getState());
+        const base::Cost cNew = opt_->combineCosts(neighbors[j]->getCost(), dist);
+
+        if (opt_->isCostBetterThan(cNew, cMin))
+        {
+            min = neighbors[j];
+            cMin = cNew;
+        }
+    }
+    return min;
+}
+
+void ompl::geometric::FMT::updateNeighborhood(Motion *m, const std::vector<Motion*> nbh)
+{
+    for (std::size_t i = 0; i < nbh.size(); ++i)
+    {
+        // If CLOSED, the neighborhood already exists. If neighborhood already exists, we have
+        // to insert the node in the corresponding place of the neighborhood of the neighbor of m.
+        if (nbh[i]->getSetType() == Motion::SET_CLOSED || neighborhoods_.find(nbh[i]) != neighborhoods_.end())
+        {
+            const base::Cost connCost = opt_->motionCost(nbh[i]->getState(), m->getState());
+            const base::Cost worstCost = opt_->motionCost(neighborhoods_[nbh[i]].back()->getState(), nbh[i]->getState());
+
+            if (opt_->isCostBetterThan(worstCost, connCost))
+                continue;
+            else
+            {
+                // Insert the neighbor in the vector in the correct order
+                std::vector<Motion*> &nbhToUpdate = neighborhoods_[nbh[i]];
+                for (std::size_t j = 0; j < nbhToUpdate.size(); ++j)
+                {
+                    // If connection to the new state is better than the current neighbor tested, insert.
+                    const base::Cost cost = opt_->motionCost(nbh[i]->getState(), nbhToUpdate[j]->getState());
+                    if (opt_->isCostBetterThan(connCost, cost))
+                    {
+                        nbhToUpdate.insert(nbhToUpdate.begin()+j, m);
+                        break;
+                    }
+                }
+            }
+        }
+        else
+        {
+            std::vector<Motion*> nbh2;
+            if (nearestK_)
+                nn_->nearestK(m, NNk_, nbh2);
+            else
+                nn_->nearestR(m, NNr_, nbh2);
+
+            if (!nbh2.empty())
+            {
+                // Save the neighborhood but skip the first element, since it will be motion m
+                neighborhoods_[nbh[i]] = std::vector<Motion*>(nbh2.size() - 1, 0);
+                std::copy(nbh2.begin() + 1, nbh2.end(), neighborhoods_[nbh[i]].begin());
+            }
+            else
+            {
+                // Save an empty neighborhood
+                neighborhoods_[nbh[i]] = std::vector<Motion*>(0);
+            }
+        }
+    }
 }


### PR DESCRIPTION
Resampling strategy for FMT.  Work included in the paper of the [Bidirectional FMT paper](http://arxiv.org/pdf/1507.07602.pdf(http://arxiv.org/pdf/1507.07602.pdf) (that planner will be included in another PR). This enormously increases the success rate of the planner with very little impact in the computation time.

Other minor modifications (simplifications) have been included.

