### PR TITLE
Fix Yocto builds

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -70,7 +70,7 @@ else(IS_ICPC)
 endif(IS_ICPC)
 
 find_package(Boost 1.54 COMPONENTS serialization filesystem system program_options REQUIRED)
-include_directories(SYSTEM ${Boost_INCLUDE_DIR})
+include_directories(${Boost_INCLUDE_DIR})
 
 # on OS X we need to check whether to use libc++ or libstdc++ with clang++
 if(APPLE AND CMAKE_CXX_COMPILER_ID STREQUAL "Clang")

--- a/CMakeModules/CompilerSettings.cmake
+++ b/CMakeModules/CompilerSettings.cmake
@@ -52,11 +52,14 @@ if((CMAKE_COMPILER_IS_GNUCXX OR IS_ICPC) AND NOT MINGW)
     add_definitions(-fPIC)
 endif((CMAKE_COMPILER_IS_GNUCXX OR IS_ICPC) AND NOT MINGW)
 
-# Set rpath http://www.paraview.org/Wiki/CMake_RPATH_handling
-set(CMAKE_SKIP_BUILD_RPATH FALSE)
-set(CMAKE_BUILD_WITH_INSTALL_RPATH FALSE)
-set(CMAKE_INSTALL_RPATH "${CMAKE_INSTALL_PREFIX}/lib")
-set(CMAKE_INSTALL_RPATH_USE_LINK_PATH TRUE)
+option(OMPL_SKIP_RPATH "Don't set RPATH to the OMPL library" OFF)
+if(NOT OMPL_SKIP_RPATH)
+    # Set rpath http://www.paraview.org/Wiki/CMake_RPATH_handling
+    set(CMAKE_SKIP_BUILD_RPATH FALSE)
+    set(CMAKE_BUILD_WITH_INSTALL_RPATH FALSE)
+    set(CMAKE_INSTALL_RPATH "${CMAKE_INSTALL_PREFIX}/lib")
+    set(CMAKE_INSTALL_RPATH_USE_LINK_PATH TRUE)
+endif()
 
 # no prefix needed for python modules
 set(CMAKE_SHARED_MODULE_PREFIX "")


### PR DESCRIPTION
These two commits make OMPL buildable with the latest Yocto. Particularly it fixes a compatibility issue with gcc6 and makes setting RPATH optional to conform with Opembedded-Core's QA checks.