### PR TITLE
SST: Add support for IntermediateSolutionCallback of problem definition

### DIFF
--- a/src/ompl/control/planners/sst/src/SST.cpp
+++ b/src/ompl/control/planners/sst/src/SST.cpp
@@ -234,6 +234,8 @@ ompl::base::PlannerStatus ompl::control::SST::solve(const base::PlannerTerminati
     if (!controlSampler_)
         controlSampler_ = siC_->allocControlSampler();
 
+    const base::ReportIntermediateSolutionFn intermediateSolutionCallback = pdef_->getIntermediateSolutionCallback();
+
     OMPL_INFORM("%s: Starting planning with %u states already in datastructure\n", getName().c_str(), nn_->size());
 
     Motion *solution = nullptr;
@@ -313,6 +315,12 @@ ompl::base::PlannerStatus ompl::control::SST::solve(const base::PlannerTerminati
                     prevSolutionCost_ = solution->accCost_;
 
                     OMPL_INFORM("Found solution with cost %.2f", solution->accCost_.value());
+                    if (intermediateSolutionCallback)
+                    {
+                        // the callback requires a vector with const elements -> create a copy
+                        std::vector<const base::State *> prevSolutionConst(prevSolution_.begin(), prevSolution_.end());
+                        intermediateSolutionCallback(this, prevSolutionConst, prevSolutionCost_);
+                    }
                     sufficientlyShort = opt_->isSatisfied(solution->accCost_);
                     if (sufficientlyShort)
                         break;

--- a/src/ompl/geometric/planners/sst/src/SST.cpp
+++ b/src/ompl/geometric/planners/sst/src/SST.cpp
@@ -245,6 +245,8 @@ ompl::base::PlannerStatus ompl::geometric::SST::solve(const base::PlannerTermina
     if (!sampler_)
         sampler_ = si_->allocStateSampler();
 
+    const base::ReportIntermediateSolutionFn intermediateSolutionCallback = pdef_->getIntermediateSolutionCallback();
+
     OMPL_INFORM("%s: Starting planning with %u states already in datastructure", getName().c_str(), nn_->size());
 
     Motion *solution = nullptr;
@@ -329,6 +331,12 @@ ompl::base::PlannerStatus ompl::geometric::SST::solve(const base::PlannerTermina
                     prevSolutionCost_ = solution->accCost_;
 
                     OMPL_INFORM("Found solution with cost %.2f", solution->accCost_.value());
+                    if (intermediateSolutionCallback)
+                    {
+                        // the callback requires a vector with const elements -> create a copy
+                        std::vector<const base::State *> prevSolutionConst(prevSolution_.begin(), prevSolution_.end());
+                        intermediateSolutionCallback(this, prevSolutionConst, prevSolutionCost_);
+                    }
                     sufficientlyShort = opt_->isSatisfied(solution->accCost_);
                     if (sufficientlyShort)
                     {


### PR DESCRIPTION
SST currently just prints an information when a new solution is found.
This change calls the (optional) callback that a user can set to get
informed about new solutions, similar to BIT*, RRT* etc.