### PR TITLE
Prevent RRTConnect returning approximate solutions from goal

### DIFF
--- a/src/ompl/geometric/planners/rrt/src/RRTConnect.cpp
+++ b/src/ompl/geometric/planners/rrt/src/RRTConnect.cpp
@@ -271,8 +271,13 @@ ompl::base::PlannerStatus ompl::geometric::RRTConnect::solve(const base::Planner
             if (gs != REACHED)
                 si_->copyState(rstate, tgi.xstate);
 
-            GrowState gsc = ADVANCED;
             tgi.start = startTree;
+
+            /* if initial progress cannot be done from the otherTree, restore tgi.start */
+            GrowState gsc = growTree(otherTree, tgi, rmotion);
+            if (gsc == TRAPPED)
+                tgi.start = !tgi.start;
+
             while (gsc == ADVANCED)
                 gsc = growTree(otherTree, tgi, rmotion);
 
@@ -284,8 +289,8 @@ ompl::base::PlannerStatus ompl::geometric::RRTConnect::solve(const base::Planner
                 // OMPL_INFORM("Estimated distance to go: %f", distanceBetweenTrees_);
             }
 
-            Motion *startMotion = startTree ? tgi.xmotion : addedMotion;
-            Motion *goalMotion = startTree ? addedMotion : tgi.xmotion;
+            Motion *startMotion = tgi.start ? tgi.xmotion : addedMotion;
+            Motion *goalMotion = tgi.start ? addedMotion : tgi.xmotion;
 
             /* if we connected the trees in a valid way (start and goal pair is valid)*/
             if (gsc == REACHED && goal->isStartGoalPairValid(startMotion->root, goalMotion->root))
@@ -332,7 +337,7 @@ ompl::base::PlannerStatus ompl::geometric::RRTConnect::solve(const base::Planner
             {
                 // We didn't reach the goal, but if we were extending the start
                 // tree, then we can mark/improve the approximate path so far.
-                if (!startTree)
+                if (tgi.start)
                 {
                     // We were working from the startTree.
                     double dist = 0.0;


### PR DESCRIPTION
I had come across RRTConnect returning approximate solutions that start at goal state.
As I believe this is not the expected behaviour, this PR prevents this from happening. 