### PR TITLE
Reorganize planner termination conditions and add cost convergence termination condition.

### DIFF
--- a/doc/header.html
+++ b/doc/header.html
@@ -38,6 +38,7 @@
               <a class="dropdown-item omplapp" href="webapp.html">OMPL web app</a>
               <a class="dropdown-item" href="python.html">Python Bindings</a>
               <a class="dropdown-item" href="planners.html">Available Planners</a>
+              <a class="dropdown-item" href="plannerTerminationConditions">Planner Termination Conditions</a>
               <a class="dropdown-item" href="benchmark.html">Benchmarking Planners</a>
               <a class="dropdown-item" href="spaces.html">Available State Spaces</a>
               <a class="dropdown-item" href="optimalPlanning.html">Optimal Planning</a>

--- a/doc/markdown/plannerTerminationConditions.md
+++ b/doc/markdown/plannerTerminationConditions.md
@@ -1,0 +1,23 @@
+# Planner Termination Conditions {#plannerTerminationConditions}
+
+OMPL uses the ompl::base::PlannerTerminationCondition concept to let planning algorithms know that an attempt to solve a motion planning problem should be terminated. This is done by passing an instance of an ompl::base::PlannerTerminationCondition to a planner's solve method. A PlannerTerminationCondition instance is essentially a functor that can be called with zero arguments that returns `true` when the planner should terminate. For convenience, there is also a cast-to-bool operator defined so the following two is statements are equivalent:
+
+~~~{.cpp}
+// ptc is an instance of ompl::base::PlannerTerminationCondition
+if (ptc()) return;
+if (ptc) return;
+~~~
+
+OMPL implements several different conditions that you can use:
+
+- `timedPlannerTerminationCondition(duration)`: a **function** that returns a PlannerTerminationCondition instance that causes the planner to terminate after a fixed amount of time has been exceeded.
+- `timedPlannerTerminationCondition(duration, interval)`: a **function** that returns a PlannerTerminationCondition instance that causes the planner to terminate after a fixed amount of time has been exceeded. Unlike the previous function, this one spawns a separate thread where the time passed is checked every `interval` seconds. 
+- `IterationTerminationCondition(numIterations)`: a PlannerTerminationCondition-derived **class** that causes a planner to terminate after its `eval()` method has been called `numIterations` times.
+- `CostConvergenceTerminationCondition(pdef, solutionsWindow, convergenceThreshold)`: a PlannerTerminationCondition-derived **class** that causes an *optimizing* planner  to terminate once the cost for the best path has converged, which is defined as 
+- `exactSolnPlannerTerminationCondition()`: a **function** that returns a PlannerTerminationCondition instance that causes the planner to terminate after an exact solution has been found.
+- `plannerNonTerminatingCondition()`: a **function** that returns a PlannerTerminationCondition instance that causes the planner to never terminate.
+- `plannerAlwaysTerminatingCondition()`: a **function** that returns a PlannerTerminationCondition instance that causes the planner to immediately terminate.
+- `plannerOrTerminationCondition(c1, c2)`: a **function** that, given two PlannerTerminationCondition instances c1 and c2, returns a PlannerTerminationCondition instance that causes the planner to terminate when either returns `true`.
+- `plannerAndTerminationCondition(c1, c2)`: a **function** that, given two PlannerTerminationCondition instances c1 and c2, returns a PlannerTerminationCondition instance that causes the planner to terminate when both return `true`.
+
+If the MORSE extension is enabled, the `ompl::base::MorseTerminationCondition` is also available, which is a PlannerTerminationCondition-derived **class** that causes a planner to terminate if the user shuts down the MORSE simulation.

--- a/py-bindings/headers_base.txt
+++ b/py-bindings/headers_base.txt
@@ -66,4 +66,6 @@ src/ompl/base/samplers/InformedStateSampler.h
 src/ompl/base/samplers/informed/PathLengthDirectInfSampler.h
 src/ompl/base/samplers/informed/RejectionInfSampler.h
 src/ompl/base/samplers/informed/OrderedInfSampler.h
