### PR TITLE
Implement k-nearest connection model in AIT*'s RGG

### DIFF
--- a/src/ompl/geometric/planners/informedtrees/AITstar.h
+++ b/src/ompl/geometric/planners/informedtrees/AITstar.h
@@ -182,6 +182,12 @@ namespace ompl
             /** \brief Rebuilds the forward queue. */
             void rebuildReverseQueue();
 
+            /** \brief Prints a message using OMPL_INFORM to let the user know that AIT* found a new solution. */
+            void informAboutNewSolution() const;
+
+            /** \brief Prints a message using OMPL_INFORM to let the user know of the planner status. */
+            void informAboutPlannerStatus(ompl::base::PlannerStatus::StatusType status) const;
+
             /** \brief Returns the path a start to the argument. */
             std::shared_ptr<ompl::geometric::PathGeometric>
             getPathToVertex(const std::shared_ptr<aitstar::Vertex> &vertex) const;
@@ -225,6 +231,12 @@ namespace ompl
 
             /** \brief Returns the best cost to come form the goal of any start. */
             ompl::base::Cost computeBestCostToComeFromGoalOfAnyStart() const;
+
+            /** \brief Counts the number of vertices in the forward tree. */
+            std::size_t countNumVerticesInForwardTree() const;
+
+            /** \brief Counts the number of vertices in the reverse tree. */
+            std::size_t countNumVerticesInReverseTree() const;
 
             /** \brief Sets the cost to come from to goal of the reverse search to infinity for the whole branch.
              */
@@ -288,6 +300,9 @@ namespace ompl
 
             /** \brief Syntactic helper to get at the motion validator of the planner base class. */
             ompl::base::MotionValidatorPtr motionValidator_;
+
+            /** \brief The number of processed edges. */
+            std::size_t numProcessedEdges_{0u};
 
             /** \brief The number of edge collision checks performed. */
             std::size_t numEdgeCollisionChecks_{0u};

--- a/src/ompl/geometric/planners/informedtrees/AITstar.h
+++ b/src/ompl/geometric/planners/informedtrees/AITstar.h
@@ -133,6 +133,12 @@ namespace ompl
             /** \brief Get whether pruning is enabled or not. */
             bool isPruningEnabled() const;
 
+            /** \brief Set whether to use a k-nearest RGG connection model. If false, AIT* uses an r-disc model. */
+            void setUseKNearest(bool useKNearest);
+
+            /** \brief Get whether to use a k-nearest RGG connection model. If false, AIT* uses an r-disc model. */
+            bool getUseKNearest() const;
+
             /** \brief Enable LPA* repair of reverse search. */
             void setRepairReverseSearch(bool repairReverseSearch);
 

--- a/src/ompl/geometric/planners/informedtrees/aitstar/ImplicitGraph.h
+++ b/src/ompl/geometric/planners/informedtrees/aitstar/ImplicitGraph.h
@@ -134,6 +134,12 @@ namespace ompl
                 /** \brief Prune all samples that can not contribute to a solution better than the current one. */
                 void prune();
 
+                /** \brief Returns the total number of sampled states. */
+                std::size_t getNumberOfSampledStates() const;
+
+                /** \brief Returns the total number of valid samples found. */
+                std::size_t getNumberOfValidSamples() const;
+
                 /** \brief Get the number of state collision checks. */
                 std::size_t getNumberOfStateCollisionChecks() const;
 
@@ -212,8 +218,11 @@ namespace ompl
                  * again. */
                 std::vector<std::shared_ptr<Vertex>> prunedGoalVertices_;
 
-                /** \brief The number of state collision checks. */
-                mutable std::size_t numStateCollisionChecks_{0u};
+                /** \brief The number of sampled states that were valid. */
+                mutable std::size_t numValidSamples_{0u};
+
+                /** \brief The number of sampled states. */
+                mutable std::size_t numSampledStates_{0u};
 
                 /** \brief The number of state collision checks. */
                 mutable std::size_t numNearestNeighborsCalls_{0u};

