### PR TITLE
Allow a PathGeometric class to be cleared

### DIFF
--- a/src/ompl/geometric/PathGeometric.h
+++ b/src/ompl/geometric/PathGeometric.h
@@ -251,6 +251,9 @@ namespace ompl
                 return states_.size();
             }
 
+            /** \brief Remove all states and clear memory */
+            void clear();
+
             /** @} */
 
         protected:

--- a/src/ompl/geometric/src/PathGeometric.cpp
+++ b/src/ompl/geometric/src/PathGeometric.cpp
@@ -525,3 +525,9 @@ int ompl::geometric::PathGeometric::getClosestIndex(const base::State *state) co
     }
     return index;
 }
+
+void ompl::geometric::PathGeometric::clear()
+{
+    freeMemory();
+    states_.clear();
+}


### PR DESCRIPTION
I want to re-use the same SharedPtr of PathGeometric being passed into a function and feel like this is cleaner than creating a new one.