### PR TITLE
Ensure RRT-Connect alternates expansion of trees

### DIFF
--- a/src/ompl/geometric/planners/rrt/RRTConnect.h
+++ b/src/ompl/geometric/planners/rrt/RRTConnect.h
@@ -177,6 +177,9 @@ namespace ompl
             /** \brief The goal tree */
             TreeData tGoal_;
 
+            /** \brief A flag that toggles between expanding the start tree (true) or goal tree (false). */
+            bool startTree_{true};
+
             /** \brief The maximum length of a motion to be added to a tree */
             double maxDistance_{0.};
 

--- a/src/ompl/geometric/planners/rrt/src/RRTConnect.cpp
+++ b/src/ompl/geometric/planners/rrt/src/RRTConnect.cpp
@@ -227,15 +227,14 @@ ompl::base::PlannerStatus ompl::geometric::RRTConnect::solve(const base::Planner
     double approxdif = std::numeric_limits<double>::infinity();
     auto *rmotion = new Motion(si_);
     base::State *rstate = rmotion->state;
-    bool startTree = true;
     bool solved = false;
 
     while (!ptc)
     {
-        TreeData &tree = startTree ? tStart_ : tGoal_;
-        tgi.start = startTree;
-        startTree = !startTree;
-        TreeData &otherTree = startTree ? tStart_ : tGoal_;
+        TreeData &tree = startTree_ ? tStart_ : tGoal_;
+        tgi.start = startTree_;
+        startTree_ = !startTree_;
+        TreeData &otherTree = startTree_ ? tStart_ : tGoal_;
 
         if (tGoal_->size() == 0 || pis_.getSampledGoalsCount() < tGoal_->size() / 2)
         {
@@ -271,7 +270,7 @@ ompl::base::PlannerStatus ompl::geometric::RRTConnect::solve(const base::Planner
             if (gs != REACHED)
                 si_->copyState(rstate, tgi.xstate);
 
-            tgi.start = startTree;
+            tgi.start = startTree_;
 
             /* if initial progress cannot be done from the otherTree, restore tgi.start */
             GrowState gsc = growTree(otherTree, tgi, rmotion);


### PR DESCRIPTION
Hi Mark

A small change for RRT-Connect:

I think it's important that planners can be visualized iteration by iteration. One way to achieve this is to repeatedly call solve with an always-terminating ptc and get the planner data after each call. This small change ensures that RRT-Connect alternates between expanding the start and goal trees in this scenario.

cc: @gammell 