### PR TITLE
Update paper references for Informed RRT*, SORRT*, and BIT*.

### DIFF
--- a/doc/markdown/developers.md
+++ b/doc/markdown/developers.md
@@ -16,7 +16,7 @@ A breakdown of all contributions by commits can be found on GitHub for the [OMPL
 - [Neil Dantam](http://www.neil.dantam.name), Rice University (now at Colorado School of Mines)
 - [Andrew Dobson](http://www.pracsyslab.org/dobson), Kostas Bekris' [Physics-aware Research for Autonomous Computational SYStems group](http://www.pracsyslab.org), Rutgers University
 - Elizabeth Fudge, Rice University
-- [Jonathan Gammell](http://mrg.robots.ox.ac.uk/mrg_people/jon-gammell/), Tim Barfoot's [Autonomous Space Robotics Lab](http://asrl.utias.utoronto.ca), University of Toronto
+- [Jonathan Gammell](https://robotic-esp.com/gammell/), Tim Barfoot's [Autonomous Space Robotics Lab](http://asrl.utias.utoronto.ca), University of Toronto
 - Bryant Gipson, Rice University (now at Google)
 - [Javier V Gomez](http://jvgomez.github.io), Universidad Carlos III de Madrid (now at Magic Leap)
 - Florian Hauer, Georgia Tech

--- a/src/ompl/base/samplers/informed/PathLengthDirectInfSampler.h
+++ b/src/ompl/base/samplers/informed/PathLengthDirectInfSampler.h
@@ -68,11 +68,10 @@ namespace ompl
 
             @par Associated publication:
 
-            J. D. Gammell, S. S. Srinivasa, T. D. Barfoot, "Informed RRT*: Optimal Sampling-based
-            Path Planning Focused via Direct Sampling of an Admissible Ellipsoidal Heuristic." In Proceedings
-            of the IEEE/RSJ International Conference on Intelligent Robots and Systems (IROS). Chicago, IL, USA,
-            14-18 Sept. 2014.
-            DOI: <a href="http://dx.doi.org/10.1109/IROS.2014.6942976">10.1109/IROS.2014.6942976</a>.
+            J. D. Gammell, T. D. Barfoot, S. S. Srinivasa, "Informed sampling for asymptotically optimal path planning."
+            IEEE Transactions on Robotics (T-RO), 34(4): 966-984, Aug. 2018.
+            DOI: <a href="https://doi.org/10.1109/TRO.2018.2830331">TRO.2018.2830331</a>.
+            arXiv: <a href="https://arxiv.org/pdf/1706.06454">1706.06454 [cs.RO]</a>.
             <a href="https://www.youtube.com/watch?v=d7dX5MvDYTc">Illustration video</a>.
             <a href="https://www.youtube.com/watch?v=nsl-5MZfwu4">Short description video</a>.
         */

--- a/src/ompl/geometric/planners/bitstar/BITstar.h
+++ b/src/ompl/geometric/planners/bitstar/BITstar.h
@@ -82,11 +82,10 @@ namespace ompl
 
         @par Associated publication:
 
-        J. D. Gammell, S. S. Srinivasa, T. D. Barfoot, "Batch Informed Trees (BIT*): Sampling-based
-        Optimal Planning via the Heuristically Guided Search of Implicit Random Geometric Graphs,"
-        In Proceedings of the IEEE International Conference on Robotics and Automation (ICRA).
-        Seattle, WA, USA, 26-30 May 2015.
-        DOI: <a href="http://dx.doi.org/10.1109/ICRA.2015.7139620">10.1109/ICRA.2015.7139620</a>.
+        J. D. Gammell, T. D. Barfoot, S. S. Srinivasa,  "Batch Informed Trees (BIT*): Informed asymptotically optimal
+        anytime search." The International Journal of Robotics Research (IJRR), 39(5): 543-567, Apr. 2020.
+        DOI: <a href="https://doi.org/10.1177/0278364919890396">10.1177/0278364919890396</a>.
+        arXiv: <a href="https://arxiv.org/pdf/1707.01888">1707.01888 [cs.RO]</a>.
         <a href="https://www.youtube.com/watch?v=MRzSfLpNBmA">Illustration video</a>.
         */
         /** \brief Batch Informed Trees (BIT*)*/

--- a/src/ompl/geometric/planners/rrt/InformedRRTstar.h
+++ b/src/ompl/geometric/planners/rrt/InformedRRTstar.h
@@ -55,11 +55,10 @@ namespace ompl
 
             @par Associated publication:
 
-            J. D. Gammell, S. S. Srinivasa, T. D. Barfoot, "Informed RRT*: Optimal Sampling-based
-            Path Planning Focused via Direct Sampling of an Admissible Ellipsoidal Heuristic." In Proceedings
-            of the IEEE/RSJ International Conference on Intelligent Robots and Systems (IROS). Chicago, IL, USA,
-            14-18 Sept. 2014.
-            DOI: <a href="http://dx.doi.org/10.1109/IROS.2014.6942976">10.1109/IROS.2014.6942976</a>.
+            J. D. Gammell, T. D. Barfoot, S. S. Srinivasa, "Informed sampling for asymptotically optimal path planning."
+            IEEE Transactions on Robotics (T-RO), 34(4): 966-984, Aug. 2018.
+            DOI: <a href="https://doi.org/10.1109/TRO.2018.2830331">TRO.2018.2830331</a>.
+            arXiv: <a href="https://arxiv.org/pdf/1706.06454">1706.06454 [cs.RO]</a>.
             <a href="https://www.youtube.com/watch?v=d7dX5MvDYTc">Illustration video</a>.
             <a href="https://www.youtube.com/watch?v=nsl-5MZfwu4">Short description video</a>.
         */

--- a/src/ompl/geometric/planners/rrt/SORRTstar.h
+++ b/src/ompl/geometric/planners/rrt/SORRTstar.h
@@ -49,7 +49,14 @@ namespace ompl
             Run \ref gRRTstar "RRT*" as SORRT* using an ordered informed search strategy that considers states in the
            subproblem that could provide a better solution in order of their potential solution cost.
             A sorted version \ref gInformedRRTstar "Informed RRT*".
-            To be published along with an extended version of \ref gBITstar "BIT*".
+
+            @par Associated publication:
+
+            J. D. Gammell, T. D. Barfoot, S. S. Srinivasa,  "Batch Informed Trees (BIT*): Informed asymptotically optimal
+            anytime search." The International Journal of Robotics Research (IJRR), 39(5): 543-567, Apr. 2020.
+            DOI: <a href="https://doi.org/10.1177/0278364919890396">10.1177/0278364919890396</a>.
+            arXiv: <a href="https://arxiv.org/pdf/1707.01888">1707.01888 [cs.RO]</a>.
+            <a href="https://www.youtube.com/watch?v=MRzSfLpNBmA">Illustration video</a>.
         */
 
         /** \brief SORRT* */

--- a/src/ompl/util/ProlateHyperspheroid.h
+++ b/src/ompl/util/ProlateHyperspheroid.h
@@ -51,11 +51,10 @@ namespace ompl
 
     /** \brief A class describing a prolate hyperspheroid, a special symmetric type of n-dimensional ellipse,
     for use in direct informed sampling for problems seeking to minimize path length.
-    @par J. D. Gammell, S. S. Srinivasa, T. D. Barfoot, "Informed RRT*: Optimal Sampling-based
-    Path Planning Focused via Direct Sampling of an Admissible Ellipsoidal Heuristic." In Proceedings
-    of the IEEE/RSJ International Conference on Intelligent Robots and Systems (IROS). Chicago, IL, USA,
-    14-18 Sept. 2014.
-    DOI: <a href="http://dx.doi.org/10.1109/IROS.2014.6942976">10.1109/IROS.2014.6942976</a>.
+    @par J. D. Gammell, T. D. Barfoot, S. S. Srinivasa, "Informed sampling for asymptotically optimal path planning."
+    IEEE Transactions on Robotics (T-RO), 34(4): 966-984, Aug. 2018.
+    DOI: <a href="https://doi.org/10.1109/TRO.2018.2830331">TRO.2018.2830331</a>.
+    arXiv: <a href="https://arxiv.org/pdf/1706.06454">1706.06454 [cs.RO]</a>.
     <a href="https://www.youtube.com/watch?v=d7dX5MvDYTc">Illustration video</a>.
     <a href="https://www.youtube.com/watch?v=nsl-5MZfwu4">Short description video</a>. */
     class ProlateHyperspheroid

--- a/src/ompl/util/RandomNumbers.h
+++ b/src/ompl/util/RandomNumbers.h
@@ -155,11 +155,10 @@ namespace ompl
 
         /** \brief Uniform random sampling of the surface of a prolate hyperspheroid, a special symmetric type of
         n-dimensional ellipse. The return variable \e value is expected to already exist.
-        @par J. D. Gammell, S. S. Srinivasa, T. D. Barfoot, "Informed RRT*: Optimal Sampling-based
-        Path Planning Focused via Direct Sampling of an Admissible Ellipsoidal Heuristic." In Proceedings
-        of the IEEE/RSJ International Conference on Intelligent Robots and Systems (IROS). Chicago, IL, USA,
-        14-18 Sept. 2014.
-        DOI: <a href="http://dx.doi.org/10.1109/IROS.2014.6942976">10.1109/IROS.2014.6942976</a>.
+        @par J. D. Gammell, T. D. Barfoot, S. S. Srinivasa, "Informed sampling for asymptotically optimal path planning."
+        IEEE Transactions on Robotics (T-RO), 34(4): 966-984, Aug. 2018.
+        DOI: <a href="https://doi.org/10.1109/TRO.2018.2830331">TRO.2018.2830331</a>.
+        arXiv: <a href="https://arxiv.org/pdf/1706.06454">1706.06454 [cs.RO]</a>
         <a href="https://www.youtube.com/watch?v=d7dX5MvDYTc">Illustration video</a>.
         <a href="https://www.youtube.com/watch?v=nsl-5MZfwu4">Short description video</a>. */
         void uniformProlateHyperspheroidSurface(const std::shared_ptr<const ProlateHyperspheroid> &phsPtr,
@@ -167,11 +166,10 @@ namespace ompl
 
         /** \brief Uniform random sampling of a prolate hyperspheroid, a special symmetric type of
         n-dimensional ellipse. The return variable \e value is expected to already exist.
-        @par J. D. Gammell, S. S. Srinivasa, T. D. Barfoot, "Informed RRT*: Optimal Sampling-based
-        Path Planning Focused via Direct Sampling of an Admissible Ellipsoidal Heuristic." In Proceedings
-        of the IEEE/RSJ International Conference on Intelligent Robots and Systems (IROS). Chicago, IL, USA,
-        14-18 Sept. 2014.
-        DOI: <a href="http://dx.doi.org/10.1109/IROS.2014.6942976">10.1109/IROS.2014.6942976</a>.
+        @par J. D. Gammell, T. D. Barfoot, S. S. Srinivasa, "Informed sampling for asymptotically optimal path planning."
+        IEEE Transactions on Robotics (T-RO), 34(4): 966-984, Aug. 2018.
+        DOI: <a href="https://doi.org/10.1109/TRO.2018.2830331">TRO.2018.2830331</a>.
+        arXiv: <a href="https://arxiv.org/pdf/1706.06454">1706.06454 [cs.RO]</a>.
         <a href="https://www.youtube.com/watch?v=d7dX5MvDYTc">Illustration video</a>.
         <a href="https://www.youtube.com/watch?v=nsl-5MZfwu4">Short description video</a>. */
         void uniformProlateHyperspheroid(const std::shared_ptr<const ProlateHyperspheroid> &phsPtr, double value[]);


### PR DESCRIPTION
Hi @mamoll ,

I was waiting to update the paper references once I had the full publication info for the BIT* IJRR paper. I have that now, so this is just a switch from conference refs to journal refs for Informed RRT*, SORRT*, and BIT*.
(And a link to me that I found when searching for paper refs to update).

Hoping it's no work for you to merge.

Thanks,
Jon