### PR TITLE
Do not localize params

### DIFF
--- a/src/ompl/base/GenericParam.h
+++ b/src/ompl/base/GenericParam.h
@@ -42,6 +42,7 @@
 #include <functional>
 #include <iostream>
 #include <string>
+#include <sstream>
 #include <utility>
 #include <vector>
 #include <map>
@@ -175,10 +176,15 @@ namespace ompl
 
             std::string getValue() const override
             {
-                if (getter_)
-                    return std::to_string(getter_());
-                else
+                if (getter_) {
+                    // convert to string using no locale
+                    std::ostringstream oss;
+                    oss.imbue(std::locale::classic());
+                    oss << getter_();
+                    return oss.str();
+                } else {
                     return "";
+                }
             }
 
         protected:

--- a/src/ompl/base/src/GenericParam.cpp
+++ b/src/ompl/base/src/GenericParam.cpp
@@ -37,6 +37,7 @@
 #include "ompl/base/GenericParam.h"
 #include "ompl/util/Exception.h"
 #include <limits>
+#include <sstream>
 
 namespace ompl
 {
@@ -78,20 +79,34 @@ namespace ompl
         {
             return std::stoull(value);
         }
+
+        template <class OutType>
+        OutType toRealImpl(const std::string& s)
+        {
+            // convert from string using no locale
+            std::istringstream stream(s);
+            stream.imbue(std::locale::classic());
+            OutType result;
+            stream >> result;
+            if (stream.fail() || !stream.eof())
+                throw std::runtime_error("Failed converting string to real number");
+            return result;
+        }
+
         template <>
         float SpecificParam<float>::lexical_cast(const std::string &value) const
         {
-            return std::stof(value);
+            return toRealImpl<float>(value);
         }
         template <>
         double SpecificParam<double>::lexical_cast(const std::string &value) const
         {
-            return std::stod(value);
+            return toRealImpl<double>(value);
         }
         template <>
         long double SpecificParam<long double>::lexical_cast(const std::string &value) const
         {
-            return std::stold(value);
+            return toRealImpl<long double>(value);
         }
         template <>
         char SpecificParam<char>::lexical_cast(const std::string &value) const


### PR DESCRIPTION
This is a very basic fix for the issue described in https://bitbucket.org/ompl/ompl/issues/496/localization-errors-or-the-tale-of-decimal

Details are given in the issue but in brief it solves the following problem: after the switch from `boost::lexical_cast` to `std::stof` and `std::to_string` parameters are handled as locale dependent. I.e. "longest_valid_segment_fraction" needs to be passed in as "0,1" if you use an European locale. Also it will be returned in the same format. 

This could be improved by having a ompl::to_string that handles all types correctly (ie using std::to_string for integers and this code for real variables) but I wanted to have some feedback first. Another possibility would be to do some template specialization on `SpecificParam::getValue` or do some `enable_if` template stuff