--- a/src/ompl/geometric/planners/informedtrees/aitstar/ImplicitGraph.h
+++ b/src/ompl/geometric/planners/informedtrees/aitstar/ImplicitGraph.h
@@ -78,6 +78,12 @@ namespace ompl
                 /** \brief Get the reqire factor of the RGG. */
                 double getRewireFactor() const;
 
+                /** \brief Whether to use a k-nearest connection model. If false, it uses an r-disc model. */
+                void setUseKNearest(bool useKNearest);
+
+                /** \brief Whether the graph uses a k-nearest connection model. If false, it uses an r-disc model. */
+                bool getUseKNearest() const;
+
                 /** \brief Sets whether to track approximate solutions or not. */
                 void setTrackApproximateSolution(bool track);
 
@@ -138,8 +144,11 @@ namespace ompl
                 /** \brief Computes the number of samples in the informed set. */
                 std::size_t computeNumberOfSamplesInInformedSet() const;
 
-                /** \brief Computes the connection radius with a given number of samples. */
+                /** \brief Computes the connection radius of the r-disc model with a given number of samples. */
                 double computeConnectionRadius(std::size_t numSamples) const;
+
+                /** \brief Computes the number of neighbors of the k-nearest model with a given number of samples. */
+                std::size_t computeNumberOfNeighbors(std::size_t numSamples) const;
 
                 /** \brief Returns wehther a state can possibly improve the current solution. */
                 bool canPossiblyImproveSolution(const std::shared_ptr<Vertex> &vertex) const;
@@ -165,11 +174,21 @@ namespace ompl
                 /** \brief The vertex to the goal. */
                 std::shared_ptr<Vertex> bestApproximateGoal_;
 
-                /** \brief The radius that defines the neighborhood of a vertex. */
+                /** \brief Whether to use a k-nearest RGG. If false, AIT* uses an r-disc RGG. */
+                bool useKNearest_{true};
+
+                /** \brief The radius that defines the neighborhood of a vertex if using an r-disc graph. */
                 double radius_{std::numeric_limits<double>::infinity()};
 
+                /** \brief The number of neighbors that defines the neighborhood of a vertex if using a k-nearest graph.
+                 */
+                std::size_t numNeighbors_{std::numeric_limits<std::size_t>::max()};
+
+                /** \brief A constant for the computation of the number of neighbors when using a k-nearest model. */
+                std::size_t k_rgg_{std::numeric_limits<std::size_t>::max()};
+
                 /** \brief The cost of the incumbent solution. */
-                const ompl::base::Cost& solutionCost_;
+                const ompl::base::Cost &solutionCost_;
 
                 /** \brief The state sampler responsible for filling the state values of vertices. */
                 ompl::base::InformedSamplerPtr sampler_;

--- a/src/ompl/geometric/planners/informedtrees/aitstar/src/ImplicitGraph.cpp
+++ b/src/ompl/geometric/planners/informedtrees/aitstar/src/ImplicitGraph.cpp
@@ -79,6 +79,8 @@ namespace ompl
                 goalVertices_.clear();
                 prunedStartVertices_.clear();
                 prunedGoalVertices_.clear();
+                numSampledStates_ = 0u;
+                numValidSamples_ = 0u;
             }
 
             void ImplicitGraph::setRewireFactor(double rewireFactor)
@@ -332,8 +334,10 @@ namespace ompl
                         sampler_->sampleUniform(newVertices.back()->getState(), solutionCost_);
 
                         // Count how many states we've checked.
-                        ++numStateCollisionChecks_;
+                        ++numSampledStates_;
                     } while (!spaceInformation_->getStateValidityChecker()->isValid(newVertices.back()->getState()));
+
+                    ++numValidSamples_;
                 }
 
                 // Add all new vertices to the nearest neighbor structure.
