### PR TITLE
Bug/dependent parameters not updated for EST and TRRT

### DIFF
--- a/src/ompl/geometric/planners/est/EST.h
+++ b/src/ompl/geometric/planners/est/EST.h
@@ -100,6 +100,9 @@ namespace ompl
             void setRange(double distance)
             {
                 maxDistance_ = distance;
+                // Make the neighborhood radius smaller than sampling range to
+                // keep probabilities relatively high for rejection sampling
+                nbrhoodRadius_ = maxDistance_ / 3.0;
             }
 
             /** \brief Get the range the planner is using */

--- a/src/ompl/geometric/planners/est/src/BiEST.cpp
+++ b/src/ompl/geometric/planners/est/src/BiEST.cpp
@@ -57,15 +57,12 @@ void ompl::geometric::BiEST::setup()
 {
     Planner::setup();
 
-    if (maxDistance_ < 1e-3)
-    {
-        tools::SelfConfig sc(si_, getName());
-        sc.configurePlannerRange(maxDistance_);
+    tools::SelfConfig sc(si_, getName());
+    sc.configurePlannerRange(maxDistance_);
 
-        // Make the neighborhood radius smaller than sampling range to
-        // keep probabilities relatively high for rejection sampling
-        nbrhoodRadius_ = maxDistance_ / 3.0;
-    }
+    // Make the neighborhood radius smaller than sampling range to
+    // keep probabilities relatively high for rejection sampling
+    nbrhoodRadius_ = maxDistance_ / 3.0;
 
     if (!nnStart_)
         nnStart_.reset(tools::SelfConfig::getDefaultNearestNeighbors<Motion *>(this));

--- a/src/ompl/geometric/planners/rrt/TRRT.h
+++ b/src/ompl/geometric/planners/rrt/TRRT.h
@@ -167,6 +167,7 @@ namespace ompl
             void setInitTemperature(double initTemperature)
             {
                 initTemperature_ = initTemperature;
+                temp_ = initTemperature_;
             }
 
             /** \brief Get the temperature at the start of planning. */

--- a/src/ompl/geometric/planners/rrt/src/RRTConnect.cpp
+++ b/src/ompl/geometric/planners/rrt/src/RRTConnect.cpp
@@ -267,7 +267,7 @@ ompl::base::PlannerStatus ompl::geometric::RRTConnect::solve(const base::Planner
 
             /* attempt to connect trees */
 
-            /* if reached, it means we used rstate directly, no need top copy again */
+            /* if reached, it means we used rstate directly, no need to copy again */
             if (gs != REACHED)
                 si_->copyState(rstate, tgi.xstate);
 


### PR DESCRIPTION
Some planners have dependent parameters  on other primary parameters which can be set externally using the setParam().  However, if the primary  parameters  change and setup is not called afterwards, in the case of EST planner and the TRRT planner  the dependent parameters are not updated . This PR fixes this by updating the dependent  parameters when the setters of the original parameters are called.   