### PR TITLE
Fix redefinition and missing include errors

### DIFF
--- a/src/ompl/datastructures/NearestNeighborsFLANN.h
+++ b/src/ompl/datastructures/NearestNeighborsFLANN.h
@@ -42,8 +42,9 @@
 #error FLANN is not available. Please use a different NearestNeighbors data structure.
 #else
 
-#include "ompl/datastructures/NearestNeighbors.h"
 #include "ompl/base/StateSpace.h"
+#include "ompl/datastructures/NearestNeighbors.h"
+#include "ompl/util/Exception.h"
 
 #include <flann/flann.hpp>
 #include <utility>
@@ -320,7 +321,8 @@ namespace ompl
     };
 
     template <>
-    void NearestNeighborsFLANN<double, flann::L2<double>>::createIndex(const flann::Matrix<double> &mat)
+    inline void NearestNeighborsFLANN<double, flann::L2<double>>::createIndex(
+        const flann::Matrix<double> &mat)
     {
         index_ = new flann::Index<flann::L2<double>>(mat, *params_);
         index_->buildIndex();


### PR DESCRIPTION
I encountered the following two errors when including `NearestNeighborsFLANN.h` in two different cpp files within the same library:

Missing `Exception.h` include:
```cpp
/home/marius/exploration_ws/devel/include/ompl/datastructures/NearestNeighborsFLANN.h:187:19: error: use of undeclared identifier 'Exception'
            throw Exception("No elements found in nearest neighbors data structure");
                  ^
1 error generated.
```

Missing `inline`:
```cpp
CMakeFiles/bla_lib.dir/src/bla.cpp.o: In function `ompl::NearestNeighborsFLANN<double, flann::L2<double> >::createIndex(flann::Matrix<double> const&)':
/home/marius/exploration_ws/src/bla/bla/src/bla.cpp:(.text+0x0): multiple definition of `ompl::NearestNeighborsFLANN<double, flann::L2<double> >::createIndex(flann::Matrix<double> const&)'
```

This happened  with both  `gcc 4.8.4` and `clang 3.7.0`.
`
