### PR TITLE
Fix for crash in LazyPRM constructor (noticed in default MoveIt setup)

### DIFF
--- a/src/ompl/geometric/planners/prm/src/LazyPRM.cpp
+++ b/src/ompl/geometric/planners/prm/src/LazyPRM.cpp
@@ -226,6 +226,15 @@ void ompl::geometric::LazyPRM::setMaxNearestNeighbors(unsigned int k)
 
 void ompl::geometric::LazyPRM::setDefaultConnectionStrategy()
 {
+    if (!nn_)
+    {
+        nn_.reset(tools::SelfConfig::getDefaultNearestNeighbors<Vertex>(this));
+        nn_->setDistanceFunction([this](const Vertex a, const Vertex b)
+                                 {
+                                     return distanceFunction(a, b);
+                                 });
+    }
+  
     if (starStrategy_)
         connectionStrategy_ = KStarStrategy<Vertex>([this] { return milestoneCount(); }, nn_, si_->getStateDimension());
     else


### PR DESCRIPTION
This fixes a bug in 1.5.0 in LazyPRM.  When the first constructor (that uses base::SpaceInformationPtr) is called, and then setRange() is called before setMaxNearestNeighbors() or setup() [this is EXACTLY how the default moveit setup is calling this], then setDefaultConnectionStrategy() is called before a NearestNeighbor pointer (nn_) is set up which then crashes OMPL in the LazyPRM constructor.