### PR TITLE
Renaming RRTX to RRTXstatic + Disclaimer

### DIFF
--- a/demos/Diagonal.cpp
+++ b/demos/Diagonal.cpp
@@ -36,7 +36,7 @@
 
 #include <ompl/base/spaces/RealVectorStateSpace.h>
 #include <ompl/geometric/planners/rrt/RRTstar.h>
-#include <ompl/geometric/planners/rrt/RRTX.h>
+#include <ompl/geometric/planners/rrt/RRTXstatic.h>
 #include <ompl/geometric/planners/rrt/RRTsharp.h>
 #include <ompl/tools/benchmark/Benchmark.h>
 #include <ompl/base/objectives/PathLengthOptimizationObjective.h>
@@ -128,27 +128,27 @@ int main(int argc, char **argv)
     rrtsh2->as<ompl::geometric::RRTsharp>()->setKNearest(knn);
     rrtsh2->as<ompl::geometric::RRTsharp>()->setVariant(2);
     b.addPlanner(rrtsh2);*/
-    ompl::base::PlannerPtr rrtX1(new ompl::geometric::RRTX(ss.getSpaceInformation()));
-    rrtX1->as<ompl::geometric::RRTX>()->setName("RRTX0.1");
-    rrtX1->as<ompl::geometric::RRTX>()->setEpsilon(0.1);
-    rrtX1->as<ompl::geometric::RRTX>()->setRange(range);
-    //rrtX1->as<ompl::geometric::RRTX>()->setVariant(3);
-    rrtX1->as<ompl::geometric::RRTX>()->setKNearest(knn);
-    b.addPlanner(rrtX1);
-    ompl::base::PlannerPtr rrtX2(new ompl::geometric::RRTX(ss.getSpaceInformation()));
-    rrtX2->as<ompl::geometric::RRTX>()->setName("RRTX0.01");
-    rrtX2->as<ompl::geometric::RRTX>()->setEpsilon(0.01);
-    rrtX2->as<ompl::geometric::RRTX>()->setRange(range);
-    //rrtX2->as<ompl::geometric::RRTX>()->setVariant(3);
-    rrtX2->as<ompl::geometric::RRTX>()->setKNearest(knn);
-    b.addPlanner(rrtX2);
-    ompl::base::PlannerPtr rrtX3(new ompl::geometric::RRTX(ss.getSpaceInformation()));
-    rrtX3->as<ompl::geometric::RRTX>()->setName("RRTX0.001");
-    rrtX3->as<ompl::geometric::RRTX>()->setEpsilon(0.001);
-    rrtX3->as<ompl::geometric::RRTX>()->setRange(range);
-    //rrtX3->as<ompl::geometric::RRTX>()->setVariant(3);
-    rrtX3->as<ompl::geometric::RRTX>()->setKNearest(knn);
-    b.addPlanner(rrtX3);
+    ompl::base::PlannerPtr RRTXstatic1(new ompl::geometric::RRTXstatic(ss.getSpaceInformation()));
+    RRTXstatic1->as<ompl::geometric::RRTXstatic>()->setName("RRTXstatic0.1");
+    RRTXstatic1->as<ompl::geometric::RRTXstatic>()->setEpsilon(0.1);
+    RRTXstatic1->as<ompl::geometric::RRTXstatic>()->setRange(range);
+    //RRTXstatic1->as<ompl::geometric::RRTXstatic>()->setVariant(3);
+    RRTXstatic1->as<ompl::geometric::RRTXstatic>()->setKNearest(knn);
+    b.addPlanner(RRTXstatic1);
+    ompl::base::PlannerPtr RRTXstatic2(new ompl::geometric::RRTXstatic(ss.getSpaceInformation()));
+    RRTXstatic2->as<ompl::geometric::RRTXstatic>()->setName("RRTXstatic0.01");
+    RRTXstatic2->as<ompl::geometric::RRTXstatic>()->setEpsilon(0.01);
+    RRTXstatic2->as<ompl::geometric::RRTXstatic>()->setRange(range);
+    //RRTXstatic2->as<ompl::geometric::RRTXstatic>()->setVariant(3);
+    RRTXstatic2->as<ompl::geometric::RRTXstatic>()->setKNearest(knn);
+    b.addPlanner(RRTXstatic2);
+    ompl::base::PlannerPtr RRTXstatic3(new ompl::geometric::RRTXstatic(ss.getSpaceInformation()));
+    RRTXstatic3->as<ompl::geometric::RRTXstatic>()->setName("RRTXstatic0.001");
+    RRTXstatic3->as<ompl::geometric::RRTXstatic>()->setEpsilon(0.001);
+    RRTXstatic3->as<ompl::geometric::RRTXstatic>()->setRange(range);
+    //RRTXstatic3->as<ompl::geometric::RRTXstatic>()->setVariant(3);
+    RRTXstatic3->as<ompl::geometric::RRTXstatic>()->setKNearest(knn);
+    b.addPlanner(RRTXstatic3);
     b.benchmark(request);
     b.saveResultsToFile(boost::str(boost::format("Diagonal.log")).c_str());
 