@@ -491,9 +495,21 @@ namespace ompl
                 // Assert that the forward and reverse queue are empty?
             }
 
+            std::size_t ImplicitGraph::getNumberOfSampledStates() const
+            {
+                return numSampledStates_;
+            }
+
+            std::size_t ImplicitGraph::getNumberOfValidSamples() const
+            {
+                return numValidSamples_;
+            }
+
             std::size_t ImplicitGraph::getNumberOfStateCollisionChecks() const
             {
-                return numStateCollisionChecks_;
+                // Each sampled state is checked for collision. Only sampled states are checked for collision (number of
+                // collision checked edges don't count here.)
+                return numSampledStates_;
             }
 
             std::size_t ImplicitGraph::getNumberOfNearestNeighborCalls() const

--- a/src/ompl/geometric/planners/informedtrees/src/AITstar.cpp
+++ b/src/ompl/geometric/planners/informedtrees/src/AITstar.cpp
@@ -81,6 +81,7 @@ namespace ompl
             specs_.canReportIntermediateSolutions = true;
 
             // Register the setting callbacks.
+            declareParam<bool>("use_k_nearest", this, &AITstar::setUseKNearest, &AITstar::getUseKNearest, "0,1");
             declareParam<double>("rewire_factor", this, &AITstar::setRewireFactor, &AITstar::getRewireFactor,
                                  "1.0:0.01:3.0");
             declareParam<std::size_t>("samples_per_batch", this, &AITstar::setBatchSize, &AITstar::getBatchSize,
@@ -342,6 +343,16 @@ namespace ompl
         bool AITstar::isPruningEnabled() const
         {
             return isPruningEnabled_;
+        }
+
+        void AITstar::setUseKNearest(bool useKNearest)
+        {
+            graph_.setUseKNearest(useKNearest);
+        }
+
+        bool AITstar::getUseKNearest() const
+        {
+            return graph_.getUseKNearest();
         }
 
         void AITstar::setRepairReverseSearch(bool repairReverseSearch)

--- a/src/ompl/geometric/planners/informedtrees/src/AITstar.cpp
+++ b/src/ompl/geometric/planners/informedtrees/src/AITstar.cpp
@@ -168,12 +168,17 @@ namespace ompl
 
         ompl::base::PlannerStatus AITstar::solve(const ompl::base::PlannerTerminationCondition &terminationCondition)
         {
+            // The planner status to return.
+            auto status = ompl::base::PlannerStatus::StatusType::UNKNOWN;
+
             // Ensure the planner is setup.
             Planner::checkValidity();
             if (!Planner::setup_)
             {
                 OMPL_WARN("%s: Failed to setup and thus solve can not do anything meaningful.", name_.c_str());
-                return ompl::base::PlannerStatus::StatusType::ABORT;
+                status = ompl::base::PlannerStatus::StatusType::ABORT;
+                informAboutPlannerStatus(status);
+                return status;
             }
 
             // If the graph currently does not have a goal state, we wait until we get one.
@@ -185,14 +190,18 @@ namespace ompl
             if (!graph_.hasAStartState())
             {
                 OMPL_WARN("%s: No solution can be found as no start states are available", name_.c_str());
-                return ompl::base::PlannerStatus::StatusType::INVALID_START;
+                status = ompl::base::PlannerStatus::StatusType::INVALID_START;
+                informAboutPlannerStatus(status);
+                return status;
             }
 
             // If the graph still doesn't have a goal after waiting there's nothing to solve.
             if (!graph_.hasAGoalState())
             {
-                OMPL_WARN("%s: No solution can be found as no start states are available", name_.c_str());
-                return ompl::base::PlannerStatus::StatusType::INVALID_GOAL;
+                OMPL_WARN("%s: No solution can be found as no goal states are available", name_.c_str());
+                status = ompl::base::PlannerStatus::StatusType::INVALID_GOAL;
+                informAboutPlannerStatus(status);
+                return status;
             }
 
             OMPL_INFORM("%s: Searching for a solution to the given planning problem.", name_.c_str());
@@ -237,18 +246,22 @@ namespace ompl
                 }
             }
 
