### PR TITLE
Update Exception.h

### DIFF
--- a/src/ompl/util/Exception.h
+++ b/src/ompl/util/Exception.h
@@ -57,7 +57,7 @@ namespace ompl
         {
         }
 
-        ~Exception() throw() override = default;
+        ~Exception() override = default;
     };
 }
 


### PR DESCRIPTION
This fixes the following compile time error: 
 'ompl::Exception::~Exception(void) throw()' : is not a special member function which can be defaulted