### PR TITLE
Small Change to BFMT* to Work with Multiple Goal Seeding (and in MoveIt!)

### DIFF
--- a/src/ompl/geometric/planners/fmt/src/BFMT.cpp
+++ b/src/ompl/geometric/planners/fmt/src/BFMT.cpp
@@ -560,8 +560,11 @@ namespace ompl
             // add nodes in Open_new to Open
             for (auto &i : Open_new)
             {
-                Open_elements[tree_][i] = Open_[tree_].insert(i);
-                i->setCurrentSet(BiDirMotion::SET_OPEN);
+                if(Open_elements[tree_][i] == nullptr)
+                {
+                    Open_elements[tree_][i] = Open_[tree_].insert(i);
+                    i->setCurrentSet(BiDirMotion::SET_OPEN);
+                }
             }
         }
 


### PR DESCRIPTION
MoveIt! seeds the BFMT* with multiple goal points. The BFMT* code theoretically should allow for that, as it pulls in multiple goals points. The code uses a map and a heap structure to determine the open node to next search from; however, multiples of the same node can be added to the heap structure (and cannot be added to the map structure). This causes a segmentation fault, as the code will eventually try to remove a node from the map that was already removed, due to a duplicate existing in the heap but not in the map. 

The change does a simple check to see if the map already has the element before inserting said element into the heap. If the element is NOT in the map already, then it will be added to the map and the heap. Otherwise, the element is ignored, as it already exists in the map and the heap structure.