+            // Return the right planner status.
             if (objective_->isFinite(solutionCost_))
             {
-                return ompl::base::PlannerStatus::StatusType::EXACT_SOLUTION;
+                status = ompl::base::PlannerStatus::StatusType::EXACT_SOLUTION;
             }
             else if (trackApproximateSolutions_ && objective_->isFinite(approximateSolutionCost_))
             {
-                return ompl::base::PlannerStatus::StatusType::APPROXIMATE_SOLUTION;
+                status = ompl::base::PlannerStatus::StatusType::APPROXIMATE_SOLUTION;
             }
             else
             {
-                return ompl::base::PlannerStatus::StatusType::TIMEOUT;
+                status = ompl::base::PlannerStatus::StatusType::TIMEOUT;
             }
+
+            informAboutPlannerStatus(status);
+            return status;
         }
 
         ompl::base::Cost AITstar::bestCost() const
@@ -412,6 +425,76 @@ namespace ompl
                 auto reverseQueuePointer = reverseQueue_.insert(element);
                 element.second->setReverseQueuePointer(reverseQueuePointer);
             }
+        }
+
+        void AITstar::informAboutNewSolution() const
+        {
+            OMPL_INFORM("%s (%u iterations): Found a new exact solution of cost %.4f. Sampled a total of %u states, %u "
+                        "of which were valid samples (%.1f \%). Processed %u edges, %u of which were collision checked "
+                        "(%.1f \%). The forward search tree has %u vertices. The reverse search tree has %u vertices.",
+                        name_.c_str(), numIterations_, solutionCost_.value(), graph_.getNumberOfSampledStates(),
+                        graph_.getNumberOfValidSamples(),
+                        100.0 * (static_cast<double>(graph_.getNumberOfValidSamples()) /
+                                 static_cast<double>(graph_.getNumberOfSampledStates())),
+                        numProcessedEdges_, numEdgeCollisionChecks_,
+                        100.0 * (static_cast<float>(numEdgeCollisionChecks_) / static_cast<float>(numProcessedEdges_)),
+                        countNumVerticesInForwardTree(), countNumVerticesInReverseTree());
+        }
+
+        void AITstar::informAboutPlannerStatus(ompl::base::PlannerStatus::StatusType status) const
+        {
+            switch (status)
+            {
+                case ompl::base::PlannerStatus::StatusType::EXACT_SOLUTION:
+                {
+                    OMPL_INFORM("%s (%u iterations): Found an exact solution of cost %.4f.", name_.c_str(),
+                                numIterations_, solutionCost_.value());
+                    break;
+                }
+                case ompl::base::PlannerStatus::StatusType::APPROXIMATE_SOLUTION:
+                {
+                    OMPL_INFORM("%s (%u iterations): Did not find an exact solution, but found an approximate solution "
+                                "of cost %.4f.",
+                                name_.c_str(), numIterations_, approximateSolutionCost_.value());
+                    break;
+                }
+                case ompl::base::PlannerStatus::StatusType::TIMEOUT:
+                {
+                    if (trackApproximateSolutions_)
+                    {
+                        OMPL_INFORM("%s (%u iterations): Did not find any solution.", name_.c_str(), numIterations_);
+                    }
+                    else
+                    {
+                        OMPL_INFORM("%s (%u iterations): Did not find an exact solution, and tracking approximate "
+                                    "solutions is disabled.",
+                                    name_.c_str(), numIterations_);
+                    }
+                    break;
+                }
+                case ompl::base::PlannerStatus::StatusType::UNKNOWN:
+                case ompl::base::PlannerStatus::StatusType::INVALID_START:
+                case ompl::base::PlannerStatus::StatusType::INVALID_GOAL:
+                case ompl::base::PlannerStatus::StatusType::UNRECOGNIZED_GOAL_TYPE:
+                case ompl::base::PlannerStatus::StatusType::CRASH:
+                case ompl::base::PlannerStatus::StatusType::ABORT:
+                case ompl::base::PlannerStatus::StatusType::TYPE_COUNT:
+                {
+                    OMPL_INFORM("%s (%u iterations): Unable to solve the given planning problem.", name_.c_str(),
+                                numIterations_);
+                }
+            }
+
+            OMPL_INFORM("%s (%u iterations): Sampled a total of %u states, %u of which were valid samples (%.1f \%). "
+                        "Processed %u edges, %u of which were collision checked (%.1f \%). The forward search tree "
+                        "has %u vertices. The reverse search tree has %u vertices.",
+                        name_.c_str(), numIterations_, graph_.getNumberOfSampledStates(),
+                        graph_.getNumberOfValidSamples(),
+                        100.0 * (static_cast<double>(graph_.getNumberOfValidSamples()) /
+                                 static_cast<double>(graph_.getNumberOfSampledStates())),
+                        numProcessedEdges_, numEdgeCollisionChecks_,
+                        100.0 * (static_cast<float>(numEdgeCollisionChecks_) / static_cast<float>(numProcessedEdges_)),
+                        countNumVerticesInForwardTree(), countNumVerticesInReverseTree());
         }
 
         std::vector<aitstar::Edge> AITstar::getEdgesInQueue() const
