### PR TITLE
Remove compatibility wrapper struct for incompatibility with prev Boost and GCC

### DIFF
--- a/src/ompl/geometric/planners/prm/SPARS.h
+++ b/src/ompl/geometric/planners/prm/SPARS.h
@@ -120,16 +120,6 @@ namespace ompl
             /** \brief Internal representation of a dense path */
             typedef std::deque<base::State*> DensePath;
 
-            // The InterfaceHash structure is wrapped inside of this struct due to a compilation error on
-            // GCC 4.6 with Boost 1.48.  An implicit assignment operator overload does not compile with these
-            // components, so an explicit overload is given here.
-            // Remove this struct when the minimum Boost requirement is > v1.48.
-            struct InterfaceHashStruct
-            {
-                InterfaceHashStruct& operator=(const InterfaceHashStruct &rhs) { interfaceHash = rhs.interfaceHash; return *this; }
-                InterfaceHash interfaceHash;
-            };
-
             /**
              @brief The constructed roadmap spanner.
 
@@ -149,7 +139,7 @@ namespace ompl
                 boost::property < boost::vertex_rank_t, VertexIndexType,
                 boost::property < vertex_color_t, GuardType,
                 boost::property < vertex_list_t, std::set<VertexIndexType>,
-                boost::property < vertex_interface_list_t, InterfaceHashStruct > > > > > >,
+                boost::property < vertex_interface_list_t, InterfaceHash > > > > > >,
                 boost::property < boost::edge_weight_t, base::Cost >
             > SpannerGraph;
 

--- a/src/ompl/geometric/planners/prm/SPARStwo.h
+++ b/src/ompl/geometric/planners/prm/SPARStwo.h
@@ -182,16 +182,6 @@ namespace ompl
             /** \brief the hash which maps pairs of neighbor points to pairs of states */
             typedef std::unordered_map<VertexPair, InterfaceData> InterfaceHash;
 
-            // The InterfaceHash structure is wrapped inside of this struct due to a compilation error on
-            // GCC 4.6 with Boost 1.48.  An implicit assignment operator overload does not compile with these
-            // components, so an explicit overload is given here.
-            // Remove this struct when the minimum Boost requirement is > v1.48.
-            struct InterfaceHashStruct
-            {
-                InterfaceHashStruct& operator=(const InterfaceHashStruct &rhs) { interfaceHash = rhs.interfaceHash; return *this; }
-                InterfaceHash interfaceHash;
-            };
-
             struct vertex_state_t {
                 typedef boost::vertex_property_tag kind;
             };
@@ -225,7 +215,7 @@ namespace ompl
                 boost::property < boost::vertex_predecessor_t, VertexIndexType,
                 boost::property < boost::vertex_rank_t, VertexIndexType,
                 boost::property < vertex_color_t, GuardType,
-                boost::property < vertex_interface_data_t, InterfaceHashStruct > > > > >,
+                boost::property < vertex_interface_data_t, InterfaceHash > > > > >,
                 boost::property < boost::edge_weight_t, base::Cost >
             > Graph;
 

