### PR TITLE
fix triangle inequality check in StateSpace::sanityChecks

### DIFF
--- a/src/ompl/base/src/StateSpace.cpp
+++ b/src/ompl/base/src/StateSpace.cpp
@@ -692,7 +692,7 @@ void ompl::base::StateSpace::sanityChecks(double zero, double eps, unsigned int 
 
             interpolate(s1, s2, 0.5, s3);
             double diff = distance(s1, s3) + distance(s3, s2) - distance(s1, s2);
-            if ((flags & STATESPACE_TRIANGLE_INEQUALITY) && fabs(diff) > eps)
+            if ((flags & STATESPACE_TRIANGLE_INEQUALITY) && diff < -eps)
                 throw Exception("Interpolation to midpoint state does not lead to distances that satisfy the triangle "
                                 "inequality (" +
                                 ompl::toString(diff) + " difference)");


### PR DESCRIPTION
Hi,
It seems to me that this check is wrong. It ensures that d(s1,s2) = d(s1,s3)+d(s3,s2), while it is expected to ensure that (triangle inequality) d(s1,s2) <= d(s1,s3)+d(s3,s2). Otherwise it may be the exception message that should be corrected.

Here is how I would have done it.

Hope I'm not misunderstanding something here :)

Cheers,
JW