### PR TITLE
Add missing parameter in TypedSpaceInformation::cloneTypedState()

### DIFF
--- a/src/ompl/base/TypedSpaceInformation.h
+++ b/src/ompl/base/TypedSpaceInformation.h
@@ -121,7 +121,7 @@ namespace ompl
             /** Clone a state of the proper type. */
             StateType *cloneTypedState(const StateType *source) const
             {
-                return this->cloneState()->template as<StateType>();
+                return this->cloneState(source)->template as<StateType>();
             }
 
             static StateType *state_as(ompl::base::State *s)


### PR DESCRIPTION
The missing parameter is caught by newer GCC versions doing stricter template checks.