### PR TITLE
make PathSimplifier aware of the objective in SimpleSetup

### DIFF
--- a/src/ompl/geometric/src/SimpleSetup.cpp
+++ b/src/ompl/geometric/src/SimpleSetup.cpp
@@ -70,6 +70,7 @@ void ompl::geometric::SimpleSetup::setup()
         planner_->setProblemDefinition(pdef_);
         if (!planner_->isSetup())
             planner_->setup();
+        psk_ = std::make_shared<PathSimplifier>(si_, pdef_->getGoal(), pdef_->getOptimizationObjective());
         configured_ = true;
     }
 }
@@ -90,13 +91,16 @@ void ompl::geometric::SimpleSetup::setStartAndGoalStates(const base::ScopedState
     // Clear any past solutions since they no longer correspond to our start and goal states
     pdef_->clearSolutionPaths();
 
-    psk_ = std::make_shared<PathSimplifier>(si_, pdef_->getGoal());
+    // force setup to rerun
+    configured_ = false;
 }
 
 void ompl::geometric::SimpleSetup::setGoalState(const base::ScopedState<> &goal, const double threshold)
 {
     pdef_->setGoalState(goal, threshold);
-    psk_ = std::make_shared<PathSimplifier>(si_, pdef_->getGoal());
+
+    // force setup to rerun 
+    configured_ = false;
 }
 
 /** \brief Set the goal for planning. This call is not
@@ -109,6 +113,9 @@ void ompl::geometric::SimpleSetup::setGoal(const base::GoalPtr &goal)
         psk_ = std::make_shared<PathSimplifier>(si_, pdef_->getGoal());
     else
         psk_ = std::make_shared<PathSimplifier>(si_);
+
+    // force setup to rerun
+    configured_ = false;
 }
 
 // we provide a duplicate implementation here to allow the planner to choose how the time is turned into a planner


### PR DESCRIPTION
The `SimpleSetup` class is absolutely awesome but it currently has a limitation where even if you set a custom objective via

```cpp
simple_setup.setOptimizationObjective(my_objective);
```

it doesn't make the `PathSimplifier` aware of that objective and it simply defaults to optimizing for the shortest path length. This can be seen in the plot below

![image (2)](https://user-images.githubusercontent.com/19624734/109522729-3dd67200-7ab7-11eb-89e4-3be7b68e267e.png)

In it, I have set a custom objective which includes optimizing for the shortest path and a potential field that should force the path to the wall on the right side. The solution states in purple are correctly optimized and sit on the right but after I run path simplification I get the path in blue which disregards my custom objective.

With the changes in this MR, running the same experiment results in 

![image (3)](https://user-images.githubusercontent.com/19624734/109523070-9b6abe80-7ab7-11eb-8a1c-6f47357649f6.png)

(the transparent line is the reference towards which the path is pulled)