### PR TITLE
Added missing header guards to header of derived classes of ompl::base::PlannerTerminationCondition 

### DIFF
--- a/src/ompl/base/terminationconditions/CostConvergenceTerminationCondition.h
+++ b/src/ompl/base/terminationconditions/CostConvergenceTerminationCondition.h
@@ -34,6 +34,9 @@
 
 /* Author: Henning Kayser, Mark Moll */
 
+#ifndef OMPL_BASE_COST_CONVERGENCE_TERMINATION_CONDITION_
+#define OMPL_BASE_COST_CONVERGENCE_TERMINATION_CONDITION_
+
 #include "ompl/base/PlannerTerminationCondition.h"
 
 namespace ompl
@@ -76,3 +79,5 @@ namespace ompl
         };
     }  // namespace base
 }  // namespace ompl
+
+#endif

--- a/src/ompl/base/terminationconditions/IterationTerminationCondition.h
+++ b/src/ompl/base/terminationconditions/IterationTerminationCondition.h
@@ -36,6 +36,9 @@
 
 #include "ompl/base/PlannerTerminationCondition.h"
 
+#ifndef OMPL_BASE_ITERATION_TERMINATION_CONDITION_
+#define OMPL_BASE_ITERATION_TERMINATION_CONDITION_
+
 namespace ompl
 {
     namespace base
@@ -72,3 +75,5 @@ namespace ompl
         };
     }  // namespace base
 }  // namespace ompl
+
+#endif


### PR DESCRIPTION
Added missing header guards to CostConvergenceTerminationCondition.h and IterationTerminationCondition.h