### PR TITLE
Make data reference const in newElement method of BinaryHeap

### DIFF
--- a/src/ompl/datastructures/BinaryHeap.h
+++ b/src/ompl/datastructures/BinaryHeap.h
@@ -261,7 +261,7 @@ namespace ompl
                 vector_.pop_back();
         }
 
-        Element *newElement(_T &data, unsigned int pos) const
+        Element *newElement(const _T &data, unsigned int pos) const
         {
             auto *element = new Element();
             element->data = data;


### PR DESCRIPTION
I think this should be a const reference for two reasons. 1) A const reference communicates that the method does not modify the input, and 2) right now `void BinaryHeap::insert(const std::vector<_T> &list)` is broken, because non-const references can not be bound to const references. On line 161 in `ompl/source/ompl/datastructures/BinaryHeap.h` we have:

```c++
Element *element = newElement(list[i], pos);
```
but this fails to compile because `list[i]` effectively returns a `const _T&`, which pre-fix `newElement` tries to bind to a `_T&`. (Sorry, I can't seem to figure out how to comment code directly in the file anymore...).

Since this PR is in quick succession to the last: If I were to find more small fixes, would you prefer it if I held them back until I have found a bunch of them and create a single PR for all or do you prefer a PR per fix?