### PR TITLE
BIT* and PathLengthDirectInfSampler fixes

### DIFF
--- a/src/ompl/base/samplers/informed/src/PathLengthDirectInfSampler.cpp
+++ b/src/ompl/base/samplers/informed/src/PathLengthDirectInfSampler.cpp
@@ -91,17 +91,26 @@ namespace ompl
             }
 
             // Check that the provided statespace is compatible and extract the necessary indices.
-            // The statespace must either be R^n or SE(2) or SE(3)
+            // The statespace must either be R^n or SE(2) or SE(3).
+            // If it is UNKNOWN, warn and treat it as R^n
             if (!InformedSampler::space_->isCompound())
             {
                 if (InformedSampler::space_->getType() == STATE_SPACE_REAL_VECTOR)
                 {
+                    // R^n, this is easy
+                    informedIdx_ = 0u;
+                    uninformedIdx_ = 0u;
+                }
+                else if (InformedSampler::space_->getType() == STATE_SPACE_UNKNOWN)
+                {
+                    // Unknown, this is annoying. I hope the user knows what they're doing
+                    OMPL_WARN("PathLengthDirectInfSampler: Treating the StateSpace of type \"STATE_SPACE_UNKNOWN\" as type \"STATE_SPACE_REAL_VECTOR\".");
                     informedIdx_ = 0u;
                     uninformedIdx_ = 0u;
                 }
                 else
                 {
-                    throw Exception("PathLengthDirectInfSampler only supports RealVector, SE2 and SE3 StateSpaces.");
+                    throw Exception("PathLengthDirectInfSampler only supports Unknown, RealVector, SE2, and SE3 StateSpaces.");
                 }
             }
             else if (InformedSampler::space_->isCompound())

--- a/src/ompl/geometric/planners/bitstar/BITstar.h
+++ b/src/ompl/geometric/planners/bitstar/BITstar.h
@@ -421,73 +421,76 @@ namespace ompl
             ///////////////////////////////////////////////////////////////////
             // Variables -- Make sure every one is configured in setup() and reset in clear():
             /** \brief A helper for cost and heuristic calculations */
-            CostHelperPtr costHelpPtr_;
+            CostHelperPtr costHelpPtr_{nullptr};
 
             /** \brief The samples represented as an edge-implicit graph */
-            ImplicitGraphPtr graphPtr_;
+            ImplicitGraphPtr graphPtr_{nullptr};
 
             /** \brief The queue of vertices to expand and edges to process ordered on "f-value", i.e., estimated
              * solution cost. Remaining vertex queue "size" and edge queue size are accessible via
              * vertexQueueSizeProgressProperty and edgeQueueSizeProgressProperty, respectively. */
-            SearchQueuePtr queuePtr_;
+            SearchQueuePtr queuePtr_{nullptr};
 
             /** \brief The goal vertex of the current best solution */
-            VertexConstPtr curGoalVertex_;
+            VertexConstPtr curGoalVertex_{nullptr};
 
             /** \brief The best cost found to date. This is the maximum total-heuristic cost of samples we'll consider.
              * Accessible via bestCostProgressProperty */
-            ompl::base::Cost bestCost_;
+             // Gets set in setup to the proper calls from OptimizationObjective
+            ompl::base::Cost bestCost_{std::numeric_limits<double>::infinity()};
 
             /** \brief The number of vertices in the best solution found to date. Accessible via
              * bestLengthProgressProperty */
-            unsigned int bestLength_;
+            unsigned int bestLength_{0u};
 
             /** \brief The cost to which the problem has been pruned. We will only prune the graph when a new solution
              * is sufficiently less than this value. */
-            ompl::base::Cost prunedCost_;
+             // Gets set in setup to the proper calls from OptimizationObjective
+            ompl::base::Cost prunedCost_{std::numeric_limits<double>::infinity()};
 
             /** \brief The measure to which the problem has been pruned. We will only prune the graph when the resulting
              * measure of a new solution is sufficiently less than this value. */
-            double prunedMeasure_;
+             // Gets set in setup with the proper call to Planner::si_->getSpaceMeasure()
+            double prunedMeasure_{0.0};
 
             /** \brief If we've found an exact solution yet */
-            bool hasExactSolution_;
+            bool hasExactSolution_{false};
 
             /** \brief A manual stop on the solve loop */
-            bool stopLoop_;
+            bool stopLoop_{false};
             ///////////////////////////////////////////////////////////////////
 
             ///////////////////////////////////////////////////////////////////
             // Informational variables - Make sure initialized in setup and reset in clear
             /** \brief The number of batches processed. Accessible via batchesProgressProperty */
