### PR TITLE
New valid state sampler w/min obstacle clearance threshold

### DIFF
--- a/src/ompl/base/samplers/MinimumClearanceValidStateSampler.h
+++ b/src/ompl/base/samplers/MinimumClearanceValidStateSampler.h
@@ -1,0 +1,94 @@
+/*********************************************************************
+ * Software License Agreement (BSD License)
+ *
+ *  Copyright (c) 2016, University of Colorado, Boulder
+ *  All rights reserved.
+ *
+ *  Redistribution and use in source and binary forms, with or without
+ *  modification, are permitted provided that the following conditions
+ *  are met:
+ *
+ *   * Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *   * Redistributions in binary form must reproduce the above
+ *     copyright notice, this list of conditions and the following
+ *     disclaimer in the documentation and/or other materials provided
+ *     with the distribution.
+ *   * Neither the name of the Univ of CO, Boulder nor the names of its
+ *     contributors may be used to endorse or promote products derived
+ *     from this software without specific prior written permission.
+ *
+ *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ *  "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ *  LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ *  FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ *  COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ *  INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ *  BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ *  LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ *  CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ *  LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ *  ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ *  POSSIBILITY OF SUCH DAMAGE.
+ *********************************************************************/
+
+/* Author: Dave Coleman <dave@dav.ee>
+   Desc:   Find a valid sample with a minimum distance to nearby obstacles
+           (clearance threshold)
+*/
+
+#ifndef OMPL_BASE_SAMPLERS_MINIMUM_CLEARANCE_VALID_STATE_SAMPLER_
+#define OMPL_BASE_SAMPLERS_MINIMUM_CLEARANCE_VALID_STATE_SAMPLER_
+
+#include "ompl/base/ValidStateSampler.h"
+#include "ompl/base/StateSampler.h"
+
+namespace ompl
+{
+    namespace base
+    {
+
+        /// @cond IGNORE
+        OMPL_CLASS_FORWARD(MinimumClearanceValidStateSampler);
+        /// @endcond
+
+        /** \brief Generate valid samples randomly with extra requirement of min for clearance to nearest obstacle */
+        class MinimumClearanceValidStateSampler : public ValidStateSampler
+        {
+        public:
+
+            /** \brief Constructor */
+            MinimumClearanceValidStateSampler(const SpaceInformation *si);
+
+            virtual ~MinimumClearanceValidStateSampler() {};
+
+            virtual bool sample(State *state);
+
+            virtual bool sampleNear(State *state, const State *near, const double distance);
+
+            /** \brief Set the minimum required distance of sample from nearest obstacle to be considered valid */
+            void setMinimumObstacleClearance(double clearance)
+            {
+                clearance_ = clearance;
+            }
+
+            /** \brief Get the minimum required distance of sample from nearest obstacle to be considered valid */
+            unsigned int getMinimumObstacleClearance() const
+            {
+                return clearance_;
+            }
+
+        protected:
+
+            /** \brief The sampler to build upon */
+            StateSamplerPtr sampler_;
+
+            /** \brief Minimum required distance of sample from nearest obstacle to be considered valid */
+            double          clearance_;
+        };
+
+    }
+}
+
+
+#endif

--- a/src/ompl/base/samplers/src/MinimumClearanceValidStateSampler.cpp
+++ b/src/ompl/base/samplers/src/MinimumClearanceValidStateSampler.cpp
@@ -1,0 +1,94 @@
+/*********************************************************************
+ * Software License Agreement (BSD License)
+ *
+ *  Copyright (c) 2016, University of Colorado, Boulder
+ *  All rights reserved.
+ *
+ *  Redistribution and use in source and binary forms, with or without
+ *  modification, are permitted provided that the following conditions
+ *  are met:
+ *
+ *   * Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *   * Redistributions in binary form must reproduce the above
+ *     copyright notice, this list of conditions and the following
+ *     disclaimer in the documentation and/or other materials provided
+ *     with the distribution.
+ *   * Neither the name of the Univ of CO, Boulder nor the names of its
+ *     contributors may be used to endorse or promote products derived
+ *     from this software without specific prior written permission.
+ *
+ *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ *  "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ *  LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ *  FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ *  COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ *  INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ *  BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ *  LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ *  CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ *  LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ *  ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ *  POSSIBILITY OF SUCH DAMAGE.
+ *********************************************************************/
+
+/* Author: Dave Coleman <dave@dav.ee>
+   Desc:   Find a valid sample with a minimum distance to nearby obstacles
+           (clearance threshold)
+*/
+
+#include "ompl/base/samplers/MinimumClearanceValidStateSampler.h"
+#include "ompl/base/SpaceInformation.h"
+
+ompl::base::MinimumClearanceValidStateSampler::MinimumClearanceValidStateSampler(const SpaceInformation *si) :
+    ValidStateSampler(si), sampler_(si->allocStateSampler()), clearance_(1)
+{
+    name_ = "min_clearance";
+    params_.declareParam<unsigned int>("min_obstacle_clearance",
+                                       std::bind(&MinimumClearanceValidStateSampler::setMinimumObstacleClearance, this, std::placeholders::_1),
+                                       std::bind(&MinimumClearanceValidStateSampler::getMinimumObstacleClearance, this));
+}
+
+bool ompl::base::MinimumClearanceValidStateSampler::sample(State *state)
+{
+    unsigned int attempts = 0;
+    bool valid = false;
+    double dist = 0.0;
+    do
+    {
+        sampler_->sampleUniform(state);
+        valid = si_->getStateValidityChecker()->isValid(state, dist);
+
+        // Also check for distance to nearest obstacle and invalidate if too close
+        if (dist < clearance_)
+        {
+            valid = false;
+        }
+
+        ++attempts;
+    } while (!valid && attempts < attempts_);
+
+    return valid;
+}
+
+bool ompl::base::MinimumClearanceValidStateSampler::sampleNear(State *state, const State *near, const double distance)
+{
+    unsigned int attempts = 0;
+    bool valid = false;
+    double dist = 0.0;
+    do
+    {
+        sampler_->sampleUniformNear(state, near, distance);
+        valid = si_->getStateValidityChecker()->isValid(state, dist);
+
+        // Also check for distance to nearest obstacle and invalidate if too close
+        if (dist < clearance_)
+        {
+            valid = false;
+        }
+
+        ++attempts;
+    } while (!valid && attempts < attempts_);
+
+    return valid;
+}


### PR DESCRIPTION
Implements a sampler as described in [Sparse roadmap spanners for asymptotically near-optimal motion planning](http://ijr.sagepub.com/content/33/1/18.full.pdf) by Andrew Dobson and Kostas E. Bekris. This sampler only accepts states "for some clearance cl > 0". This is a missing component in the current SPARS and SPARS2 implementation in OMPL, but I am using it in my current work.

This PR also includes an optional settings for state validity checkers that would allow iterative or APPROXIMATE checkers that do an iterative search in increasing distances from the sampled state to have get/set that search distance. This search distance could/should correspond to the above sampler's minimum clearance threshold. The sampler I'm using this setting for is a 2D grid based on PPM image files, but I do not believe its generic enough to go inside OMPL itself.