### PR TITLE
preemptive c++17 compiler fix for FLANN

### DIFF
--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -19,6 +19,8 @@ if (OMPL_BUILD_TESTS)
     add_ompl_test(test_nearestneighbors datastructures/nearestneighbors.cpp)
     if(flann_FOUND)
         target_link_libraries(test_nearestneighbors ${FLANN_LIBRARIES})
+        # FLANN uses std::random_shuffle in a header file which is removed in C++17
+        set_target_properties(test_nearestneighbors PROPERTIES CXX_STANDARD 14)
     endif()
     add_ompl_test(test_pdf datastructures/pdf.cpp)
 


### PR DESCRIPTION
The rest of the code compiles fine when switching the OMPL C++ standard to C++17 with this one-line change:
```diff
--- a/CMakeModules/CompilerSettings.cmake
+++ b/CMakeModules/CompilerSettings.cmake
@@ -1,4 +1,4 @@
-set(CMAKE_CXX_STANDARD 14)
+set(CMAKE_CXX_STANDARD 17)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 set(CMAKE_CXX_EXTENSIONS OFF)
```