-            unsigned int numBatches_;
+            unsigned int numBatches_{0u};
 
             /** \brief The number of times the graph/samples have been pruned. Accessible via pruningProgressProperty */
-            unsigned int numPrunings_;
+            unsigned int numPrunings_{0u};
 
             /** \brief The number of iterations run. Accessible via iterationProgressProperty */
-            unsigned int numIterations_;
+            unsigned int numIterations_{0u};
 
             /** \brief The number of times a state in the graph was rewired. Accessible via rewiringProgressProperty */
-            unsigned int numRewirings_;
+            unsigned int numRewirings_{0u};
 
             /** \brief The number of edge collision checks. Accessible via edgeCollisionCheckProgressProperty */
-            unsigned int numEdgeCollisionChecks_;
+            unsigned int numEdgeCollisionChecks_{0u};
             ///////////////////////////////////////////////////////////////////
 
             ///////////////////////////////////////////////////////////////////
             // Parameters - Set defaults in construction/setup and DO NOT reset in clear.
             /** \brief The number of samples per batch (param) */
-            unsigned int samplesPerBatch_;
+            unsigned int samplesPerBatch_{100u};
 
             /** \brief Whether to use graph pruning (param) */
-            bool usePruning_;
+            bool usePruning_{true};
 
             /** \brief The fractional decrease in solution cost required to trigger pruning (param) */
-            double pruneFraction_;
+            double pruneFraction_{0.05};
 
             /** \brief Whether to stop the planner as soon as the path changes (param) */
-            bool stopOnSolnChange_;
+            bool stopOnSolnChange_{false};
             ///////////////////////////////////////////////////////////////////
         };  // class: BITstar
 

--- a/src/ompl/geometric/planners/bitstar/datastructures/src/ImplicitGraph.cpp
+++ b/src/ompl/geometric/planners/bitstar/datastructures/src/ImplicitGraph.cpp
@@ -724,14 +724,18 @@ namespace ompl
         {
             this->confirmSetup();
 
+            // Variable:
+            // Create a copy of the vertex pointer so we don't delete it out from under ourselves.
+            VertexPtr sampleToDelete(oldSample);
+
             // Increment our counter
             ++numFreeStatesPruned_;
 
             // Remove from the set of samples
-            freeStateNN_->remove(oldSample);
+            freeStateNN_->remove(sampleToDelete);
 
             // Mark the sample as pruned
-            oldSample->markPruned();
+            sampleToDelete->markPruned();
         }
 
         void BITstar::ImplicitGraph::addVertex(const VertexPtr &newVertex, bool removeFromFree)
@@ -767,32 +771,40 @@ namespace ompl
             }
         }
 
-        unsigned int BITstar::ImplicitGraph::removeVertex(const VertexPtr &oldSample, bool moveToFree)
+        unsigned int BITstar::ImplicitGraph::removeVertex(const VertexPtr &oldVertex, bool moveToFree)
         {
             this->confirmSetup();
+
+            // Variable:
+            // A copy of the vertex pointer to be removed so we can't delete it out from under ourselves (occurs when
+            // this function is given an element of the maintained set as the argument)
+            VertexPtr vertexToDelete(oldVertex);
 
             // Increment our counter
             ++numVerticesDisconnected_;
 
             // Remove from the nearest-neighbour structure
-            vertexNN_->remove(oldSample);
+            vertexNN_->remove(vertexToDelete);
 
             // Add back as sample, if that would be beneficial
-            if (moveToFree && !queuePtr_->samplePruneCondition(oldSample))
+            if (moveToFree && !queuePtr_->samplePruneCondition(vertexToDelete))
             {
                 // Yes, the vertex is still useful as a sample. Track as recycled so they are reused as samples in the
                 // next batch.
-                recycledSamples_.push_back(oldSample);
+                recycledSamples_.push_back(vertexToDelete);
 
                 // Return that the vertex was recycled
                 return 0u;
             }
-            // No, the vertex is not useful anymore. Mark as pruned. This functions as a lock to prevent accessing
-            // anything about the vertex.
-            oldSample->markPruned();
+            else
+            {
+                // No, the vertex is not useful anymore. Mark as pruned. This functions as a lock to prevent accessing
+                // anything about the vertex.
+                vertexToDelete->markPruned();
 
-            // Return that the vertex was completely pruned
-            return 1u;
+                // Return that the vertex was completely pruned
+                return 1u;
+            }
         }
         /////////////////////////////////////////////////////////////////////////////////////////////
 

