### PR TITLE
Conditionally use ament_cmake to register package for colcon workspaces environment

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -245,6 +245,7 @@ endif()
 
 find_package(ament_cmake QUIET)
 if(ament_cmake_FOUND)
+    ament_export_include_directories(include)
     # Allows ament to register colcon package when using ompl from underlay workspaces
     ament_package()
 endif()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -243,13 +243,11 @@ if (OMPL_REGISTRATION)
     endif()
 endif()
 
-# install catkin package.xml (needed for ROS installation)
-install(FILES package.xml
-    DESTINATION share/${PROJECT_NAME})
-
-# Allows Colcon to find non-Ament packages when using workspace underlays
-file(WRITE ${CMAKE_CURRENT_BINARY_DIR}/share/ament_index/resource_index/packages/${PROJECT_NAME} "")
-install(FILES ${CMAKE_CURRENT_BINARY_DIR}/share/ament_index/resource_index/packages/${PROJECT_NAME} DESTINATION share/ament_index/resource_index/packages)
+find_package(ament_cmake QUIET)
+if(ament_cmake_FOUND)
+    # Allows ament to register colcon package when using ompl from underlay workspaces
+    ament_package()
+endif()
 
 set_package_properties(PkgConfig PROPERTIES
     URL "https://www.freedesktop.org/wiki/Software/pkg-config/"

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -245,7 +245,7 @@ endif()
 
 find_package(ament_cmake QUIET)
 if(ament_cmake_FOUND)
-    ament_export_include_directories(include)
+    ament_export_include_directories(${CMAKE_INSTALL_INCLUDEDIR})
     # Allows ament to register colcon package when using ompl from underlay workspaces
     ament_package()
 endif()

--- a/package.xml
+++ b/package.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0"?>
-<package format="2">
+<package format="3">
   <name>ompl</name>
   <version>1.5.2</version>
   <description>OMPL is a free sampling-based motion planning library.</description>
@@ -13,6 +13,8 @@
   <author>Kavraki Lab</author>
 
   <buildtool_depend>cmake</buildtool_depend>
+  <buildtool_depend condition="$ROS_VERSION == 2">ament_cmake</buildtool_depend>
+
 
   <build_depend>cmake</build_depend>
   <build_depend>boost</build_depend>
@@ -27,6 +29,7 @@
   <exec_depend>libflann-dev</exec_depend>
 
   <export>
-    <build_type>cmake</build_type>
+    <build_type condition="$ROS_VERSION == 1">cmake</build_type>
+    <build_type condition="$ROS_VERSION == 2">ament_cmake</build_type>
   </export>
 </package>


### PR DESCRIPTION
Fixes https://github.com/ompl/ompl/issues/883 by mimicking the approach  from BehaviorTree.CPP to conditionally use ament_cmake.