+src/ompl/base/terminationconditions/CostConvergenceTerminationCondition.h
+src/ompl/base/terminationconditions/IterationTerminationCondition.h
 py-bindings/ompl_py_base.h

--- a/src/ompl/base/PlannerTerminationCondition.h
+++ b/src/ompl/base/PlannerTerminationCondition.h
@@ -130,37 +130,6 @@ namespace ompl
         /** \brief Return a termination condition that will become true as soon as the problem definition has an exact
          * solution */
         PlannerTerminationCondition exactSolnPlannerTerminationCondition(const ompl::base::ProblemDefinitionPtr &pdef);
-
-        /** \brief A class to run a planner for a specific number of iterations. Casts to a PTC for use with
-         * Planner::solve */
-        class IterationTerminationCondition
-        {
-        public:
-            /** \brief Construct a termination condition that can be evaluated numIterations times before returning
-             * true. */
-            IterationTerminationCondition(unsigned int numIterations);
-
-            /** \brief Increment the number of times eval has been called and check if the planner should now terminate.
-             */
-            bool eval();
-
-            /** \brief Reset the number of times the IterationTeriminationCondition has been called. */
-            void reset();
-
-            /** \brief Cast to a PlannerTerminationCondition */
-            operator PlannerTerminationCondition();
-
-            unsigned int getTimesCalled() const
-            {
-                return timesCalled_;
-            }
-
-        private:
-            /** \brief The max number of iterations the condition can be called before returning true. */
-            unsigned int maxCalls_;
-            /** \brief The number of times called so far.*/
-            unsigned int timesCalled_;
-        };
     }
 }
 

--- a/src/ompl/base/src/PlannerTerminationCondition.cpp
+++ b/src/ompl/base/src/PlannerTerminationCondition.cpp
@@ -245,34 +245,3 @@ ompl::base::exactSolnPlannerTerminationCondition(const ompl::base::ProblemDefini
                                            return pdef->hasExactSolution();
                                        });
 }
-
-namespace ompl
-{
-    namespace base
-    {
-        IterationTerminationCondition::IterationTerminationCondition(unsigned int numIterations)
-          : maxCalls_(numIterations), timesCalled_(0u)
-        {
-        }
-
-        bool IterationTerminationCondition::eval()
-        {
-            ++timesCalled_;
-
-            return (timesCalled_ > maxCalls_);
-        }
-
-        void IterationTerminationCondition::reset()
-        {
-            timesCalled_ = 0u;
-        }
-
-        IterationTerminationCondition::operator PlannerTerminationCondition()
-        {
-            return PlannerTerminationCondition([this]
-                                               {
-                                                   return eval();
-                                               });
-        }
-    }
-}

--- a/src/ompl/base/terminationconditions/CostConvergenceTerminationCondition.h
+++ b/src/ompl/base/terminationconditions/CostConvergenceTerminationCondition.h
@@ -1,0 +1,65 @@
+/*********************************************************************
+ * Software License Agreement (BSD License)
+ *
+ *  Copyright (c) 2019, PickNik LLC
+ *  All rights reserved.
+ *
+ *  Redistribution and use in source and binary forms, with or without
+ *  modification, are permitted provided that the following conditions
+ *  are met:
+ *
+ *   * Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *   * Redistributions in binary form must reproduce the above
+ *     copyright notice, this list of conditions and the following
+ *     disclaimer in the documentation and/or other materials provided
+ *     with the distribution.
+ *   * Neither the name of the PickNik LLC nor the names of its
+ *     contributors may be used to endorse or promote products derived
+ *     from this software without specific prior written permission.
+ *
+ *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ *  "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ *  LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ *  FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ *  COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ *  INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ *  BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ *  LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ *  CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ *  LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ *  ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ *  POSSIBILITY OF SUCH DAMAGE.
+ *********************************************************************/
+
+/* Author: Henning Kayser, Mark Moll */
+/* Description: A termination condition for early-stopping OMPL optimizing
+   planners based on cost-convergence. */
+
+#include "ompl/base/PlannerTerminationCondition.h"
+
+namespace ompl
+{
+    namespace base
+    {
+        class CostConvergenceTerminationCondition : public PlannerTerminationCondition
+        {
+        public:
+            CostConvergenceTerminationCondition(ProblemDefinitionPtr &pdef, size_t solutionsWindow = 10,
+                                                double convergenceThreshold = 0.9);
+
+            // Compute the running average cost of the last solutions (solutionWindow)
+            // and terminate if the cost of a new solution is worse than
+            // convergenceThreshold times the average cost.
+            void processNewSolution(const Cost solutionCost);
+
+        private:
+            ProblemDefinitionPtr pdef_;
+            double averageCost_{0.};
+            size_t solutions_{0};
+
+            const size_t solutionsWindow_;
+            const double convergenceThreshold_;
+        };
+    }  // namespace base
+}  // namespace ompl

