### PR TITLE
pass interval in timedPlannerTerminationCondition constructor

### DIFF
--- a/src/ompl/base/src/PlannerTerminationCondition.cpp
+++ b/src/ompl/base/src/PlannerTerminationCondition.cpp
@@ -234,7 +234,8 @@ ompl::base::PlannerTerminationCondition ompl::base::timedPlannerTerminationCondi
     return PlannerTerminationCondition([endTime]
                                        {
                                            return time::now() > endTime;
-                                       });
+                                       },
+                                       interval);
 }
 
 ompl::base::PlannerTerminationCondition


### PR DESCRIPTION
It seems that interval is ignored.
I only confirmed that the build passed after this change, and have not confirmed that it actually works