--- a/src/ompl/geometric/planners/bitstar/datastructures/src/ImplicitGraph.cpp
+++ b/src/ompl/geometric/planners/bitstar/datastructures/src/ImplicitGraph.cpp
@@ -226,14 +226,14 @@ namespace ompl
                 vertexNN_.reset();
             }
 
-            // The various calculations and tracked values
+            // The various calculations and tracked values, same as in the header
             samplesInThisBatch_ = 0u;
             numUniformStates_ = 0u;
             r_ = 0.0;
             k_rgg_ = 0.0;  // This is a double for better rounding later
             k_ = 0u;
 
-            approximationMeasure_ = si_->getSpaceMeasure();
+            approximationMeasure_ = 0.0;
             minCost_ = ompl::base::Cost(std::numeric_limits<double>::infinity());
             maxCost_ = ompl::base::Cost(std::numeric_limits<double>::infinity());
             costSampled_ = ompl::base::Cost(std::numeric_limits<double>::infinity());

--- a/src/ompl/geometric/planners/bitstar/src/BITstar.cpp
+++ b/src/ompl/geometric/planners/bitstar/src/BITstar.cpp
@@ -240,58 +240,63 @@ namespace ompl
 
         void BITstar::setup()
         {
-            // Call the base class setup:
+            // Call the base class setup. Marks Planner::setup_ as true.
             Planner::setup();
 
-            // Do some sanity checks
-            // Make sure we have a problem definition
-            if (!static_cast<bool>(Planner::pdef_))
+            // Check if we have a problem definition
+            if (static_cast<bool>(Planner::pdef_))
             {
-                OMPL_ERROR("%s::setup() was called without a problem definition.", Planner::getName().c_str());
-                Planner::setup_ = false;
-                return;
-            }
-
-            // Make sure we have an optimization objective
-            if (!Planner::pdef_->hasOptimizationObjective())
-            {
-                OMPL_INFORM("%s: No optimization objective specified. Defaulting to optimizing path length.",
-                            Planner::getName().c_str());
-                Planner::pdef_->setOptimizationObjective(
-                    std::make_shared<base::PathLengthOptimizationObjective>(Planner::si_));
-            }
-
-            // If the problem definition *has* a goal, make sure it is of appropriate type
-            if (static_cast<bool>(Planner::pdef_->getGoal()))
-            {
-                if (!Planner::pdef_->getGoal()->hasType(ompl::base::GOAL_SAMPLEABLE_REGION))
+                // We do, do some initialization work.
+                // See if we have an optimization objective
+                if (!Planner::pdef_->hasOptimizationObjective())
                 {
-                    OMPL_ERROR("%s::setup() BIT* currently only supports goals that can be cast to a sampleable goal "
-                               "region.",
-                               Planner::getName().c_str());
-                    Planner::setup_ = false;
-                    return;
+                    OMPL_INFORM("%s: No optimization objective specified. Defaulting to optimizing path length.",
+                                Planner::getName().c_str());
+                    Planner::pdef_->setOptimizationObjective(
+                        std::make_shared<base::PathLengthOptimizationObjective>(Planner::si_));
                 }
-                // No else, of correct type.
+                // No else, we were given one.
+
+                // If the problem definition *has* a goal, make sure it is of appropriate type
+                if (static_cast<bool>(Planner::pdef_->getGoal()))
+                {
+                    if (!Planner::pdef_->getGoal()->hasType(ompl::base::GOAL_SAMPLEABLE_REGION))
+                    {
+                        OMPL_ERROR("%s::setup() BIT* currently only supports goals that can be cast to a sampleable goal "
+                                   "region.",
+                                   Planner::getName().c_str());
+                        // Mark as not setup:
+                        Planner::setup_ = false;
+                        return;
+                    }
+                    // No else, of correct type.
+                }
+                // No else, called without a goal. Is this MoveIt?
+
+                // Setup the CostHelper, it provides everything I need from optimization objective plus some frills
+                costHelpPtr_->setup(Planner::pdef_->getOptimizationObjective(), graphPtr_);
+
+                // Setup the queue
+                queuePtr_->setup(costHelpPtr_, graphPtr_);
+
+                // Setup the graph, it does not hold a copy of this or Planner::pis_, but uses them to create a NN struct
+                // and check for starts/goals, respectively.
+                graphPtr_->setup(Planner::si_, Planner::pdef_, costHelpPtr_, queuePtr_, this, Planner::pis_);
+
+                // Set the best and pruned costs to the proper objective-based values:
+                bestCost_ = costHelpPtr_->infiniteCost();
+                prunedCost_ = costHelpPtr_->infiniteCost();
+
+                // Get the measure of the problem
+                prunedMeasure_ = Planner::si_->getSpaceMeasure();
+
+                // We are already marked as setup.
             }
-            // No else, called without a goal. Is this MoveIt?
-
-            // Setup the CostHelper, it provides everything I need from optimization objective plus some frills
-            costHelpPtr_->setup(Planner::pdef_->getOptimizationObjective(), graphPtr_);
-
-            // Setup the queue
-            queuePtr_->setup(costHelpPtr_, graphPtr_);
-
-            // Setup the graph, it does not hold a copy of this or Planner::pis_, but uses them to create a NN struct
-            // and check for starts/goals, respectively.
-            graphPtr_->setup(Planner::si_, Planner::pdef_, costHelpPtr_, queuePtr_, this, Planner::pis_);
-
-            // Set the best and pruned costs to the proper objective-based values:
-            bestCost_ = costHelpPtr_->infiniteCost();
-            prunedCost_ = costHelpPtr_->infiniteCost();
-
-            // Get the measure of the problem
-            prunedMeasure_ = Planner::si_->getSpaceMeasure();
+            else
+            {
+                // We don't, so we can't setup. Make sure that is explicit.
+                Planner::setup_ = false;
+            }
         }
 
         void BITstar::clear()
