### PR TITLE
override the validSegmentCount function of the ReedsSheppState Space

### DIFF
--- a/src/ompl/base/spaces/ReedsSheppStateSpace.h
+++ b/src/ompl/base/spaces/ReedsSheppStateSpace.h
@@ -99,6 +99,11 @@ namespace ompl
             }
 
             double distance(const State *state1, const State *state2) const override;
+            unsigned int validSegmentCount(const State *state1, const State *state2) const override
+            {
+                return longestValidSegmentCountFactor_ *
+                       (unsigned int)ceil(distance(state1, state2) / longestValidSegment_);
+            }
 
             void interpolate(const State *from, const State *to, double t, State *state) const override;
             virtual void interpolate(const State *from, const State *to, double t, bool &firstTime,


### PR DESCRIPTION
the inherited validSegmentCount is calculated by 2D distances between states, which causes the undersampling issue to the ReedsShepp curves connecting two states near in 2D positions.