### PR TITLE
Allow base::CompoundState to be cast to base::State

### DIFF
--- a/src/ompl/base/State.h
+++ b/src/ompl/base/State.h
@@ -92,6 +92,26 @@ namespace ompl
 
             ~CompoundState() override = default;
 
+            /** \brief Cast this instance to a desired type. */
+            template <class T>
+            T *as()
+            {
+                /** \brief Make sure the type we are casting to is indeed a state space */
+                BOOST_CONCEPT_ASSERT((boost::Convertible<T *, State *>));
+
+                return static_cast<T *>(this);
+            }
+
+            /** \brief Cast this instance to a desired type. */
+            template <class T>
+            const T *as() const
+            {
+                /** \brief Make sure the type we are casting to is indeed a state space */
+                BOOST_CONCEPT_ASSERT((boost::Convertible<T *, State *>));
+
+                return static_cast<const T *>(this);
+            }
+
             /** \brief Cast a component of this instance to a desired type. */
             template <class T>
             const T *as(const unsigned int index) const


### PR DESCRIPTION
I'm doing task planning with CompoundStates and am explicitly using that type within my code to prevent confusion with other locations in my code that use a different type of State. However there are many places throughout OMPL that require a ``base::State*``, so I need to be able to downcast my ``base::CompoundState*`` using these functions.