@@ -333,7 +338,16 @@ namespace ompl
 
         ompl::base::PlannerStatus BITstar::solve(const ompl::base::PlannerTerminationCondition &ptc)
         {
+            // Check that Planner::setup_ is true, if not call this->setup()
             Planner::checkValidity();
+
+            // Assert setup succeeded
+            if (!Planner::setup_)
+            {
+                throw ompl::Exception("%s::solve() failed to set up the planner. Has a problem definition been set?", Planner::getName().c_str());
+            }
+            // No else
+
             OMPL_INFORM("%s: Searching for a solution to the given planning problem.", Planner::getName().c_str());
 
             // Reset the manual stop to the iteration loop:

--- a/src/ompl/geometric/planners/bitstar/src/BITstar.cpp
+++ b/src/ompl/geometric/planners/bitstar/src/BITstar.cpp
@@ -75,27 +75,6 @@ namespace ompl
         // Public functions:
         BITstar::BITstar(const ompl::base::SpaceInformationPtr &si, const std::string &name /*= "BITstar"*/)
           : ompl::base::Planner(si, name)
-          , costHelpPtr_(nullptr)
-          , graphPtr_(nullptr)
-          , queuePtr_(nullptr)
-          , curGoalVertex_(nullptr)
-          , bestCost_(std::numeric_limits<double>::infinity())  // Gets set in setup to the proper calls from
-                                                                // OptimizationObjective
-          , bestLength_(0u)
-          , prunedCost_(std::numeric_limits<double>::infinity())  // Gets set in setup to the proper calls from
-                                                                  // OptimizationObjective
-          , prunedMeasure_(0.0)  // Gets set in setup with the proper call to Planner::si_->getSpaceMeasure()
-          , hasExactSolution_(false)
-          , stopLoop_(false)
-          , numBatches_(0u)
-          , numPrunings_(0u)
-          , numIterations_(0u)
-          , numRewirings_(0u)
-          , numEdgeCollisionChecks_(0u)
-          , samplesPerBatch_(100u)
-          , usePruning_(true)
-          , pruneFraction_(0.05)
-          , stopOnSolnChange_(false)
         {
 #ifdef BITSTAR_DEBUG
             OMPL_WARN("%s: Compiled with debug-level asserts.", Planner::getName().c_str());


### PR DESCRIPTION
1. Allow `BITstar::setup()` to run without a problem definition and delay the necessary work until `BITstar::solve()` calls `Planner::checkValidity()` (which will then recall `BITstar::setup()`)
2. Allow `PathLengthDirectInfSampler` to support `STATE_SPACE_UNKNOWN` with a warning.
3. Initialize `BITstar` member variables in the header instead of constructor as per style.
4. Revert `BITstar::ImplicitGraph::removeSample()` and `BITstar::ImplicitGraph::removeVertex()` to taking a local copy of the removed data to avoid a low-frequency segfault. [See issue here](https://bitbucket.org/ompl/ompl/issues/364/code-cleanup-breaking-bit).
5. Fix segfault in `BITstar::ImplicitGraph::clear()` caused by an already cleared pointer.