### PR TITLE
Set the sampled cost to identity when adding a new batch in BIT*

### DIFF
--- a/src/ompl/geometric/planners/informedtrees/bitstar/src/ImplicitGraph.cpp
+++ b/src/ompl/geometric/planners/informedtrees/bitstar/src/ImplicitGraph.cpp
@@ -600,8 +600,8 @@ namespace ompl
         {
             ASSERT_SETUP
 
-            // Set the cost sampled to the minimum
-            sampledCost_ = minCost_;
+            // Set the cost sampled to identity
+            sampledCost_ = costHelpPtr_->identityCost();
 
             // Store the number of samples being used in this batch
             numNewSamplesInCurrentBatch_ = numSamples;


### PR DESCRIPTION
This PR fixes a small issue that @gammell and I noticed when BIT* plans in compound spaces where the informed set of some subspaces can be sampled directly.

Here's how I understand what the problem was: If sampling from a compound state space with `RealVectorStateSpace`s as components, then direct informed sampling is used for these components. To support just-in-time sampling, BIT* samples "shells" of the informed set in these components. These shells are defined by a minimum and maximum cost. The issue with initializing `sampledCost_` as the minimum possible cost to solve the problem is that some of that cost might come from non-`RealVectorStateSpace` components of the compound state space, e.g., the angular component in SE(2). If this is the case, then the center of the informed set in the `RealVectorStateSpace` components is never sampled.

Initializing `sampledCost_` to the identity cost whenever a new batch is added ensures that the first shell includes the center.