--- a/src/ompl/base/terminationconditions/IterationTerminationCondition.h
+++ b/src/ompl/base/terminationconditions/IterationTerminationCondition.h
@@ -1,0 +1,74 @@
+/*********************************************************************
+ * Software License Agreement (BSD License)
+ *
+ *  Copyright (c) 2019, Rice University
+ *  All rights reserved.
+ *
+ *  Redistribution and use in source and binary forms, with or without
+ *  modification, are permitted provided that the following conditions
+ *  are met:
+ *
+ *   * Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *   * Redistributions in binary form must reproduce the above
+ *     copyright notice, this list of conditions and the following
+ *     disclaimer in the documentation and/or other materials provided
+ *     with the distribution.
+ *   * Neither the name of the Rice University nor the names of its
+ *     contributors may be used to endorse or promote products derived
+ *     from this software without specific prior written permission.
+ *
+ *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ *  "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ *  LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ *  FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ *  COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ *  INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ *  BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ *  LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ *  CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ *  LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ *  ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ *  POSSIBILITY OF SUCH DAMAGE.
+ *********************************************************************/
+
+/* Author: Mark Moll */
+
+#include "ompl/base/PlannerTerminationCondition.h"
+
+namespace ompl
+{
+    namespace base
+    {
+        /** \brief A class to run a planner for a specific number of iterations. Casts to a PTC for use with
+         * Planner::solve */
+        class IterationTerminationCondition
+        {
+        public:
+            /** \brief Construct a termination condition that can be evaluated numIterations times before returning
+             * true. */
+            IterationTerminationCondition(unsigned int numIterations);
+
+            /** \brief Increment the number of times eval has been called and check if the planner should now terminate.
+             */
+            bool eval();
+
+            /** \brief Reset the number of times the IterationTeriminationCondition has been called. */
+            void reset();
+
+            /** \brief Cast to a PlannerTerminationCondition */
+            operator PlannerTerminationCondition();
+
+            unsigned int getTimesCalled() const
+            {
+                return timesCalled_;
+            }
+
+        private:
+            /** \brief The max number of iterations the condition can be called before returning true. */
+            unsigned int maxCalls_;
+            /** \brief The number of times called so far.*/
+            unsigned int timesCalled_;
+        };
+    }  // namespace base
+}  // namespace ompl

