### PR TITLE
Fixed mismatched tags in package.xml

### DIFF
--- a/package.xml
+++ b/package.xml
@@ -18,8 +18,8 @@
   <build_depend>boost</build_depend>
   <build_depend>eigen</build_depend>
   <build_depend>pkg-config</build_depend>
-  <build_depend>opende</exec_depend>
-  <build_depend>libflann-dev</exec_depend>
+  <build_depend>opende</build_depend>
+  <build_depend>libflann-dev</build_depend>
 
   <exec_depend>boost</exec_depend>
   <exec_depend>eigen</exec_depend>


### PR DESCRIPTION
The xml tags were mismatched, resulting in an error when I recently attempted to install OMPL.

I changed the close tags to be the same as the open tags and then I was able to compile OMPL.