--- a/py-bindings/headers_geometric.txt
+++ b/py-bindings/headers_geometric.txt
@@ -21,7 +21,7 @@ src/ompl/geometric/planners/rrt/LazyRRT.h
 src/ompl/geometric/planners/rrt/TRRT.h
 src/ompl/geometric/planners/rrt/RRTstar.h
 src/ompl/geometric/planners/rrt/RRTsharp.h
-src/ompl/geometric/planners/rrt/RRTX.h
+src/ompl/geometric/planners/rrt/RRTXstatic.h
 src/ompl/geometric/planners/rrt/LBTRRT.h
 src/ompl/geometric/planners/rrt/LazyLBTRRT.h
 src/ompl/geometric/planners/rrt/InformedRRTstar.h

--- a/src/ompl/geometric/planners/rrt/RRTXstatic.h
+++ b/src/ompl/geometric/planners/rrt/RRTXstatic.h
@@ -34,8 +34,8 @@
 
 /* Author: Florian Hauer */
 
-#ifndef OMPL_GEOMETRIC_PLANNERS_RRT_RRTX_
-#define OMPL_GEOMETRIC_PLANNERS_RRT_RRTX_
+#ifndef OMPL_GEOMETRIC_PLANNERS_RRT_RRTXstatic_
+#define OMPL_GEOMETRIC_PLANNERS_RRT_RRTXstatic_
 
 #include "ompl/geometric/planners/PlannerIncludes.h"
 #include "ompl/base/OptimizationObjective.h"
