### PR TITLE
Make unit test assumption explicit

### DIFF
--- a/src/ompl/geometric/planners/informedtrees/AITstar.h
+++ b/src/ompl/geometric/planners/informedtrees/AITstar.h
@@ -245,8 +245,11 @@ namespace ompl
             /** \brief The cost of the incumbent solution. */
             ompl::base::Cost solutionCost_;
 
-            /** \brief The cost to go to the goal of the vertex that is closest to the goal (in cost space). */
+            /** \brief The cost to come to the vertex that is closest to the goal (in cost space). */
             ompl::base::Cost approximateSolutionCost_{};
+
+            /** \brief The cost to go to the goal from the current best approximate solution. */
+            ompl::base::Cost approximateSolutionCostToGoal_{};
 
             /** \brief The increasingly dense sampling-based approximation. */
             aitstar::ImplicitGraph graph_;

--- a/tests/geometric/2d/2dcircles_optimize.cpp
+++ b/tests/geometric/2d/2dcircles_optimize.cpp
@@ -128,8 +128,8 @@ protected:
             opt->setCostThreshold(opt->infiniteCost());
 
             time::point start = time::now();
-            bool solved = planner->solve(solutionTime);
-            if (solved)
+            auto solved = planner->solve(solutionTime);
+            if (solved == base::PlannerStatus::EXACT_SOLUTION)
             {
               // we change the optimization objective so the planner runs until timeout
               opt->setCostThreshold(base::Cost(std::numeric_limits<double>::epsilon()));


### PR DESCRIPTION
Hi Mark,

As far as I understand, `test_2d_circles_opt_geometric` makes the implicit assumption that the planners find an exact solution to the problem. Otherwise the checks on lines 152, 156, 160, and 173 don't make sense:

- Line 152: `BOOST_CHECK(!opt->isCostBetterThan(prev_cost, new_cost));` If the solution is approximate, this should be allowed happen.
- Line 156: `BOOST_CHECK(!pdef->hasApproximateSolution());` Checks for exact solutions, but the condition of the enclosing `while` prevents this check from being reached when the planner doesn't find an exact solution and uses all the solution time.
- Line 160: `BOOST_CHECK(!opt->isCostBetterThan(ini_cost, prev_cost));` This can happen if the initial solution is approximate.
- Line 173: `BOOST_CHECK(!opt->isCostBetterThan(prev_cost, min_cost));` If `prev_cost` is the cost of an approximate solution, it can be lower that the theoretically lowest cost of an exact solution (which is `min_cost`).

This PR proposes to correct this by making the assumption of an exact solution explicit.

I think AIT* was failing on the Travis CI because there was a situation (seed?) for which AIT* did not find an exact solution to the problem in the given time. We don't expect AIT* to be great relative to other planners for problems with relatively low collision detection resolution and many small obstacles in a large configuration space. We're currently working on an algorithm with improved performance even in these scenarios.

This PR also fixes two bugs in AIT* that I found when figuring out what was going on. One is related to how AIT* handles the `plannerAlwaysTerminatingCondition`, and one how the best approximate solution is updated. I don't think either of these were the cause for the failure of the Travis build.

(Edited for clarity.)