### PR TITLE
Bridge Test Implementation

### DIFF
--- a/src/ompl/base/samplers/BridgeTestValidStateSampler.h
+++ b/src/ompl/base/samplers/BridgeTestValidStateSampler.h
@@ -1,0 +1,91 @@
+/*********************************************************************
+* Software License Agreement (BSD License)
+*
+*  Copyright (c) 2010, Rice University
+*  All rights reserved.
+*
+*  Redistribution and use in source and binary forms, with or without
+*  modification, are permitted provided that the following conditions
+*  are met:
+*
+*   * Redistributions of source code must retain the above copyright
+*     notice, this list of conditions and the following disclaimer.
+*   * Redistributions in binary form must reproduce the above
+*     copyright notice, this list of conditions and the following
+*     disclaimer in the documentation and/or other materials provided
+*     with the distribution.
+*   * Neither the name of the Rice University nor the names of its
+*     contributors may be used to endorse or promote products derived
+*     from this software without specific prior written permission.
+*
+*  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+*  "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+*  LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+*  FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+*  COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+*  INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+*  BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+*  LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+*  CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+*  LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+*  ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+*  POSSIBILITY OF SUCH DAMAGE.
+*********************************************************************/
+
+#pragma once
+
+#include <ompl/base/ValidStateSampler.h>
+#include <ompl/base/StateSampler.h>
+
+namespace ompl
+{
+    namespace base
+    {
+        /** \brief Generate valid samples using bridge test. First
+            sample an invalid state, then sample another invalid state. Take the midpoint of those samples. 
+            If midpoint is valid, return. If midpoint is invalid continue.
+
+            @par External documentation
+            Hsu, D., Jiang, T., Reif, J., & Sun, Z., The bridge test for sampling narrow
+            passages with probabilistic roadmap planners. In <em>Robotics and
+            Automation</em>, 2003. 
+            [[URL]](ftp://www-cs-faculty.stanford.edu/cs/robotics/pub/dyhsu/papers/icra03.pdf)
+
+        */
+
+        class BridgeTestValidStateSampler : public ValidStateSampler
+        {
+        public:
+            /** \brief Constructor */
+            BridgeTestValidStateSampler(const SpaceInformation *si);
+
+            ~BridgeTestValidStateSampler() override = default;
+
+            bool sample(State *state) override;
+            bool sampleNear(State *state, const State *near, const double distance) override;
+
+            /** \brief Get the standard deviation used when sampling */
+            double getStdDev() const
+            {
+                return stddev_;
+            }
+
+            /** \brief Set the standard deviation to use when sampling */
+            void setStdDev(double stddev)
+            {
+                stddev_ = stddev;
+            }
+
+
+        protected:
+            /** \brief The sampler to build upon */
+            StateSamplerPtr sampler_;
+
+            /** \brief The standard deviation to use in the sampling process */
+            double stddev_;
+
+
+
+        };
+    }
+}

--- a/src/ompl/base/samplers/BridgeTestValidStateSampler.h
+++ b/src/ompl/base/samplers/BridgeTestValidStateSampler.h
@@ -1,7 +1,10 @@
 /*********************************************************************
 * Software License Agreement (BSD License)
 *
-*  Copyright (c) 2010, Rice University
+*  Copyright (c) 2017, 
+*  National Institute of Advanced Industrial Science and
+*  Technology (AIST)
+*
 *  All rights reserved.
 *
 *  Redistribution and use in source and binary forms, with or without
@@ -14,9 +17,10 @@
 *     copyright notice, this list of conditions and the following
 *     disclaimer in the documentation and/or other materials provided
 *     with the distribution.
-*   * Neither the name of the Rice University nor the names of its
-*     contributors may be used to endorse or promote products derived
-*     from this software without specific prior written permission.
+*   * Neither the name of the National Institute of Advanced Industrial 
+*     Science and Technology nor the names of its contributors may be 
+*     used to endorse or promote products derived from this software 
+*     without specific prior written permission.
 *
 *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
 *  "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
@@ -32,10 +36,13 @@
 *  POSSIBILITY OF SUCH DAMAGE.
 *********************************************************************/
 
-#pragma once
+/* Author: Andreas Orthey */
 
-#include <ompl/base/ValidStateSampler.h>
-#include <ompl/base/StateSampler.h>
+#ifndef OMPL_BASE_SAMPLERS_BRIDGE_TEST_VALID_STATE_SAMPLER_
+#define OMPL_BASE_SAMPLERS_BRIDGE_TEST_VALID_STATE_SAMPLER_
+
+#include "ompl/base/ValidStateSampler.h"
+#include "ompl/base/StateSampler.h"
 
 namespace ompl
 {
@@ -49,7 +56,7 @@ namespace ompl
             Hsu, D., Jiang, T., Reif, J., & Sun, Z., The bridge test for sampling narrow
             passages with probabilistic roadmap planners. In <em>Robotics and
             Automation</em>, 2003. 
-            [[URL]](ftp://www-cs-faculty.stanford.edu/cs/robotics/pub/dyhsu/papers/icra03.pdf)
+            [[URL]](http://dx.doi.org/10.1109/ROBOT.2003.1242285)
 
         */
 
@@ -89,3 +96,4 @@ namespace ompl
         };
     }
 }
+#endif

--- a/src/ompl/base/samplers/src/BridgeTestValidStateSampler.cpp
+++ b/src/ompl/base/samplers/src/BridgeTestValidStateSampler.cpp
@@ -1,6 +1,6 @@
-#include "BridgeTestValidStateSampler.h"
-#include <ompl/base/SpaceInformation.h>
-#include <ompl/tools/config/MagicConstants.h>
+#include "ompl/base/samplers/BridgeTestValidStateSampler.h"
+#include "ompl/base/SpaceInformation.h"
+#include "ompl/tools/config/MagicConstants.h"
 
 
 ompl::base::BridgeTestValidStateSampler::BridgeTestValidStateSampler(const SpaceInformation *si)
