### PR TITLE
Set BOOST_MATH_NO_LONG_DOUBLE_MATH_FUNCTIONS definition

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -41,6 +41,8 @@ if(MSVC)
 endif(MSVC)
 # Ensure dynamic linking with boost unit_test_framework
 add_definitions(-DBOOST_TEST_DYN_LINK)
+# Avoid valgrind error due to overflow error, cf. https://bitbucket.org/ompl/ompl/issues/543
+add_definitions(-DBOOST_MATH_NO_LONG_DOUBLE_MATH_FUNCTIONS)
 
 set_package_properties(Boost PROPERTIES
     URL "http://boost.org"


### PR DESCRIPTION
- Avoids overflow error when running under Valgrind
- Resolves issue described in https://bitbucket.org/ompl/ompl/issues/543