### PR TITLE
Fix issue in ConstrainedStateSpace geodesicInterpolate when planner range value is small

### DIFF
--- a/src/ompl/base/spaces/constraint/src/ConstrainedStateSpace.cpp
+++ b/src/ompl/base/spaces/constraint/src/ConstrainedStateSpace.cpp
@@ -312,6 +312,7 @@ ompl::base::State *ompl::base::ConstrainedStateSpace::geodesicInterpolate(const 
         const double t2 = (i <= n - 2) ? d[i + 1] / last - t : 1;
 
         delete[] d;
-        return (t1 < t2) ? geodesic[i] : geodesic[i + 1];
+        assert((t1 < t2 || std::abs(t1 - t2) < std::numeric_limits<double>::epsilon())  ? (i < geodesic.size()) : (i + 1 < geodesic.size()));
+        return (t1 < t2 || std::abs(t1 - t2) < std::numeric_limits<double>::epsilon()) ? geodesic[i] : geodesic[i + 1];
     }
 }


### PR DESCRIPTION
I ran into an issue when trying to used constrained planning functionality in OMPL, where if you made the range value for a planner  small (0.01) it would try to index outside the `geodesic`. These changes fix the issue but not being familiar with the code I am not certain this is the correct fix and there may be some other issue elsewhere in the code.