@@ -28,11 +28,11 @@ bool ompl::base::BridgeTestValidStateSampler::sample(State *state)
     {
         sampler_->sampleUniform(state);
         bool v1 = si_->isValid(state);
-        sampler_->sampleGaussian(endpoint, state, stddev_);
-        bool v2 = si_->isValid(endpoint);
-        if(v1==v2)
+        if(!v1)
         {
-            if(!v1)
+            sampler_->sampleGaussian(endpoint, state, stddev_);
+            bool v2 = si_->isValid(endpoint);
+            if(!v2)
             {
                 si_->getStateSpace()->interpolate(endpoint, state, 0.5, state);
                 valid = si_->isValid(state);
@@ -54,11 +54,11 @@ bool ompl::base::BridgeTestValidStateSampler::sampleNear(State *state, const Sta
     {
         sampler_->sampleUniformNear(state, near, distance);
         bool v1 = si_->isValid(state);
-        sampler_->sampleGaussian(endpoint, state, distance);
-        bool v2 = si_->isValid(endpoint);
-        if(v1==v2)
+        if(!v1)
         {
-            if(!v1)
+            sampler_->sampleGaussian(endpoint, state, distance);
+            bool v2 = si_->isValid(endpoint);
+            if(!v2)
             {
                 si_->getStateSpace()->interpolate(endpoint, state, 0.5, state);
                 valid = si_->isValid(state);

--- a/src/ompl/base/samplers/src/BridgeTestValidStateSampler.cpp
+++ b/src/ompl/base/samplers/src/BridgeTestValidStateSampler.cpp
@@ -39,7 +39,7 @@ bool ompl::base::BridgeTestValidStateSampler::sample(State *state)
             }
         }
         ++attempts;
-    } while (valid && attempts < attempts_);
+    } while (!valid && attempts < attempts_);
 
     si_->freeState(endpoint);
     return valid;
@@ -65,7 +65,7 @@ bool ompl::base::BridgeTestValidStateSampler::sampleNear(State *state, const Sta
             }
         }
         ++attempts;
-    } while (valid && attempts < attempts_);
+    } while (!valid && attempts < attempts_);
 
     si_->freeState(endpoint);
     return valid;

--- a/src/ompl/base/samplers/src/BridgeTestValidStateSampler.cpp
+++ b/src/ompl/base/samplers/src/BridgeTestValidStateSampler.cpp
@@ -1,0 +1,72 @@
+#include "BridgeTestValidStateSampler.h"
+#include <ompl/base/SpaceInformation.h>
+#include <ompl/tools/config/MagicConstants.h>
+
+
+ompl::base::BridgeTestValidStateSampler::BridgeTestValidStateSampler(const SpaceInformation *si)
+  : ValidStateSampler(si), sampler_(si->allocStateSampler())
+    , stddev_(si->getMaximumExtent() * magic::STD_DEV_AS_SPACE_EXTENT_FRACTION)
+{
+    name_ = "bridge_test";
+    params_.declareParam<double>("standard_deviation",
+                                 [this](double stddev)
+                                 {
+                                     setStdDev(stddev);
+                                 },
+                                 [this]
+                                 {
+                                     return getStdDev();
+                                 });
+}
+
+bool ompl::base::BridgeTestValidStateSampler::sample(State *state)
+{
+    unsigned int attempts = 0;
+    bool valid = false;
+    State *endpoint = si_->allocState();
+    do
+    {
+        sampler_->sampleUniform(state);
+        bool v1 = si_->isValid(state);
+        sampler_->sampleGaussian(endpoint, state, stddev_);
+        bool v2 = si_->isValid(endpoint);
+        if(v1==v2)
+        {
+            if(!v1)
+            {
+                si_->getStateSpace()->interpolate(endpoint, state, 0.5, state);
+                valid = si_->isValid(state);
+            }
+        }
+        ++attempts;
+    } while (valid && attempts < attempts_);
+
+    si_->freeState(endpoint);
+    return valid;
+}
+
+bool ompl::base::BridgeTestValidStateSampler::sampleNear(State *state, const State *near, const double distance)
+{
+    unsigned int attempts = 0;
+    bool valid = false;
+    State *endpoint = si_->allocState();
+    do
+    {
+        sampler_->sampleUniformNear(state, near, distance);
+        bool v1 = si_->isValid(state);
+        sampler_->sampleGaussian(endpoint, state, distance);
+        bool v2 = si_->isValid(endpoint);
+        if(v1==v2)
+        {
+            if(!v1)
+            {
+                si_->getStateSpace()->interpolate(endpoint, state, 0.5, state);
+                valid = si_->isValid(state);
+            }
+        }
+        ++attempts;
+    } while (valid && attempts < attempts_);
+
+    si_->freeState(endpoint);
+    return valid;
+}


### PR DESCRIPTION
Implements the bridge-test sampler, described in "The bridge test for sampling narrow passages with probabilistic roadmap planners" by Hsu, et al.

Has been tested for a spherical robot on the plane:

<img src="https://user-images.githubusercontent.com/1220541/34032155-07743ce2-e1b8-11e7-90f6-695cdf9dd977.png" width="300"><img src="https://user-images.githubusercontent.com/1220541/34032154-07319ebe-e1b8-11e7-815c-a4d5cb19c0f8.png" width="300">
Left: Obstacle-Based Sampler (ObstacleBasedValidStateSampler.h), Right: Bridge-Test Sampler (BridgeTestValidStateSampler.h)

