### PR TITLE
PathLengthDirectInfSampler: Add support for nested RealVectorStatespace

### DIFF
--- a/src/ompl/base/samplers/informed/src/PathLengthDirectInfSampler.cpp
+++ b/src/ompl/base/samplers/informed/src/PathLengthDirectInfSampler.cpp
@@ -117,16 +117,16 @@ namespace ompl
             }
             else if (InformedSampler::space_->isCompound())
             {
+                // Variable:
+                // An ease of use upcasted pointer to the space as a compound space
+                const CompoundStateSpace *compoundSpace = InformedSampler::space_->as<CompoundStateSpace>();
+
                 // Check that the given space is SE2, SE3, Dubins, or Reeds-Shepp.
                 if (InformedSampler::space_->getType() == STATE_SPACE_SE2 ||
                     InformedSampler::space_->getType() == STATE_SPACE_SE3 ||
                     InformedSampler::space_->getType() == STATE_SPACE_DUBINS ||
                     InformedSampler::space_->getType() == STATE_SPACE_REEDS_SHEPP)
                 {
-                    // Variable:
-                    // An ease of use upcasted pointer to the space as a compound space
-                    const CompoundStateSpace *compoundSpace = InformedSampler::space_->as<CompoundStateSpace>();
-
                     // Sanity check
                     if (compoundSpace->getSubspaceCount() != 2u)
                     {
@@ -154,15 +154,28 @@ namespace ompl
                         else
                         {
                             // Pout
-                            throw Exception("The provided compound state space contains a subspace that is not R^2, "
-                                            "R^3, SO(2), or SO(3).");
+                            throw Exception("The provided compound state space contains a subspace (" +
+                                            std::to_string(idx) + ") that is not R^N, SO(2), or SO(3): " +
+                                            std::to_string(compoundSpace->getSubspace(idx)->getType()));
                         }
                     }
                 }
                 else
                 {
-                    throw Exception("PathLengthDirectInfSampler only supports RealVector, SE2, SE3, Dubins, and "
-                                    "ReedsShepp state spaces.");
+                    // Case where we have a compound state space with only one subspace, and said subspace being R^N
+                    if (compoundSpace->getSubspaceCount() == 1u &&
+                        compoundSpace->getSubspace(0)->getType() == STATE_SPACE_REAL_VECTOR)
+                    {
+                        informedIdx_ = 0u;
+                        uninformedIdx_ = 0u;
+                    }
+                    else
+                    {
+                        throw Exception("PathLengthDirectInfSampler only supports RealVector, SE2, SE3, Dubins, and "
+                                        "ReedsShepp state spaces. Provided compound state space of type: " +
+                                        std::to_string(InformedSampler::space_->getType()) + " with " +
+                                        std::to_string(compoundSpace->getSubspaceCount()) + " subspaces.");
+                    }
                 }
             }
 

--- a/src/ompl/geometric/PathSimplifier.h
+++ b/src/ompl/geometric/PathSimplifier.h
@@ -133,8 +133,8 @@ namespace ompl
 
                 \param path the path to reduce vertices from
 
-                \param stepSize the size of the pertubations, i.e. the distance from a randomly selected configuration
-                and its position after perbutation. Also used to determine how far the points on either side of the
+                \param stepSize the size of the perturbations, i.e. the distance from a randomly selected configuration
+                and its position after perturbation. Also used to determine how far the points on either side of the
                 selected configuration are (stepSize / 2).
 
                 \param maxSteps the maximum number of attemps to perturb the path. If this value is set to 0 (the default),


### PR DESCRIPTION
This PR adds more detail to exceptions for compound state-spaces which help in diagnosing setup errors. 

It also enables compound state-spaces which have one RealVectorStatespace to work as if they were non-compound-state spaces.