### PR TITLE
Clean up BIT* planner progress properties

### DIFF
--- a/src/ompl/geometric/planners/informedtrees/BITstar.h
+++ b/src/ompl/geometric/planners/informedtrees/BITstar.h
@@ -476,8 +476,7 @@ namespace ompl
             std::shared_ptr<ImplicitGraph> graphPtr_{nullptr};
 
             /** \brief The queue of vertices to expand and edges to process ordered on "f-value", i.e., estimated
-             * solution cost. Remaining vertex queue "size" and edge queue size are accessible via
-             * vertexQueueSizeProgressProperty and edgeQueueSizeProgressProperty, respectively. */
+             * solution cost. */
             std::shared_ptr<SearchQueue> queuePtr_{nullptr};
 
             /** \brief The inflation factor for the initial search. */

--- a/src/ompl/geometric/planners/informedtrees/BITstar.h
+++ b/src/ompl/geometric/planners/informedtrees/BITstar.h
@@ -149,7 +149,7 @@ namespace ompl
             using NameFunc = std::function<std::string()>;
 
             /** \brief Construct with a pointer to the space information and an optional name. */
-            BITstar(const base::SpaceInformationPtr &spaceInfo, const std::string &name = "BITstar");
+            BITstar(const base::SpaceInformationPtr &spaceInfo, const std::string &name = "kBITstar");
 
             /** \brief Destruct using the default destructor. */
             virtual ~BITstar() override = default;

--- a/src/ompl/geometric/planners/informedtrees/bitstar/src/ImplicitGraph.cpp
+++ b/src/ompl/geometric/planners/informedtrees/bitstar/src/ImplicitGraph.cpp
@@ -247,24 +247,6 @@ namespace ompl
             // The approximation id.
             *approximationId_ = 1u;
 
-            // The lookups and white-/blacklists of the start vertices.
-            for (const auto &vertex : startVertices_)
-            {
-                vertex->clearEdgeQueueInLookup();
-                vertex->clearEdgeQueueOutLookup();
-                vertex->clearBlacklist();
-                vertex->clearWhitelist();
-            }
-
-            // The lookups and white-/blacklists of the goal vertices.
-            for (const auto &vertex : goalVertices_)
-            {
-                vertex->clearEdgeQueueInLookup();
-                vertex->clearEdgeQueueOutLookup();
-                vertex->clearBlacklist();
-                vertex->clearWhitelist();
-            }
-
             // The various convenience pointers:
             // DO NOT reset the parameters:
             // rewireFactor_

--- a/src/ompl/geometric/planners/informedtrees/src/BITstar.cpp
+++ b/src/ompl/geometric/planners/informedtrees/src/BITstar.cpp
@@ -1325,7 +1325,7 @@ namespace ompl
 
         std::string BITstar::bestCostProgressProperty() const
         {
-            return ompl::toString(this->bestCost().value());
+            return ompl::toString(bestCost_.value());
         }
 
         std::string BITstar::bestLengthProgressProperty() const
@@ -1340,12 +1340,12 @@ namespace ompl
 
         std::string BITstar::iterationProgressProperty() const
         {
-            return std::to_string(this->numIterations());
+            return std::to_string(numIterations_);
         }
 
         std::string BITstar::batchesProgressProperty() const
         {
-            return std::to_string(this->numBatches());
+            return std::to_string(numBatches_);
         }
 
         std::string BITstar::pruningProgressProperty() const

--- a/src/ompl/geometric/planners/informedtrees/src/BITstar.cpp
+++ b/src/ompl/geometric/planners/informedtrees/src/BITstar.cpp
@@ -126,10 +126,6 @@ namespace ompl
 
             // Extra progress info that aren't necessary for every day use. Uncomment if desired.
             /*
-            addPlannerProgressProperty("vertex queue size INTEGER", [this]
-                                       {
-                                           return vertexQueueSizeProgressProperty();
-                                       });
             addPlannerProgressProperty("edge queue size INTEGER", [this]
                                        {
                                            return edgeQueueSizeProgressProperty();

--- a/src/ompl/geometric/planners/informedtrees/src/BITstar.cpp
+++ b/src/ompl/geometric/planners/informedtrees/src/BITstar.cpp
@@ -117,9 +117,6 @@ namespace ompl
             addPlannerProgressProperty("best cost DOUBLE", [this] { return bestCostProgressProperty(); });
             addPlannerProgressProperty("number of segments in solution path INTEGER",
                                        [this] { return bestLengthProgressProperty(); });
-            addPlannerProgressProperty("current free states INTEGER", [this] { return currentFreeProgressProperty(); });
-            addPlannerProgressProperty("current graph vertices INTEGER",
-                                       [this] { return currentVertexProgressProperty(); });
             addPlannerProgressProperty("state collision checks INTEGER",
                                        [this] { return stateCollisionCheckProgressProperty(); });
             addPlannerProgressProperty("edge collision checks INTEGER",
@@ -1338,16 +1335,6 @@ namespace ompl
         std::string BITstar::bestLengthProgressProperty() const
         {
             return std::to_string(bestLength_);
-        }
-
-        std::string BITstar::currentFreeProgressProperty() const
-        {
-            return std::to_string(graphPtr_->numSamples());
-        }
-
-        std::string BITstar::currentVertexProgressProperty() const
-        {
-            return std::to_string(graphPtr_->numVertices());
         }
 
         std::string BITstar::edgeQueueSizeProgressProperty() const

--- a/src/ompl/geometric/planners/informedtrees/src/BITstar.cpp
+++ b/src/ompl/geometric/planners/informedtrees/src/BITstar.cpp
@@ -661,14 +661,10 @@ namespace ompl
 
                 // Count the number of samples that could be pruned.
                 auto samples = graphPtr_->getCopyOfSamples();
-                unsigned int numSamplesThatCouldBePruned(0u);
-                for (const auto &sample : samples)
-                {
-                    if (graphPtr_->canSampleBePruned(sample))
-                    {
-                        ++numSamplesThatCouldBePruned;
-                    }
-                }
+                auto numSamplesThatCouldBePruned =
+                    std::count_if(samples.begin(), samples.end(), [this](const auto& sample){
+                        return graphPtr_->canSampleBePruned(sample);
+                    });
 
                 // Only prune if the decrease in number of samples and the associated decrease in nearest neighbour
                 // lookup cost justifies the cost of pruning. There has to be a way to make this more formal, and less


### PR DESCRIPTION
The main purpose of this PR is to remove the planner progress properties in BIT* that are not thread-safe (namely getting number of current vertices in graph and getting number of total samples). This should fix #779, @jediofgever can you please confirm?

I also changed the default name of BIT* from `"BITstar"` to `"kBITstar"` since by default BIT* is instantiated with a k-nearest connection model (since c08da89), which silences a warning. I also took the chance to clean up some code as it came up.