### PR TITLE
Optimization Objectives: Add support for control-space planners

### DIFF
--- a/src/ompl/base/OptimizationObjective.h
+++ b/src/ompl/base/OptimizationObjective.h
@@ -42,6 +42,7 @@
 #include "ompl/util/ClassForward.h"
 #include "ompl/base/ProblemDefinition.h"
 #include "ompl/base/samplers/InformedStateSampler.h"
+#include "ompl/control/Control.h"
 
 #include <functional>
 #include <iostream>
@@ -114,6 +115,10 @@ namespace ompl
 
             /** \brief Get the cost that corresponds to the motion segment between \e s1 and \e s2 */
             virtual Cost motionCost(const State *s1, const State *s2) const = 0;
+
+            /** \brief Get the cost that corresponds to the motion created by a control \e c applied for duration \e steps.
+             * The default implementation uses the identityCost. */
+            virtual Cost controlCost(const control::Control *c, unsigned int steps) const;
 
             /** \brief Get the cost that corresponds to combining the costs \e c1 and \e c2. Default implementation
              * defines this combination as an addition. */

--- a/src/ompl/base/objectives/ControlDurationObjective.h
+++ b/src/ompl/base/objectives/ControlDurationObjective.h
@@ -1,0 +1,72 @@
+/*********************************************************************
+* Software License Agreement (BSD License)
+*
+*  Copyright (c) 2010, Rice University
+*  All rights reserved.
+*
+*  Redistribution and use in source and binary forms, with or without
+*  modification, are permitted provided that the following conditions
+*  are met:
+*
+*   * Redistributions of source code must retain the above copyright
+*     notice, this list of conditions and the following disclaimer.
+*   * Redistributions in binary form must reproduce the above
+*     copyright notice, this list of conditions and the following
+*     disclaimer in the documentation and/or other materials provided
+*     with the distribution.
+*   * Neither the name of the Rice University nor the names of its
+*     contributors may be used to endorse or promote products derived
+*     from this software without specific prior written permission.
+*
+*  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+*  "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+*  LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+*  FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+*  COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+*  INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+*  BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+*  LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+*  CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+*  LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+*  ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+*  POSSIBILITY OF SUCH DAMAGE.
+*********************************************************************/
+
+/* Author: Wolfgang Hönig */
+
+#ifndef OMPL_BASE_OBJECTIVES_CONTROL_DURATION_OPTIMIZATION_OBJECTIVE_
+#define OMPL_BASE_OBJECTIVES_CONTROL_DURATION_OPTIMIZATION_OBJECTIVE_
+
+#include "ompl/base/OptimizationObjective.h"
+#include "ompl/control/SpaceInformation.h"
+
+namespace ompl
+{
+    namespace base
+    {
+        /** \brief Defines optimization objectives where the total
+            time of a control action is summed. This cost function is
+            specified by implementing the controlCost() method. */
+        class ControlDurationObjective : public OptimizationObjective
+        {
+        public:
+            /** \brief Requires a control::SpaceInformationPtr to access \p dt. */
+            ControlDurationObjective(const control::SpaceInformationPtr &si);
+
+            /** \brief Returns a cost with a value of 0. */
+            Cost stateCost(const State *s) const override;
+
+            /** \brief Returns a cost with a value of 0. */
+            Cost motionCost(const State *s1, const State *s2) const override;
+
+            /** \brief Returns the cost with the value of steps*dt. */
+            Cost controlCost(const control::Control *c, unsigned int steps) const override;
+
+        protected:
+            /** \brief Duration of each control step. */
+            double dt_;
+        };
+    }
+}
+
+#endif

--- a/src/ompl/base/objectives/src/ControlDurationObjective.cpp
+++ b/src/ompl/base/objectives/src/ControlDurationObjective.cpp
@@ -1,0 +1,60 @@
+/*********************************************************************
+* Software License Agreement (BSD License)
+*
+*  Copyright (c) 2010, Rice University
+*  All rights reserved.
+*
+*  Redistribution and use in source and binary forms, with or without
+*  modification, are permitted provided that the following conditions
+*  are met:
+*
+*   * Redistributions of source code must retain the above copyright
+*     notice, this list of conditions and the following disclaimer.
+*   * Redistributions in binary form must reproduce the above
+*     copyright notice, this list of conditions and the following
+*     disclaimer in the documentation and/or other materials provided
+*     with the distribution.
+*   * Neither the name of the Rice University nor the names of its
+*     contributors may be used to endorse or promote products derived
+*     from this software without specific prior written permission.
+*
+*  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+*  "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+*  LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+*  FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+*  COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+*  INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+*  BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+*  LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+*  CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+*  LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+*  ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+*  POSSIBILITY OF SUCH DAMAGE.
+*********************************************************************/
+
+/* Author: Wolfgang Hönig */
+
+#include "ompl/base/objectives/ControlDurationObjective.h"
+
+ompl::base::ControlDurationObjective::ControlDurationObjective(const control::SpaceInformationPtr &si)
+  : OptimizationObjective(si)
+{
+    description_ = "Control Duration";
+    dt_ = si->getPropagationStepSize();
+}
+
+ompl::base::Cost ompl::base::ControlDurationObjective::stateCost(const State *) const
+{
+    return Cost(0.0);
+}
+
+ompl::base::Cost ompl::base::ControlDurationObjective::motionCost(const State *, const State *) const
+{
+    return Cost(0.0);
+}
+
+ompl::base::Cost ompl::base::ControlDurationObjective::controlCost(const control::Control *,
+                                                                     unsigned int steps) const
+{
+    return Cost(steps * dt_);
+}

--- a/src/ompl/base/src/OptimizationObjective.cpp
+++ b/src/ompl/base/src/OptimizationObjective.cpp
@@ -88,6 +88,11 @@ ompl::base::Cost ompl::base::OptimizationObjective::betterCost(Cost c1, Cost c2)
     return isCostBetterThan(c1, c2) ? c1 : c2;
 }
 
+ompl::base::Cost ompl::base::OptimizationObjective::controlCost(const control::Control *, unsigned int) const
+{
+    return identityCost();
+}
+
 ompl::base::Cost ompl::base::OptimizationObjective::combineCosts(Cost c1, Cost c2) const
 {
     return Cost(c1.value() + c2.value());

--- a/src/ompl/control/planners/sst/src/SST.cpp
+++ b/src/ompl/control/planners/sst/src/SST.cpp
@@ -266,7 +266,9 @@ ompl::base::PlannerStatus ompl::control::SST::solve(const base::PlannerTerminati
 
         if (propCd == cd)
         {
-            base::Cost incCost = opt_->motionCost(nmotion->state_, rstate);
+            base::Cost incCostMotion = opt_->motionCost(nmotion->state_, rstate);
+            base::Cost incCostControl = opt_->controlCost(rctrl, cd);
+            base::Cost incCost = opt_->combineCosts(incCostMotion, incCostControl);
             base::Cost cost = opt_->combineCosts(nmotion->accCost_, incCost);
             Witness *closestWitness = findClosestWitness(rmotion);
 


### PR DESCRIPTION
OptimizationObjective was designed for geometric planning and cannot
associate costs with ompl::control::Control. This addresses this short-
coming in the following way:

* New controlCost(control, steps) function (defaults to identityCost)
* New ControlDurationObjective, which minimizes the total time needed
* Support for controlCost() in the control-space version of SST

Other typical control-space costs include control-integral costs, but
are application-specific and can be now defined by the user by creating
a derived class inheriting from OptimizationObjective().