--- a/src/ompl/geometric/planners/prm/src/SPARS.cpp
+++ b/src/ompl/geometric/planners/prm/src/SPARS.cpp
@@ -649,7 +649,7 @@ bool ompl::geometric::SPARS::checkAddPath(DenseVertex q, const std::vector<Dense
             {
                 SparseVertex vpp = VPPs[j];
                 //For each q", which are stored interface nodes on v for i(vpp,v)
-                foreach( DenseVertex qpp, interfaceListsProperty_[v].interfaceHash[vpp] )
+                foreach( DenseVertex qpp, interfaceListsProperty_[v][vpp] )
                 {
                     // check that representatives are consistent
                     assert(representativesProperty_[qpp] == v);
@@ -877,7 +877,7 @@ void ompl::geometric::SPARS::addToRepresentatives(DenseVertex q, SparseVertex re
         foreach( SparseVertex v, oreps )
         {
             assert(rep == representativesProperty_[q]);
-            bool new_insert = interfaceListsProperty_[rep].interfaceHash[v].insert(q).second;
+            bool new_insert = interfaceListsProperty_[rep][v].insert(q).second;
             if (!new_insert)
                 assert(false);
         }
@@ -890,10 +890,10 @@ void ompl::geometric::SPARS::removeFromRepresentatives(DenseVertex q, SparseVert
     nonInterfaceListsProperty_[rep].erase(q);
 
     // From each of the interfaces
-    foreach (SparseVertex vpp, interfaceListsProperty_[rep].interfaceHash | boost::adaptors::map_keys)
+    foreach (SparseVertex vpp, interfaceListsProperty_[rep] | boost::adaptors::map_keys)
     {
         // Remove this node from that list
-        interfaceListsProperty_[rep].interfaceHash[vpp].erase( q );
+        interfaceListsProperty_[rep][vpp].erase( q );
     }
 }
 
@@ -910,7 +910,7 @@ void ompl::geometric::SPARS::computeX(SparseVertex v, SparseVertex vp, SparseVer
     Xs.clear();
     foreach( SparseVertex cx, boost::adjacent_vertices( vpp, s_ ) )
         if( boost::edge( cx, v, s_ ).second && !boost::edge( cx, vp, s_ ).second )
-            if (interfaceListsProperty_[vpp].interfaceHash[cx].size() > 0)
+            if (interfaceListsProperty_[vpp][cx].size() > 0)
                 Xs.push_back( cx );
     Xs.push_back( vpp );
 }

--- a/src/ompl/geometric/planners/prm/src/SPARStwo.cpp
+++ b/src/ompl/geometric/planners/prm/src/SPARStwo.cpp
@@ -159,7 +159,7 @@ void ompl::geometric::SPARStwo::freeMemory()
 
     foreach (Vertex v, boost::vertices(g_))
     {
-        foreach (InterfaceData &d, interfaceDataProperty_[v].interfaceHash | boost::adaptors::map_values)
+        foreach (InterfaceData &d, interfaceDataProperty_[v] | boost::adaptors::map_values)
             d.clear(si_);
         if( stateProperty_[v] != nullptr )
             si_->freeState(stateProperty_[v]);
@@ -696,7 +696,7 @@ ompl::geometric::SPARStwo::VertexPair ompl::geometric::SPARStwo::index( Vertex v
 
 ompl::geometric::SPARStwo::InterfaceData& ompl::geometric::SPARStwo::getData( Vertex v, Vertex vp, Vertex vpp )
 {
-    return interfaceDataProperty_[v].interfaceHash[index( vp, vpp )];
+    return interfaceDataProperty_[v][index( vp, vpp )];
 }
 
 void ompl::geometric::SPARStwo::distanceCheck(Vertex rep, const base::State *q, Vertex r, const base::State *s, Vertex rp)
@@ -741,7 +741,7 @@ void ompl::geometric::SPARStwo::distanceCheck(Vertex rep, const base::State *q, 
     }
 
     // Lastly, save what we have discovered
-    interfaceDataProperty_[rep].interfaceHash[index(r, rp)] = d;
+    interfaceDataProperty_[rep][index(r, rp)] = d;
 }
 
 void ompl::geometric::SPARStwo::abandonLists(base::State *st)
@@ -756,8 +756,8 @@ void ompl::geometric::SPARStwo::abandonLists(base::State *st)
     //For each of the vertices
     foreach (Vertex v, hold)
     {
-        foreach (VertexPair r, interfaceDataProperty_[v].interfaceHash | boost::adaptors::map_keys)
-            interfaceDataProperty_[v].interfaceHash[r].clear(si_);
+        foreach (VertexPair r, interfaceDataProperty_[v] | boost::adaptors::map_keys)
+            interfaceDataProperty_[v][r].clear(si_);
     }
 }
 
@@ -882,4 +882,3 @@ ompl::base::Cost ompl::geometric::SPARStwo::costHeuristic(Vertex u, Vertex v) co
 {
     return opt_->motionCostHeuristic(stateProperty_[u], stateProperty_[v]);
 }
-


### PR DESCRIPTION
Since the minimum required boost is now greater than 1.48, we can remove this hack:

> The InterfaceHash structure is wrapped inside of this struct due to a compilation error on
> GCC 4.6 with Boost 1.48.  An implicit assignment operator overload does not compile with these
> components, so an explicit overload is given here.
> Remove this struct when the minimum Boost requirement is > v1.48.

I've been running this fix on my fork of SPARS for some time now with no problems
