### PR TITLE
Changed RRTXstatic to use r_rrt and k_rrt instead of r_rrg and k_rrg

### DIFF
--- a/src/ompl/geometric/planners/rrt/RRTXstatic.h
+++ b/src/ompl/geometric/planners/rrt/RRTXstatic.h
@@ -416,9 +416,9 @@ namespace ompl
             double rewireFactor_;
 
             /** \brief A constant for k-nearest rewiring calculations */
-            double k_rrg_;
+            double k_rrt_;
             /** \brief A constant for r-disc rewiring calculations */
-            double r_rrg_;
+            double r_rrt_;
 
             /** \brief Objective we're optimizing */
             base::OptimizationObjectivePtr opt_;


### PR DESCRIPTION
Similarly to the recent update on RRTstar, the constants for the radius of the ball and the number of nearest neighbors has been updated in RRTXstatic to guarantee optimality.