@@ -54,9 +54,9 @@ namespace ompl
     namespace geometric
     {
         /**
-           @anchor gRRTX
+           @anchor gRRTXstatic
            @par Short description
-           \ref gRRTX "RRTX" is an asymptotically-optimal incremental
+           \ref gRRTXstatic "RRTXstatic" is an asymptotically-optimal incremental
            sampling-based motion planning algorithm. It differs from the \ref gRRTstar "RRT*" 
            algorithm by maintaining a pseudo-optimal tree.\n
            When adding a new motion, any rewiring improving the cost by more than epsilon is done.
@@ -78,8 +78,13 @@ namespace ompl
 
            The queue is implemented only using a scalar (cost + heuristic) as a key for ordering. With random samples, the set {cost + heuristic = constant}
            should be of measure 0, so a more complex key is not needed.
+
+           @par Disclaimer
+           Only the static part of the RRTX algorithm is implemented. Dynamical obstacles and updates of 
+           the robot position are not available in this implementation.
+
            @par External documentation
-           -# M. Otte & E. Frazzoli - RRTX : Real-Time Motion Planning/Replanning for Environments with Unpredictable Obstacles,
+           -# M. Otte & E. Frazzoli - RRTXstatic : Real-Time Motion Planning/Replanning for Environments with Unpredictable Obstacles,
            Algorithmic Foundations of Robotics XI,
            Volume 107 of the series Springer Tracts in Advanced Robotics pp 461-478
            -# O. Arslan, P. Tsiotras - The role of vertex consistency in sampling-based algorithms for optimal motion planning,
@@ -89,12 +94,12 @@ namespace ompl
         */
 
         /** \brief Optimal Rapidly-exploring Random Trees Maintaining A Pseudo Optimal Tree*/
-        class RRTX : public base::Planner
+        class RRTXstatic : public base::Planner
         {
         public:
-            RRTX(const base::SpaceInformationPtr &si);
+            RRTXstatic(const base::SpaceInformationPtr &si);
 
-            virtual ~RRTX();
+            virtual ~RRTXstatic();
 
             virtual void getPlannerData(base::PlannerData &data) const;
 

--- a/src/ompl/geometric/planners/rrt/RRTsharp.h
+++ b/src/ompl/geometric/planners/rrt/RRTsharp.h
@@ -37,7 +37,7 @@
 #ifndef OMPL_GEOMETRIC_PLANNERS_RRT_RRTsharp_
 #define OMPL_GEOMETRIC_PLANNERS_RRT_RRTsharp_
 
-#include "ompl/geometric/planners/rrt/RRTX.h"
+#include "ompl/geometric/planners/rrt/RRTXstatic.h"
 
 namespace ompl
 {
@@ -47,11 +47,11 @@ namespace ompl
            @anchor gRRTsharp
            @par Short description
            \ref gRRTsharp "RRT#" is an asymptotically-optimal incremental
-           sampling-based motion planning algorithm. It is similar from  \ref gRRTX "RRTX"
-           but maintains an optimal tree, same as \ref gRRTX "RRTX" with a treshold 0.\n
-           The parameters are the same as \ref gRRTX "RRTX" except for the paramtere epsilon.
+           sampling-based motion planning algorithm. It is similar from  \ref gRRTXstatic "RRTXstatic"
+           but maintains an optimal tree, same as \ref gRRTXstatic "RRTXstatic" with a treshold 0.\n
+           The parameters are the same as \ref gRRTXstatic "RRTXstatic" except for the paramtere epsilon.
            @par External documentation
-           -# M. Otte & E. Frazzoli - RRTX : Real-Time Motion Planning/Replanning for Environments with Unpredictable Obstacles,
+           -# M. Otte & E. Frazzoli - RRTXstatic : Real-Time Motion Planning/Replanning for Environments with Unpredictable Obstacles,
            Algorithmic Foundations of Robotics XI,
            Volume 107 of the series Springer Tracts in Advanced Robotics pp 461-478
            -# O. Arslan, P. Tsiotras - The role of vertex consistency in sampling-based algorithms for optimal motion planning,
@@ -61,13 +61,13 @@ namespace ompl
         */
 
         /** \brief Optimal Rapidly-exploring Random Trees Maintaining An Optimal Tree*/
-        class RRTsharp : public RRTX
+        class RRTsharp : public RRTXstatic
         {
         public:
 
             RRTsharp(const base::SpaceInformationPtr &si);
 
-            /** \brief Overwrite of RRTX setEpsilon. It does nothing but warn the user that this parameter cannot be changed */
+            /** \brief Overwrite of RRTXstatic setEpsilon. It does nothing but warn the user that this parameter cannot be changed */
             void setEpsilon(double epsilon)
             {
                 OMPL_WARN("The parameter epsilon is 0 for the %s algorithm, it cannot be changed.", getName().c_str());

--- a/src/ompl/geometric/planners/rrt/src/RRTXstatic.cpp
+++ b/src/ompl/geometric/planners/rrt/src/RRTXstatic.cpp
@@ -34,7 +34,7 @@
 
 /* Author: Florian Hauer */
 
-#include "ompl/geometric/planners/rrt/RRTX.h"
+#include "ompl/geometric/planners/rrt/RRTXstatic.h"
 #include "ompl/base/goals/GoalSampleableRegion.h"
 #include "ompl/tools/config/SelfConfig.h"
 #include "ompl/base/objectives/PathLengthOptimizationObjective.h"
@@ -47,8 +47,8 @@
 #include <limits>
 #include <boost/math/constants/constants.hpp>
 
-ompl::geometric::RRTX::RRTX(const base::SpaceInformationPtr &si) :
-    base::Planner(si, "RRTX"),
+ompl::geometric::RRTXstatic::RRTXstatic(const base::SpaceInformationPtr &si) :
+    base::Planner(si, "RRTXstatic"),
     goalBias_(0.05),
     maxDistance_(0.0),
     useKNearest_(true),
@@ -72,17 +72,17 @@ ompl::geometric::RRTX::RRTX(const base::SpaceInformationPtr &si) :
     specs_.optimizingPaths = true;
     specs_.canReportIntermediateSolutions = true;
 
-    Planner::declareParam<double>("range", this, &RRTX::setRange, &RRTX::getRange, "0.:1.:10000.");
-    Planner::declareParam<double>("goal_bias", this, &RRTX::setGoalBias, &RRTX::getGoalBias, "0.:.05:1.");
-    Planner::declareParam<double>("epsilon", this, &RRTX::setEpsilon, &RRTX::getEpsilon, "0.:.01:10.");
-    Planner::declareParam<double>("rewire_factor", this, &RRTX::setRewireFactor, &RRTX::getRewireFactor, "1.0:0.01:2.0");
-    Planner::declareParam<bool>("use_k_nearest", this, &RRTX::setKNearest, &RRTX::getKNearest, "0,1");
-    Planner::declareParam<bool>("update_children", this, &RRTX::setUpdateChildren, &RRTX::getUpdateChildren, "0,1");
-    Planner::declareParam<int>("rejection_variant", this, &RRTX::setVariant, &RRTX::getVariant, "0:3");
-    Planner::declareParam<double>("rejection_variant_alpha", this, &RRTX::setAlpha, &RRTX::getAlpha, "0.:1.");
-    Planner::declareParam<bool>("informed_sampling", this, &RRTX::setInformedSampling, &RRTX::getInformedSampling, "0,1");
-    Planner::declareParam<bool>("sample_rejection", this, &RRTX::setSampleRejection, &RRTX::getSampleRejection, "0,1");
-    Planner::declareParam<bool>("number_sampling_attempts", this, &RRTX::setNumSamplingAttempts, &RRTX::getNumSamplingAttempts, "10:10:100000");
+    Planner::declareParam<double>("range", this, &RRTXstatic::setRange, &RRTXstatic::getRange, "0.:1.:10000.");
+    Planner::declareParam<double>("goal_bias", this, &RRTXstatic::setGoalBias, &RRTXstatic::getGoalBias, "0.:.05:1.");
+    Planner::declareParam<double>("epsilon", this, &RRTXstatic::setEpsilon, &RRTXstatic::getEpsilon, "0.:.01:10.");
+    Planner::declareParam<double>("rewire_factor", this, &RRTXstatic::setRewireFactor, &RRTXstatic::getRewireFactor, "1.0:0.01:2.0");
+    Planner::declareParam<bool>("use_k_nearest", this, &RRTXstatic::setKNearest, &RRTXstatic::getKNearest, "0,1");
+    Planner::declareParam<bool>("update_children", this, &RRTXstatic::setUpdateChildren, &RRTXstatic::getUpdateChildren, "0,1");
+    Planner::declareParam<int>("rejection_variant", this, &RRTXstatic::setVariant, &RRTXstatic::getVariant, "0:3");
+    Planner::declareParam<double>("rejection_variant_alpha", this, &RRTXstatic::setAlpha, &RRTXstatic::getAlpha, "0.:1.");
+    Planner::declareParam<bool>("informed_sampling", this, &RRTXstatic::setInformedSampling, &RRTXstatic::getInformedSampling, "0,1");
+    Planner::declareParam<bool>("sample_rejection", this, &RRTXstatic::setSampleRejection, &RRTXstatic::getSampleRejection, "0,1");
+    Planner::declareParam<bool>("number_sampling_attempts", this, &RRTXstatic::setNumSamplingAttempts, &RRTXstatic::getNumSamplingAttempts, "10:10:100000");
 
     addPlannerProgressProperty("iterations INTEGER", [this]
                                {
@@ -98,12 +98,12 @@ ompl::geometric::RRTX::RRTX(const base::SpaceInformationPtr &si) :
                                });
 }
 
-ompl::geometric::RRTX::~RRTX()
+ompl::geometric::RRTXstatic::~RRTXstatic()
 {
     freeMemory();
 }
 
-void ompl::geometric::RRTX::setup()
+void ompl::geometric::RRTXstatic::setup()
 {
     Planner::setup();
     tools::SelfConfig sc(si_, getName());
@@ -153,7 +153,7 @@ void ompl::geometric::RRTX::setup()
     bestCost_ = opt_->infiniteCost();
 }
 
-void ompl::geometric::RRTX::clear()
+void ompl::geometric::RRTXstatic::clear()
 {
     setup_ = false;
     Planner::clear();
@@ -170,7 +170,7 @@ void ompl::geometric::RRTX::clear()
     bestCost_ = base::Cost(std::numeric_limits<double>::quiet_NaN());
 }
 
-ompl::base::PlannerStatus ompl::geometric::RRTX::solve(const base::PlannerTerminationCondition &ptc)
+ompl::base::PlannerStatus ompl::geometric::RRTXstatic::solve(const base::PlannerTerminationCondition &ptc)
 {   
     checkValidity();
     base::Goal                  *goal   = pdef_->getGoal().get();
@@ -561,7 +561,7 @@ ompl::base::PlannerStatus ompl::geometric::RRTX::solve(const base::PlannerTermin
     return base::PlannerStatus(addedSolution, approximate);
 }
 
-void ompl::geometric::RRTX::updateQueue(Motion *x)
+void ompl::geometric::RRTXstatic::updateQueue(Motion *x)
 {
     // If x->handle is not NULL, x is already in the queue and needs to be update, otherwise it is inserted
     if(x->handle != nullptr)
@@ -574,7 +574,7 @@ void ompl::geometric::RRTX::updateQueue(Motion *x)
     }
 }
 
-void ompl::geometric::RRTX::removeFromParent(Motion *m)
+void ompl::geometric::RRTXstatic::removeFromParent(Motion *m)
 {
     for (std::vector<Motion *>::iterator it = m->parent->children.begin ();
         it != m->parent->children.end (); ++it)
@@ -587,14 +587,14 @@ void ompl::geometric::RRTX::removeFromParent(Motion *m)
     }
 }
 
-void ompl::geometric::RRTX::calculateRRG()
+void ompl::geometric::RRTXstatic::calculateRRG()
 {
     double cardDbl = static_cast<double>(nn_->size() + 1u);
     rrg_k_ = std::ceil(k_rrg_ * log(cardDbl));
     rrg_r_ = std::min(maxDistance_, r_rrg_ * std::pow(log(cardDbl) / cardDbl, 1 / static_cast<double>(si_->getStateDimension())));
 }
 
-void ompl::geometric::RRTX::getNeighbors(Motion *motion) const
+void ompl::geometric::RRTXstatic::getNeighbors(Motion *motion) const
 {
     if(motion->nbh.size()>0){
         return;
@@ -618,7 +618,7 @@ void ompl::geometric::RRTX::getNeighbors(Motion *motion) const
                   });
 }
 
-bool ompl::geometric::RRTX::includeVertex(const Motion *x) const
+bool ompl::geometric::RRTXstatic::includeVertex(const Motion *x) const
 {
     switch(variant_)
     {
@@ -633,7 +633,7 @@ bool ompl::geometric::RRTX::includeVertex(const Motion *x) const
     }
 }
 
-void ompl::geometric::RRTX::freeMemory()
+void ompl::geometric::RRTXstatic::freeMemory()
 {
     if (nn_)
     {
@@ -648,7 +648,7 @@ void ompl::geometric::RRTX::freeMemory()
     }
 }
 
-void ompl::geometric::RRTX::getPlannerData(base::PlannerData &data) const
+void ompl::geometric::RRTXstatic::getPlannerData(base::PlannerData &data) const
 {
     Planner::getPlannerData(data);
 
@@ -669,7 +669,7 @@ void ompl::geometric::RRTX::getPlannerData(base::PlannerData &data) const
     }
 }
 
-void ompl::geometric::RRTX::setInformedSampling(bool informedSampling)
+void ompl::geometric::RRTXstatic::setInformedSampling(bool informedSampling)
 {
     if (static_cast<bool>(opt_) == true)
     {
@@ -704,7 +704,7 @@ void ompl::geometric::RRTX::setInformedSampling(bool informedSampling)
     }
 }
 
-void ompl::geometric::RRTX::setSampleRejection(const bool reject)
+void ompl::geometric::RRTXstatic::setSampleRejection(const bool reject)
 {
     if (static_cast<bool>(opt_) == true)
     {
@@ -739,7 +739,7 @@ void ompl::geometric::RRTX::setSampleRejection(const bool reject)
     }
 }
 
-void ompl::geometric::RRTX::allocSampler()
+void ompl::geometric::RRTXstatic::allocSampler()
 {
     // Allocate the appropriate type of sampler.
     if (useInformedSampling_)
@@ -761,7 +761,7 @@ void ompl::geometric::RRTX::allocSampler()
     }
 }
 
