### PR TITLE
Use optimization objective to initialize cost in FMT*

### DIFF
--- a/src/ompl/geometric/planners/fmt/src/FMT.cpp
+++ b/src/ompl/geometric/planners/fmt/src/FMT.cpp
@@ -546,7 +546,7 @@ bool ompl::geometric::FMT::expandTreeFromNode(Motion **z)
         }
 
         // Find the lowest cost-to-come connection from Open to x
-        base::Cost cMin(std::numeric_limits<double>::infinity());
+        base::Cost cMin(opt_->infiniteCost());
         Motion *yMin = getBestParent(x, yNear, cMin);
         yNear.clear();
 


### PR DESCRIPTION
Using `std::numeric_limits<double>::infinity()` assumes that we are minimizing the objective. The fix allows to use maximization objectives (e.g., max min clearance http://ompl.kavrakilab.org/optimizationObjectivesTutorial.html).