### PR TITLE
Add nullptr check when setting AIT* to track approximate solutions

### DIFF
--- a/src/ompl/geometric/planners/informedtrees/AITstar.h
+++ b/src/ompl/geometric/planners/informedtrees/AITstar.h
@@ -272,7 +272,7 @@ namespace ompl
             bool repairReverseSearch_{true};
 
             /** \brief The option that specifies whether to track approximate solutions. */
-            bool trackApproximateSolutions_{false};
+            bool trackApproximateSolutions_{true};
 
             /** \brief The option that specifies whether to prune the graph of useless samples. */
             bool isPruningEnabled_{true};

--- a/src/ompl/geometric/planners/informedtrees/src/AITstar.cpp
+++ b/src/ompl/geometric/planners/informedtrees/src/AITstar.cpp
@@ -74,7 +74,7 @@ namespace ompl
             // Specify AIT*'s planner specs.
             specs_.recognizedGoal = base::GOAL_SAMPLEABLE_REGION;
             specs_.multithreaded = false;
-            specs_.approximateSolutions = trackApproximateSolutions_;  // Disabled by default.
+            specs_.approximateSolutions = true;
             specs_.optimizingPaths = true;
             specs_.directed = true;
             specs_.provingSolutionNonExistence = false;

--- a/src/ompl/geometric/planners/informedtrees/src/AITstar.cpp
+++ b/src/ompl/geometric/planners/informedtrees/src/AITstar.cpp
@@ -709,6 +709,13 @@ namespace ompl
                     // Check if the solution can benefit from this.
                     updateExactSolution();
 
+                    // If we don't have an exact solution but are tracking approximate solutions, see if the child is
+                    // the best approximate solution so far.
+                    if (!pdef_->hasExactSolution() && trackApproximateSolutions_)
+                    {
+                        updateApproximateSolution(child);
+                    }
+
                     // Insert the child's outgoing edges into the queue.
                     auto edges = getOutgoingEdges(child);
                     if (haveAllVerticesBeenProcessed(edges))

--- a/src/ompl/geometric/planners/informedtrees/src/AITstar.cpp
+++ b/src/ompl/geometric/planners/informedtrees/src/AITstar.cpp
@@ -325,7 +325,10 @@ namespace ompl
             trackApproximateSolutions_ = track;
             if (!trackApproximateSolutions_)
             {
-                approximateSolutionCost_ = objective_->infiniteCost();
+                if (static_cast<bool>(objective_))
+                {
+                    approximateSolutionCost_ = objective_->infiniteCost();
+                }
             }
         }
 


### PR DESCRIPTION
Summary:

1. Add `nullptr` check when calling `AITstar::trackApproximateSolutions`
2. Enable tracking approximate solutions by default
3. Continuously track approximate solutions (previously got best approximate solution only before `solve` returns)

Reasoning:
1. AIT* tries to initialize its approximate solution cost with `OptimizationObjective::infiniteCost`, which needs access to an optimization objective. Calling `AITstar::trackApproximateSolutions` when the planner hasn't been `setup` yet resulted in a segfault because AIT* didn't know of the optimization objective yet. This PR adds the necessary check. (Without an optimization objective, AIT* can't know how to initialize the approximate solution cost and  therefore simply refrains from doing so.)
2. This seems to be the default for other planners.
3. It seems like there is a use case where this is beneficial.