@@ -631,6 +714,9 @@ namespace ompl
 
             // Remove the edge from the queue.
             forwardQueue_.pop();
+
+            // This counts as processing an edge.
+            ++numProcessedEdges_;
 
             // Register that an outgoing edge of the parent has been popped from the queue. This means that the parent
             // has optimal cost-to-come for the current approximation.
@@ -1245,6 +1331,9 @@ namespace ompl
 
                     // Let the problem definition know that a new solution exists.
                     pdef_->addSolutionPath(solution);
+
+                    // Let the user know about the new solution.
+                    informAboutNewSolution();
                 }
             }
         }
@@ -1320,6 +1409,34 @@ namespace ompl
                 bestCost = objective_->betterCost(bestCost, start->getCostToComeFromGoal());
             }
             return bestCost;
+        }
+
+        std::size_t AITstar::countNumVerticesInForwardTree() const
+        {
+            std::size_t numVerticesInForwardTree = 0u;
+            auto vertices = graph_.getVertices();
+            for (const auto &vertex : vertices)
+            {
+                if (graph_.isStart(vertex) || vertex->hasForwardParent())
+                {
+                    ++numVerticesInForwardTree;
+                }
+            }
+            return numVerticesInForwardTree;
+        }
+
+        std::size_t AITstar::countNumVerticesInReverseTree() const
+        {
+            std::size_t numVerticesInReverseTree = 0u;
+            auto vertices = graph_.getVertices();
+            for (const auto &vertex : vertices)
+            {
+                if (graph_.isGoal(vertex) || vertex->hasReverseParent())
+                {
+                    ++numVerticesInReverseTree;
+                }
+            }
+            return numVerticesInReverseTree;
         }
 
         void AITstar::invalidateCostToComeFromGoalOfReverseBranch(const std::shared_ptr<aitstar::Vertex> &vertex)


### PR DESCRIPTION
Hi Mark,

The problem was that the connection radius of the edge-implicit RGG that AIT* searches was not appropriate for problems in which some dimensions are (much) larger than others (the theory holds for the unit cube). This PR implements an option that turns AIT*'s r-disc RGG into a k-nearest RGG, which seems to be more robust to dimensions of unequal extent. I've set the k-nearest model as the default option.

With this, AIT* to solved the problem referenced in #721 in less than 10 seconds 10/10 times on my machine.