### PR TITLE
Fix/aitstar miscellaneous

### DIFF
--- a/demos/OptimalPlanning.cpp
+++ b/demos/OptimalPlanning.cpp
@@ -43,6 +43,7 @@
 #include "ompl/util/Console.h"
 
 // The supported optimal planners, in alphabetical order
+#include <ompl/geometric/planners/informedtrees/AITstar.h>
 #include <ompl/geometric/planners/informedtrees/BITstar.h>
 #include <ompl/geometric/planners/cforest/CForest.h>
 #include <ompl/geometric/planners/fmt/FMT.h>
@@ -70,6 +71,7 @@ namespace og = ompl::geometric;
 // An enum of supported optimal planners, alphabetical order
 enum optimalPlanner
 {
+    PLANNER_AITSTAR,
     PLANNER_BFMTSTAR,
     PLANNER_BITSTAR,
     PLANNER_CFOREST,
@@ -144,7 +146,12 @@ ob::PlannerPtr allocatePlanner(ob::SpaceInformationPtr si, optimalPlanner planne
 {
     switch (plannerType)
     {
-		case PLANNER_BFMTSTAR:
+        case PLANNER_AITSTAR:
+        {
+            return std::make_shared<og::AITstar>(si);
+            break;
+        }
+     		case PLANNER_BFMTSTAR:
         {
             return std::make_shared<og::BFMT>(si);
             break;
@@ -423,7 +430,7 @@ bool argParse(int argc, char** argv, double* runTimePtr, optimalPlanner *planner
     desc.add_options()
         ("help,h", "produce help message")
         ("runtime,t", bpo::value<double>()->default_value(1.0), "(Optional) Specify the runtime in seconds. Defaults to 1 and must be greater than 0.")
-        ("planner,p", bpo::value<std::string>()->default_value("RRTstar"), "(Optional) Specify the optimal planner to use, defaults to RRTstar if not given. Valid options are BFMTstar, BITstar, CForest, FMTstar, InformedRRTstar, PRMstar, RRTstar, and SORRTstar.") //Alphabetical order
+        ("planner,p", bpo::value<std::string>()->default_value("RRTstar"), "(Optional) Specify the optimal planner to use, defaults to RRTstar if not given. Valid options are AITstar, BFMTstar, BITstar, CForest, FMTstar, InformedRRTstar, PRMstar, RRTstar, and SORRTstar.") //Alphabetical order
         ("objective,o", bpo::value<std::string>()->default_value("PathLength"), "(Optional) Specify the optimization objective, defaults to PathLength if not given. Valid options are PathClearance, PathLength, ThresholdPathLength, and WeightedLengthAndClearanceCombo.") //Alphabetical order
         ("file,f", bpo::value<std::string>()->default_value(""), "(Optional) Specify an output path for the found solution path.")
         ("info,i", bpo::value<unsigned int>()->default_value(0u), "(Optional) Set the OMPL log level. 0 for WARN, 1 for INFO, 2 for DEBUG. Defaults to WARN.");
@@ -474,7 +481,10 @@ bool argParse(int argc, char** argv, double* runTimePtr, optimalPlanner *planner
     std::string plannerStr = vm["planner"].as<std::string>();
 
     // Map the string to the enum
-    if (boost::iequals("BFMTstar", plannerStr))
+    if (boost::iequals("AITstar", plannerStr)) {
+        *plannerPtr = PLANNER_AITSTAR;
+    }
+    else if (boost::iequals("BFMTstar", plannerStr))
     {
         *plannerPtr = PLANNER_BFMTSTAR;
     }

--- a/src/ompl/geometric/planners/informedtrees/AITstar.h
+++ b/src/ompl/geometric/planners/informedtrees/AITstar.h
@@ -159,7 +159,7 @@ namespace ompl
 
         private:
             /** \brief Performs one iteration of AIT*. */
-            void iterate();
+            void iterate(const ompl::base::PlannerTerminationCondition &terminationCondition);
 
             /** \brief Performs one forward search iterations. */
             void performForwardSearchIteration();

--- a/src/ompl/geometric/planners/informedtrees/aitstar/ImplicitGraph.h
+++ b/src/ompl/geometric/planners/informedtrees/aitstar/ImplicitGraph.h
@@ -88,7 +88,8 @@ namespace ompl
                 void setTrackApproximateSolution(bool track);
 
                 /** \brief Adds a batch of samples and returns the samples it has added. */
-                std::vector<std::shared_ptr<Vertex>> addSamples(std::size_t numNewSamples);
+                bool addSamples(std::size_t numNewSamples,
+                                const ompl::base::PlannerTerminationCondition &terminationCondition);
 
                 /** \brief Gets the number of samples in the graph. */
                 std::size_t getNumVertices() const;
@@ -217,6 +218,9 @@ namespace ompl
                  * add start states after we've pruned some goal states, we might want to add these pruned goal states
                  * again. */
                 std::vector<std::shared_ptr<Vertex>> prunedGoalVertices_;
+
+                /** \brief The new samples already sampled but not yet added to the nearest neighbor struct. */
+                std::vector<std::shared_ptr<Vertex>> newSamples_;
 
                 /** \brief The number of sampled states that were valid. */
                 mutable std::size_t numValidSamples_{0u};

--- a/src/ompl/geometric/planners/informedtrees/aitstar/Vertex.h
+++ b/src/ompl/geometric/planners/informedtrees/aitstar/Vertex.h
@@ -178,7 +178,7 @@ namespace ompl
                 void cacheNeighbors(const std::vector<std::shared_ptr<Vertex>> &neighbors) const;
 
                 /** \brief Returns the nearest neighbors, throws if not up to date. */
-                const std::vector<std::shared_ptr<Vertex>> &getNeighbors() const;
+                const std::vector<std::shared_ptr<Vertex>> getNeighbors() const;
 
                 /** \brief Registers that a child has been added to this vertex during the current forward search. */
                 void registerPoppedOutgoingEdgeDuringForwardSearch();
@@ -281,7 +281,7 @@ namespace ompl
                 std::vector<std::weak_ptr<Vertex>> reverseChildren_{};
 
                 /** \brief The cached neighbors of this vertex. */
-                mutable std::vector<std::shared_ptr<Vertex>> neighbors_{};
+                mutable std::vector<std::weak_ptr<Vertex>> neighbors_{};
 
                 /** \brief The list of whitelisted children. */
                 mutable std::vector<std::weak_ptr<Vertex>> whitelistedChildren_{};


### PR DESCRIPTION
Hi Mark,

I hope you are doing well.

TLDR: This PR

1. fixes a memory-leak in AIT* (hopefully this is the error you referenced in #723);
2. makes AIT* check termination conditions while sampling a new batch of states; and
3. adds AIT* to the optimal planning demo.

Please let me know if you have any questions.

Details:

1. Memory leak: AIT* caches nearest-neighbors results for each sample. It used to do so by storing the nearest-neighbors in a vector of `std::shared_ptr`s, but this could lead to a memory leak when two (or more) neighboring samples were pruned. This PR changes the nearest-neighbor cache to hold `std::weak_ptr`s instead.
2. Check termination condition while sampling: AIT* uses informed sampling to sample states. If the optimization objective does not support a direct sampler and the current solution is close to optimal, sampling informed states can take many attempts. This PR ensures AIT* is better at respecting the termination condition by checking it after every sample.
3. Add AIT* to the optimal planning demo: In trying to make this PR as little work for you as possible, I've ensured AIT* works on the optimal planning demo (`demo_OptimalPlanning`), the SE3 rigid body planning demo of ompl app (`demo_SE3RigidBodyPlanning`), as well as the 2d circles test for optimal planners (`test_2dcircles_opt_geometric`). I figured I could leave AIT* as option in the optimal planning demo.