-bool ompl::geometric::RRTX::sampleUniform(base::State *statePtr)
+bool ompl::geometric::RRTXstatic::sampleUniform(base::State *statePtr)
 {
     // Use the appropriate sampler
     if (useInformedSampling_ || useRejectionSampling_)
@@ -782,7 +782,7 @@ bool ompl::geometric::RRTX::sampleUniform(base::State *statePtr)
     }
 }
 
-void ompl::geometric::RRTX::calculateRewiringLowerBounds()
+void ompl::geometric::RRTXstatic::calculateRewiringLowerBounds()
 {
     double dimDbl = static_cast<double>(si_->getStateDimension());
 

--- a/src/ompl/geometric/planners/rrt/src/RRTsharp.cpp
+++ b/src/ompl/geometric/planners/rrt/src/RRTsharp.cpp
@@ -36,7 +36,7 @@
 
 #include "ompl/geometric/planners/rrt/RRTsharp.h"
 
-ompl::geometric::RRTsharp::RRTsharp(const base::SpaceInformationPtr &si) : RRTX(si)
+ompl::geometric::RRTsharp::RRTsharp(const base::SpaceInformationPtr &si) : RRTXstatic(si)
 {
     setName("RRT#");
     params().remove("epsilon");


### PR DESCRIPTION
After discussion with Michael Otte (author of the RRTX paper), we decided to rename RRTX into RRTXstatic because only the static part of the algorithm is implemented (dynamic obstacles and robot motion are not available in this implementation).
We also added a disclaimer explaining it.

It aims at reducing confusion for the user and preventing users from naively using it in dynamical environment.