### PR TITLE
Register package with the ament index for ROS2 installation

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -244,7 +244,12 @@ if (OMPL_REGISTRATION)
 endif()
 
 # install catkin package.xml (needed for ROS installation)
-install(FILES package.xml DESTINATION "share/ompl")
+install(FILES package.xml
+    DESTINATION share/${PROJECT_NAME})
+
+# Allows Colcon to find non-Ament packages when using workspace underlays
+file(WRITE ${CMAKE_CURRENT_BINARY_DIR}/share/ament_index/resource_index/packages/${PROJECT_NAME} "")
+install(FILES ${CMAKE_CURRENT_BINARY_DIR}/share/ament_index/resource_index/packages/${PROJECT_NAME} DESTINATION share/ament_index/resource_index/packages)
 
 set_package_properties(PkgConfig PROPERTIES
     URL "https://www.freedesktop.org/wiki/Software/pkg-config/"


### PR DESCRIPTION
Reference:
* https://github.com/ros-industrial/noether/blob/80d95795af4c8bfec4ac508ef602cbeb7c157528/noether_filtering/CMakeLists.txt#L185-L187
* https://github.com/ros-industrial/noether/pull/91

Fixes: https://github.com/ompl/ompl/issues/753

cc @SteveMacenski @mikaelarguedas