### PR TITLE
Fix compilation with Eigen master branch

### DIFF
--- a/src/ompl/base/src/ProjectionEvaluator.cpp
+++ b/src/ompl/base/src/ProjectionEvaluator.cpp
@@ -200,8 +200,8 @@ namespace ompl
                                                     Eigen::Ref<Eigen::VectorXi> coord)
         {
             // compute floor(projection ./ cellSizes)
-            coord = projection.cwiseQuotient(Eigen::Map<const Eigen::VectorXd>(cellSizes.data(), cellSizes.size()))
-                        .unaryExpr((double (*)(double))std::floor)
+            coord = (projection.array() / Eigen::Map<const Eigen::VectorXd>(cellSizes.data(), cellSizes.size()).array())
+                        .floor()
                         .cast<int>();
         }
     }  // namespace base


### PR DESCRIPTION
compilation with current Eigen master branch failed with c++17 enabled, see the error message below:

```
In file included from /usr/local/include/eigen3/Eigen/Core:261:0,
                 from /opt/ros/melodic/src/ompl/src/ompl/base/ProjectionEvaluator.h:49,
                 from /opt/ros/melodic/src/ompl/src/ompl/base/StateSpace.h:43,
                 from /opt/ros/melodic/src/ompl/src/ompl/base/src/ProjectionEvaluator.cpp:37:
/usr/local/include/eigen3/Eigen/src/Core/CoreEvaluators.h: In instantiation of ‘class Eigen::internal::unary_evaluator<Eigen::CwiseUnaryOp<double (*)(double) throw (), const Eigen::CwiseBinaryOp<Eigen::internal::scalar_quotient_op<double, double>, const Eigen::Ref<Eigen::Matrix<double, -1, 1> >, const Eigen::Map<const Eigen::Matrix<double, -1, 1>, 0, Eigen::Stride<0, 0> > > >, Eigen::internal::IndexBased, double>::Data’:
/usr/local/include/eigen3/Eigen/src/Core/CoreEvaluators.h:619:8:   required from ‘struct Eigen::internal::unary_evaluator<Eigen::CwiseUnaryOp<double (*)(double) throw (), const Eigen::CwiseBinaryOp<Eigen::internal::scalar_quotient_op<double, double>, const Eigen::Ref<Eigen::Matrix<double, -1, 1> >, const Eigen::Map<const Eigen::Matrix<double, -1, 1>, 0, Eigen::Stride<0, 0> > > >, Eigen::internal::IndexBased, double>’
/usr/local/include/eigen3/Eigen/src/Core/CoreEvaluators.h:90:8:   required from ‘struct Eigen::internal::evaluator<Eigen::CwiseUnaryOp<double (*)(double) throw (), const Eigen::CwiseBinaryOp<Eigen::internal::scalar_quotient_op<double, double>, const Eigen::Ref<Eigen::Matrix<double, -1, 1> >, const Eigen::Map<const Eigen::Matrix<double, -1, 1>, 0, Eigen::Stride<0, 0> > > > >’
/usr/local/include/eigen3/Eigen/src/Core/CoreEvaluators.h:100:8:   required from ‘struct Eigen::internal::evaluator<const Eigen::CwiseUnaryOp<double (*)(double) throw (), const Eigen::CwiseBinaryOp<Eigen::internal::scalar_quotient_op<double, double>, const Eigen::Ref<Eigen::Matrix<double, -1, 1> >, const Eigen::Map<const Eigen::Matrix<double, -1, 1>, 0, Eigen::Stride<0, 0> > > > >’
/usr/local/include/eigen3/Eigen/src/Core/CoreEvaluators.h:564:55:   required from ‘struct Eigen::internal::unary_evaluator<Eigen::CwiseUnaryOp<Eigen::internal::scalar_cast_op<double, int>, const Eigen::CwiseUnaryOp<double (*)(double) throw (), const Eigen::CwiseBinaryOp<Eigen::internal::scalar_quotient_op<double, double>, const Eigen::Ref<Eigen::Matrix<double, -1, 1> >, const Eigen::Map<const Eigen::Matrix<double, -1, 1>, 0, Eigen::Stride<0, 0> > > > >, Eigen::internal::IndexBased, int>’
/usr/local/include/eigen3/Eigen/src/Core/CoreEvaluators.h:90:8:   required from ‘struct Eigen::internal::evaluator<Eigen::CwiseUnaryOp<Eigen::internal::scalar_cast_op<double, int>, const Eigen::CwiseUnaryOp<double (*)(double) throw (), const Eigen::CwiseBinaryOp<Eigen::internal::scalar_quotient_op<double, double>, const Eigen::Ref<Eigen::Matrix<double, -1, 1> >, const Eigen::Map<const Eigen::Matrix<double, -1, 1>, 0, Eigen::Stride<0, 0> > > > > >’
/usr/local/include/eigen3/Eigen/src/Core/Ref.h:44:26:   required from ‘struct Eigen::internal::traits<Eigen::Ref<Eigen::Matrix<int, -1, 1> > >::match<Eigen::CwiseUnaryOp<Eigen::internal::scalar_cast_op<double, int>, const Eigen::CwiseUnaryOp<double (*)(double) throw (), const Eigen::CwiseBinaryOp<Eigen::internal::scalar_quotient_op<double, double>, const Eigen::Ref<Eigen::Matrix<double, -1, 1> >, const Eigen::Map<const Eigen::Matrix<double, -1, 1>, 0, Eigen::Stride<0, 0> > > > > >’
/usr/local/include/eigen3/Eigen/src/Core/Ref.h:202:63:   required by substitution of ‘template<class Derived> Eigen::Ref<Eigen::Matrix<int, -1, 1> >::Ref(const Eigen::DenseBase<Derived>&, typename Eigen::internal::enable_if<(bool)(Eigen::internal::traits<Eigen::Ref<Eigen::Matrix<int, -1, 1> > >::match<Derived>::MatchAtCompileTime), Derived>::type*) [with Derived = Eigen::CwiseUnaryOp<Eigen::internal::scalar_cast_op<double, int>, const Eigen::CwiseUnaryOp<double (*)(double) throw (), const Eigen::CwiseBinaryOp<Eigen::internal::scalar_quotient_op<double, double>, const Eigen::Ref<Eigen::Matrix<double, -1, 1> >, const Eigen::Map<const Eigen::Matrix<double, -1, 1>, 0, Eigen::Stride<0, 0> > > > >]’
/opt/ros/melodic/src/ompl/src/ompl/base/src/ProjectionEvaluator.cpp:205:36:   required from here
/usr/local/include/eigen3/Eigen/src/Core/CoreEvaluators.h:609:9: error: base type ‘double (*)(double) throw ()’ fails to be a struct or class type
   class Data : private UnaryOp
         ^~~~
/usr/local/include/eigen3/Eigen/src/Core/CoreEvaluators.h: In instantiation of ‘const UnaryOp& Eigen::internal::unary_evaluator<Eigen::CwiseUnaryOp<UnaryOp, ArgType>, Eigen::internal::IndexBased>::Data::func() const [with UnaryOp = double (*)(double) throw (); ArgType = const Eigen::CwiseBinaryOp<Eigen::internal::scalar_quotient_op<double, double>, const Eigen::Ref<Eigen::Matrix<double, -1, 1> >, const Eigen::Map<const Eigen::Matrix<double, -1, 1>, 0, Eigen::Stride<0, 0> > >]’:
/usr/local/include/eigen3/Eigen/src/Core/CoreEvaluators.h:589:22:   recursively required from ‘Eigen::internal::unary_evaluator<Eigen::CwiseUnaryOp<UnaryOp, ArgType>, Eigen::internal::IndexBased>::CoeffReturnType Eigen::internal::unary_evaluator<Eigen::CwiseUnaryOp<UnaryOp, ArgType>, Eigen::internal::IndexBased>::coeff(Eigen::Index) const [with UnaryOp = double (*)(double) throw (); ArgType = const Eigen::CwiseBinaryOp<Eigen::internal::scalar_quotient_op<double, double>, const Eigen::Ref<Eigen::Matrix<double, -1, 1> >, const Eigen::Map<const Eigen::Matrix<double, -1, 1>, 0, Eigen::Stride<0, 0> > >; typename Eigen::CwiseUnaryOp<UnaryOp, ArgType>::Scalar = double; Eigen::internal::unary_evaluator<Eigen::CwiseUnaryOp<UnaryOp, ArgType>, Eigen::internal::IndexBased>::CoeffReturnType = double; Eigen::Index = long int]’
/usr/local/include/eigen3/Eigen/src/Core/CoreEvaluators.h:589:22:   required from ‘Eigen::internal::unary_evaluator<Eigen::CwiseUnaryOp<UnaryOp, ArgType>, Eigen::internal::IndexBased>::CoeffReturnType Eigen::internal::unary_evaluator<Eigen::CwiseUnaryOp<UnaryOp, ArgType>, Eigen::internal::IndexBased>::coeff(Eigen::Index) const [with UnaryOp = Eigen::internal::scalar_cast_op<double, int>; ArgType = const Eigen::CwiseUnaryOp<double (*)(double) throw (), const Eigen::CwiseBinaryOp<Eigen::internal::scalar_quotient_op<double, double>, const Eigen::Ref<Eigen::Matrix<double, -1, 1> >, const Eigen::Map<const Eigen::Matrix<double, -1, 1>, 0, Eigen::Stride<0, 0> > > >; typename Eigen::CwiseUnaryOp<UnaryOp, ArgType>::Scalar = int; Eigen::internal::unary_evaluator<Eigen::CwiseUnaryOp<UnaryOp, ArgType>, Eigen::internal::IndexBased>::CoeffReturnType = int; Eigen::Index = long int]’
/usr/local/include/eigen3/Eigen/src/Core/AssignEvaluator.h:642:5:   required from ‘void Eigen::internal::generic_dense_assignment_kernel<DstEvaluatorTypeT, SrcEvaluatorTypeT, Functor, Version>::assignCoeff(Eigen::Index) [with DstEvaluatorTypeT = Eigen::internal::evaluator<Eigen::Ref<Eigen::Matrix<int, -1, 1> > >; SrcEvaluatorTypeT = Eigen::internal::evaluator<Eigen::CwiseUnaryOp<Eigen::internal::scalar_cast_op<double, int>, const Eigen::CwiseUnaryOp<double (*)(double) throw (), const Eigen::CwiseBinaryOp<Eigen::internal::scalar_quotient_op<double, double>, const Eigen::Ref<Eigen::Matrix<double, -1, 1> >, const Eigen::Map<const Eigen::Matrix<double, -1, 1>, 0, Eigen::Stride<0, 0> > > > > >; Functor = Eigen::internal::assign_op<int, int>; int Version = 0; Eigen::Index = long int]’
/usr/local/include/eigen3/Eigen/src/Core/AssignEvaluator.h:501:7:   required from ‘static void Eigen::internal::dense_assignment_loop<Kernel, 1, 0>::run(Kernel&) [with Kernel = Eigen::internal::generic_dense_assignment_kernel<Eigen::internal::evaluator<Eigen::Ref<Eigen::Matrix<int, -1, 1> > >, Eigen::internal::evaluator<Eigen::CwiseUnaryOp<Eigen::internal::scalar_cast_op<double, int>, const Eigen::CwiseUnaryOp<double (*)(double) throw (), const Eigen::CwiseBinaryOp<Eigen::internal::scalar_quotient_op<double, double>, const Eigen::Ref<Eigen::Matrix<double, -1, 1> >, const Eigen::Map<const Eigen::Matrix<double, -1, 1>, 0, Eigen::Stride<0, 0> > > > > >, Eigen::internal::assign_op<int, int>, 0>]’
/usr/local/include/eigen3/Eigen/src/Core/AssignEvaluator.h:767:37:   required from ‘void Eigen::internal::call_dense_assignment_loop(DstXprType&, const SrcXprType&, const Functor&) [with DstXprType = Eigen::Ref<Eigen::Matrix<int, -1, 1> >; SrcXprType = Eigen::CwiseUnaryOp<Eigen::internal::scalar_cast_op<double, int>, const Eigen::CwiseUnaryOp<double (*)(double) throw (), const Eigen::CwiseBinaryOp<Eigen::internal::scalar_quotient_op<double, double>, const Eigen::Ref<Eigen::Matrix<double, -1, 1> >, const Eigen::Map<const Eigen::Matrix<double, -1, 1>, 0, Eigen::Stride<0, 0> > > > >; Functor = Eigen::internal::assign_op<int, int>]’
/usr/local/include/eigen3/Eigen/src/Core/AssignEvaluator.h:926:31:   required from ‘static void Eigen::internal::Assignment<DstXprType, SrcXprType, Functor, Eigen::internal::Dense2Dense, Weak>::run(DstXprType&, const SrcXprType&, const Functor&) [with DstXprType = Eigen::Ref<Eigen::Matrix<int, -1, 1> >; SrcXprType = Eigen::CwiseUnaryOp<Eigen::internal::scalar_cast_op<double, int>, const Eigen::CwiseUnaryOp<double (*)(double) throw (), const Eigen::CwiseBinaryOp<Eigen::internal::scalar_quotient_op<double, double>, const Eigen::Ref<Eigen::Matrix<double, -1, 1> >, const Eigen::Map<const Eigen::Matrix<double, -1, 1>, 0, Eigen::Stride<0, 0> > > > >; Functor = Eigen::internal::assign_op<int, int>; Weak = void]’
/usr/local/include/eigen3/Eigen/src/Core/AssignEvaluator.h:862:49:   required from ‘void Eigen::internal::call_assignment_no_alias(Dst&, const Src&, const Func&) [with Dst = Eigen::Ref<Eigen::Matrix<int, -1, 1> >; Src = Eigen::CwiseUnaryOp<Eigen::internal::scalar_cast_op<double, int>, const Eigen::CwiseUnaryOp<double (*)(double) throw (), const Eigen::CwiseBinaryOp<Eigen::internal::scalar_quotient_op<double, double>, const Eigen::Ref<Eigen::Matrix<double, -1, 1> >, const Eigen::Map<const Eigen::Matrix<double, -1, 1>, 0, Eigen::Stride<0, 0> > > > >; Func = Eigen::internal::assign_op<int, int>]’
/usr/local/include/eigen3/Eigen/src/Core/AssignEvaluator.h:830:27:   required from ‘void Eigen::internal::call_assignment(Dst&, const Src&, const Func&, typename Eigen::internal::enable_if<(! Eigen::internal::evaluator_assume_aliasing<Src>::value), void*>::type) [with Dst = Eigen::Ref<Eigen::Matrix<int, -1, 1> >; Src = Eigen::CwiseUnaryOp<Eigen::internal::scalar_cast_op<double, int>, const Eigen::CwiseUnaryOp<double (*)(double) throw (), const Eigen::CwiseBinaryOp<Eigen::internal::scalar_quotient_op<double, double>, const Eigen::Ref<Eigen::Matrix<double, -1, 1> >, const Eigen::Map<const Eigen::Matrix<double, -1, 1>, 0, Eigen::Stride<0, 0> > > > >; Func = Eigen::internal::assign_op<int, int>; typename Eigen::internal::enable_if<(! Eigen::internal::evaluator_assume_aliasing<Src>::value), void*>::type = void*]’
/usr/local/include/eigen3/Eigen/src/Core/AssignEvaluator.h:808:18:   required from ‘void Eigen::internal::call_assignment(Dst&, const Src&) [with Dst = Eigen::Ref<Eigen::Matrix<int, -1, 1> >; Src = Eigen::CwiseUnaryOp<Eigen::internal::scalar_cast_op<double, int>, const Eigen::CwiseUnaryOp<double (*)(double) throw (), const Eigen::CwiseBinaryOp<Eigen::internal::scalar_quotient_op<double, double>, const Eigen::Ref<Eigen::Matrix<double, -1, 1> >, const Eigen::Map<const Eigen::Matrix<double, -1, 1>, 0, Eigen::Stride<0, 0> > > > >]’
/usr/local/include/eigen3/Eigen/src/Core/Assign.h:66:28:   required from ‘Derived& Eigen::MatrixBase<Derived>::operator=(const Eigen::DenseBase<OtherDerived>&) [with OtherDerived = Eigen::CwiseUnaryOp<Eigen::internal::scalar_cast_op<double, int>, const Eigen::CwiseUnaryOp<double (*)(double) throw (), const Eigen::CwiseBinaryOp<Eigen::internal::scalar_quotient_op<double, double>, const Eigen::Ref<Eigen::Matrix<double, -1, 1> >, const Eigen::Map<const Eigen::Matrix<double, -1, 1>, 0, Eigen::Stride<0, 0> > > > >; Derived = Eigen::Ref<Eigen::Matrix<int, -1, 1> >]’
/opt/ros/melodic/src/ompl/src/ompl/base/src/ProjectionEvaluator.cpp:205:36:   required from here
/usr/local/include/eigen3/Eigen/src/Core/CoreEvaluators.h:615:42: error: invalid static_cast from type ‘const Eigen::internal::unary_evaluator<Eigen::CwiseUnaryOp<double (*)(double) throw (), const Eigen::CwiseBinaryOp<Eigen::internal::scalar_quotient_op<double, double>, const Eigen::Ref<Eigen::Matrix<double, -1, 1> >, const Eigen::Map<const Eigen::Matrix<double, -1, 1>, 0, Eigen::Stride<0, 0> > > >, Eigen::internal::IndexBased, double>::Data’ to type ‘double (* const&)(double) throw ()’
     const UnaryOp& func() const { return static_cast<const UnaryOp&>(*this); }
                                          ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
/usr/local/include/eigen3/Eigen/src/Core/CoreEvaluators.h: In instantiation of ‘Eigen::internal::unary_evaluator<Eigen::CwiseUnaryOp<UnaryOp, ArgType>, Eigen::internal::IndexBased>::Data::Data(const XprType&) [with UnaryOp = double (*)(double) throw (); ArgType = const Eigen::CwiseBinaryOp<Eigen::internal::scalar_quotient_op<double, double>, const Eigen::Ref<Eigen::Matrix<double, -1, 1> >, const Eigen::Map<const Eigen::Matrix<double, -1, 1>, 0, Eigen::Stride<0, 0> > >; Eigen::internal::unary_evaluator<Eigen::CwiseUnaryOp<UnaryOp, ArgType>, Eigen::internal::IndexBased>::XprType = Eigen::CwiseUnaryOp<double (*)(double) throw (), const Eigen::CwiseBinaryOp<Eigen::internal::scalar_quotient_op<double, double>, const Eigen::Ref<Eigen::Matrix<double, -1, 1> >, const Eigen::Map<const Eigen::Matrix<double, -1, 1>, 0, Eigen::Stride<0, 0> > > >]’:
/usr/local/include/eigen3/Eigen/src/Core/CoreEvaluators.h:572:55:   required from ‘Eigen::internal::unary_evaluator<Eigen::CwiseUnaryOp<UnaryOp, ArgType>, Eigen::internal::IndexBased>::unary_evaluator(const XprType&) [with UnaryOp = double (*)(double) throw (); ArgType = const Eigen::CwiseBinaryOp<Eigen::internal::scalar_quotient_op<double, double>, const Eigen::Ref<Eigen::Matrix<double, -1, 1> >, const Eigen::Map<const Eigen::Matrix<double, -1, 1>, 0, Eigen::Stride<0, 0> > >; typename Eigen::CwiseUnaryOp<UnaryOp, ArgType>::Scalar = double; Eigen::internal::unary_evaluator<Eigen::CwiseUnaryOp<UnaryOp, ArgType>, Eigen::internal::IndexBased>::XprType = Eigen::CwiseUnaryOp<double (*)(double) throw (), const Eigen::CwiseBinaryOp<Eigen::internal::scalar_quotient_op<double, double>, const Eigen::Ref<Eigen::Matrix<double, -1, 1> >, const Eigen::Map<const Eigen::Matrix<double, -1, 1>, 0, Eigen::Stride<0, 0> > > >]’
/usr/local/include/eigen3/Eigen/src/Core/CoreEvaluators.h:94:46:   required from ‘Eigen::internal::evaluator<T>::evaluator(const T&) [with T = Eigen::CwiseUnaryOp<double (*)(double) throw (), const Eigen::CwiseBinaryOp<Eigen::internal::scalar_quotient_op<double, double>, const Eigen::Ref<Eigen::Matrix<double, -1, 1> >, const Eigen::Map<const Eigen::Matrix<double, -1, 1>, 0, Eigen::Stride<0, 0> > > >]’
/usr/local/include/eigen3/Eigen/src/Core/CoreEvaluators.h:104:54:   required from ‘Eigen::internal::evaluator<const T>::evaluator(const T&) [with T = Eigen::CwiseUnaryOp<double (*)(double) throw (), const Eigen::CwiseBinaryOp<Eigen::internal::scalar_quotient_op<double, double>, const Eigen::Ref<Eigen::Matrix<double, -1, 1> >, const Eigen::Map<const Eigen::Matrix<double, -1, 1>, 0, Eigen::Stride<0, 0> > > >]’
/usr/local/include/eigen3/Eigen/src/Core/CoreEvaluators.h:613:86:   required from ‘Eigen::internal::unary_evaluator<Eigen::CwiseUnaryOp<UnaryOp, ArgType>, Eigen::internal::IndexBased>::Data::Data(const XprType&) [with UnaryOp = Eigen::internal::scalar_cast_op<double, int>; ArgType = const Eigen::CwiseUnaryOp<double (*)(double) throw (), const Eigen::CwiseBinaryOp<Eigen::internal::scalar_quotient_op<double, double>, const Eigen::Ref<Eigen::Matrix<double, -1, 1> >, const Eigen::Map<const Eigen::Matrix<double, -1, 1>, 0, Eigen::Stride<0, 0> > > >; Eigen::internal::unary_evaluator<Eigen::CwiseUnaryOp<UnaryOp, ArgType>, Eigen::internal::IndexBased>::XprType = Eigen::CwiseUnaryOp<Eigen::internal::scalar_cast_op<double, int>, const Eigen::CwiseUnaryOp<double (*)(double) throw (), const Eigen::CwiseBinaryOp<Eigen::internal::scalar_quotient_op<double, double>, const Eigen::Ref<Eigen::Matrix<double, -1, 1> >, const Eigen::Map<const Eigen::Matrix<double, -1, 1>, 0, Eigen::Stride<0, 0> > > > >]’
/usr/local/include/eigen3/Eigen/src/Core/CoreEvaluators.h:572:55:   required from ‘Eigen::internal::unary_evaluator<Eigen::CwiseUnaryOp<UnaryOp, ArgType>, Eigen::internal::IndexBased>::unary_evaluator(const XprType&) [with UnaryOp = Eigen::internal::scalar_cast_op<double, int>; ArgType = const Eigen::CwiseUnaryOp<double (*)(double) throw (), const Eigen::CwiseBinaryOp<Eigen::internal::scalar_quotient_op<double, double>, const Eigen::Ref<Eigen::Matrix<double, -1, 1> >, const Eigen::Map<const Eigen::Matrix<double, -1, 1>, 0, Eigen::Stride<0, 0> > > >; typename Eigen::CwiseUnaryOp<UnaryOp, ArgType>::Scalar = int; Eigen::internal::unary_evaluator<Eigen::CwiseUnaryOp<UnaryOp, ArgType>, Eigen::internal::IndexBased>::XprType = Eigen::CwiseUnaryOp<Eigen::internal::scalar_cast_op<double, int>, const Eigen::CwiseUnaryOp<double (*)(double) throw (), const Eigen::CwiseBinaryOp<Eigen::internal::scalar_quotient_op<double, double>, const Eigen::Ref<Eigen::Matrix<double, -1, 1> >, const Eigen::Map<const Eigen::Matrix<double, -1, 1>, 0, Eigen::Stride<0, 0> > > > >]’
/usr/local/include/eigen3/Eigen/src/Core/CoreEvaluators.h:94:46:   [ skipping 2 instantiation contexts, use -ftemplate-backtrace-limit=0 to disable ]
/usr/local/include/eigen3/Eigen/src/Core/AssignEvaluator.h:926:31:   required from ‘static void Eigen::internal::Assignment<DstXprType, SrcXprType, Functor, Eigen::internal::Dense2Dense, Weak>::run(DstXprType&, const SrcXprType&, const Functor&) [with DstXprType = Eigen::Ref<Eigen::Matrix<int, -1, 1> >; SrcXprType = Eigen::CwiseUnaryOp<Eigen::internal::scalar_cast_op<double, int>, const Eigen::CwiseUnaryOp<double (*)(double) throw (), const Eigen::CwiseBinaryOp<Eigen::internal::scalar_quotient_op<double, double>, const Eigen::Ref<Eigen::Matrix<double, -1, 1> >, const Eigen::Map<const Eigen::Matrix<double, -1, 1>, 0, Eigen::Stride<0, 0> > > > >; Functor = Eigen::internal::assign_op<int, int>; Weak = void]’
/usr/local/include/eigen3/Eigen/src/Core/AssignEvaluator.h:862:49:   required from ‘void Eigen::internal::call_assignment_no_alias(Dst&, const Src&, const Func&) [with Dst = Eigen::Ref<Eigen::Matrix<int, -1, 1> >; Src = Eigen::CwiseUnaryOp<Eigen::internal::scalar_cast_op<double, int>, const Eigen::CwiseUnaryOp<double (*)(double) throw (), const Eigen::CwiseBinaryOp<Eigen::internal::scalar_quotient_op<double, double>, const Eigen::Ref<Eigen::Matrix<double, -1, 1> >, const Eigen::Map<const Eigen::Matrix<double, -1, 1>, 0, Eigen::Stride<0, 0> > > > >; Func = Eigen::internal::assign_op<int, int>]’
/usr/local/include/eigen3/Eigen/src/Core/AssignEvaluator.h:830:27:   required from ‘void Eigen::internal::call_assignment(Dst&, const Src&, const Func&, typename Eigen::internal::enable_if<(! Eigen::internal::evaluator_assume_aliasing<Src>::value), void*>::type) [with Dst = Eigen::Ref<Eigen::Matrix<int, -1, 1> >; Src = Eigen::CwiseUnaryOp<Eigen::internal::scalar_cast_op<double, int>, const Eigen::CwiseUnaryOp<double (*)(double) throw (), const Eigen::CwiseBinaryOp<Eigen::internal::scalar_quotient_op<double, double>, const Eigen::Ref<Eigen::Matrix<double, -1, 1> >, const Eigen::Map<const Eigen::Matrix<double, -1, 1>, 0, Eigen::Stride<0, 0> > > > >; Func = Eigen::internal::assign_op<int, int>; typename Eigen::internal::enable_if<(! Eigen::internal::evaluator_assume_aliasing<Src>::value), void*>::type = void*]’
/usr/local/include/eigen3/Eigen/src/Core/AssignEvaluator.h:808:18:   required from ‘void Eigen::internal::call_assignment(Dst&, const Src&) [with Dst = Eigen::Ref<Eigen::Matrix<int, -1, 1> >; Src = Eigen::CwiseUnaryOp<Eigen::internal::scalar_cast_op<double, int>, const Eigen::CwiseUnaryOp<double (*)(double) throw (), const Eigen::CwiseBinaryOp<Eigen::internal::scalar_quotient_op<double, double>, const Eigen::Ref<Eigen::Matrix<double, -1, 1> >, const Eigen::Map<const Eigen::Matrix<double, -1, 1>, 0, Eigen::Stride<0, 0> > > > >]’
/usr/local/include/eigen3/Eigen/src/Core/Assign.h:66:28:   required from ‘Derived& Eigen::MatrixBase<Derived>::operator=(const Eigen::DenseBase<OtherDerived>&) [with OtherDerived = Eigen::CwiseUnaryOp<Eigen::internal::scalar_cast_op<double, int>, const Eigen::CwiseUnaryOp<double (*)(double) throw (), const Eigen::CwiseBinaryOp<Eigen::internal::scalar_quotient_op<double, double>, const Eigen::Ref<Eigen::Matrix<double, -1, 1> >, const Eigen::Map<const Eigen::Matrix<double, -1, 1>, 0, Eigen::Stride<0, 0> > > > >; Derived = Eigen::Ref<Eigen::Matrix<int, -1, 1> >]’
/opt/ros/melodic/src/ompl/src/ompl/base/src/ProjectionEvaluator.cpp:205:36:   required from here
/usr/local/include/eigen3/Eigen/src/Core/CoreEvaluators.h:613:86: error: type ‘double (*)(double) throw ()’ is not a direct base of ‘Eigen::internal::unary_evaluator<Eigen::CwiseUnaryOp<double (*)(double) throw (), const Eigen::CwiseBinaryOp<Eigen::internal::scalar_quotient_op<double, double>, const Eigen::Ref<Eigen::Matrix<double, -1, 1> >, const Eigen::Map<const Eigen::Matrix<double, -1, 1>, 0, Eigen::Stride<0, 0> > > >, Eigen::internal::IndexBased, double>::Data’
     Data(const XprType& xpr) : UnaryOp(xpr.functor()), argImpl(xpr.nestedExpression()) {}
                                                                                      ^
make[2]: *** [src/ompl/CMakeFiles/ompl.dir/base/src/ProjectionEvaluator.cpp.o] Error 1
make[1]: *** [src/ompl/CMakeFiles/ompl.dir/all] Error 2
make: *** [all] Error 2
```