### PR TITLE
SimpleSetup cleanup

### DIFF
--- a/src/ompl/geometric/SimpleSetup.h
+++ b/src/ompl/geometric/SimpleSetup.h
@@ -139,13 +139,16 @@ namespace ompl
 
             /** \brief Return true if a solution path is available (previous call to solve() was successful) and the
              * solution is exact (not approximate) */
-            bool haveExactSolutionPath() const;
+            bool haveExactSolutionPath() const
+            {
+                return pdef_->hasExactSolution();
+            }
 
             /** \brief Return true if a solution path is available (previous call to solve() was successful). The
              * solution may be approximate. */
             bool haveSolutionPath() const
             {
-                return pdef_->getSolutionPath() != nullptr;
+                return pdef_->hasSolution();
             }
 
             /** \brief Get the best solution's planer name. Throw an exception if no solution is available */

--- a/src/ompl/geometric/src/SimpleSetup.cpp
+++ b/src/ompl/geometric/src/SimpleSetup.cpp
@@ -214,12 +214,6 @@ ompl::geometric::PathGeometric &ompl::geometric::SimpleSetup::getSolutionPath() 
     throw Exception("No solution path");
 }
 
-bool ompl::geometric::SimpleSetup::haveExactSolutionPath() const
-{
-    return haveSolutionPath() && (!pdef_->hasApproximateSolution() ||
-                                  pdef_->getSolutionDifference() < std::numeric_limits<double>::epsilon());
-}
-
 void ompl::geometric::SimpleSetup::getPlannerData(base::PlannerData &pd) const
 {
     pd.clear();


### PR DESCRIPTION
This fixes an inconsistency between what `SimpleSetup` and `ProblemDefinition` considers an exact solution by passing through `SimpleSetup`'s calls.

This specifically removes the
```
pdef_->getSolutionDifference() < std::numeric_limits<double>::epsilon()
```
check that `SimpleSetup` was doing to decide if a solution was exact and instead reports what the planner actually returned in its `PlannerStatus` flag.

The existing behaviour caused a bug with RRTConnect when searching from a goal area (https://github.com/ompl/ompl/pull/683).