--- a/src/ompl/base/terminationconditions/src/CostConvergenceTerminationCondition.cpp
+++ b/src/ompl/base/terminationconditions/src/CostConvergenceTerminationCondition.cpp
@@ -1,0 +1,65 @@
+/*********************************************************************
+* Software License Agreement (BSD License)
+*
+*  Copyright (c) 2019, PickNik LLC
+*  All rights reserved.
+*
+*  Redistribution and use in source and binary forms, with or without
+*  modification, are permitted provided that the following conditions
+*  are met:
+*
+*   * Redistributions of source code must retain the above copyright
+*     notice, this list of conditions and the following disclaimer.
+*   * Redistributions in binary form must reproduce the above
+*     copyright notice, this list of conditions and the following
+*     disclaimer in the documentation and/or other materials provided
+*     with the distribution.
+*   * Neither the name of the PickNik LLC nor the names of its
+*     contributors may be used to endorse or promote products derived
+*     from this software without specific prior written permission.
+*
+*  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+*  "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+*  LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+*  FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+*  COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+*  INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+*  BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+*  LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+*  CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+*  LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+*  ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+*  POSSIBILITY OF SUCH DAMAGE.
+*********************************************************************/
+
+/* Author: Henning Kayser, Mark Moll */
+
+#include "ompl/base/OptimizationObjective.h"
+#include "ompl/base/terminationconditions/CostConvergenceTerminationCondition.h"
+
+ompl::base::CostConvergenceTerminationCondition::CostConvergenceTerminationCondition(
+    ompl::base::ProblemDefinitionPtr &pdef, size_t solutionsWindow, double convergenceThreshold)
+    : ompl::base::PlannerTerminationCondition(ompl::base::plannerNonTerminatingCondition()),
+      pdef_(pdef),
+      solutionsWindow_(solutionsWindow),
+      convergenceThreshold_(convergenceThreshold)
+{
+    pdef_->setIntermediateSolutionCallback(
+	    [this](const Planner* /*planner*/, const std::vector<const State*>& /*states*/, const Cost cost) {
+	        this->processNewSolution(cost);
+	    });
+}
+
+void ompl::base::CostConvergenceTerminationCondition::processNewSolution(const ompl::base::Cost solutionCost)
+{
+    ++solutions_;
+    size_t solutions = std::min(solutions_, solutionsWindow_);
+    Cost newCost(((solutions - 1) * averageCost_ + solutionCost.value()) / solutions);
+
+    if (solutions == solutionsWindow_ && pdef_->getOptimizationObjective()->isCostBetterThan(
+        Cost(convergenceThreshold_ * averageCost_), newCost))
+    {
+        OMPL_DEBUG("CostConvergenceTerminationCondition: Cost of optimizing planner converged after %lu solutions", solutions_);
+        terminate();
+    }
+}

--- a/src/ompl/base/terminationconditions/src/IterationTerminationCondition.cpp
+++ b/src/ompl/base/terminationconditions/src/IterationTerminationCondition.cpp
@@ -1,0 +1,59 @@
+/*********************************************************************
+ * Software License Agreement (BSD License)
+ *
+ *  Copyright (c) 2019, Rice University
+ *  All rights reserved.
+ *
+ *  Redistribution and use in source and binary forms, with or without
+ *  modification, are permitted provided that the following conditions
+ *  are met:
+ *
+ *   * Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *   * Redistributions in binary form must reproduce the above
+ *     copyright notice, this list of conditions and the following
+ *     disclaimer in the documentation and/or other materials provided
+ *     with the distribution.
+ *   * Neither the name of the Rice University nor the names of its
+ *     contributors may be used to endorse or promote products derived
+ *     from this software without specific prior written permission.
+ *
+ *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ *  "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ *  LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ *  FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ *  COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ *  INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ *  BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ *  LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ *  CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ *  LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ *  ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ *  POSSIBILITY OF SUCH DAMAGE.
+ *********************************************************************/
+
+/* Author: Mark Moll */
+
+#include "ompl/base/terminationconditions/IterationTerminationCondition.h"
+
+ompl::base::IterationTerminationCondition::IterationTerminationCondition(unsigned int numIterations)
+  : maxCalls_(numIterations), timesCalled_(0u)
+{
+}
+
+bool ompl::base::IterationTerminationCondition::eval()
+{
+    ++timesCalled_;
+
+    return (timesCalled_ > maxCalls_);
+}
+
+void ompl::base::IterationTerminationCondition::reset()
+{
+    timesCalled_ = 0u;
+}
+
+ompl::base::IterationTerminationCondition::operator PlannerTerminationCondition()
+{
+    return PlannerTerminationCondition([this] { return eval(); });
+}


### PR DESCRIPTION
- Add documentation for all planner termination conditions on one page
accessible from the web site's documentation menu.
- Update Python bindings.