### PR TITLE
made PlannerTerminationCondition bools atomic

### DIFF
--- a/src/ompl/base/src/PlannerTerminationCondition.cpp
+++ b/src/ompl/base/src/PlannerTerminationCondition.cpp
@@ -36,6 +36,7 @@
 
 #include "ompl/base/PlannerTerminationCondition.h"
 #include "ompl/util/Time.h"
+#include <atomic>
 #include <thread>
 #include <utility>
 
@@ -147,10 +148,10 @@ namespace ompl
             std::thread *thread_;
 
             /** \brief Cached value returned by fn_() */
-            bool evalValue_;
+            std::atomic<bool> evalValue_;
 
             /** \brief Flag used to signal the condition evaluation thread to stop. */
-            bool signalThreadStop_;
+            std::atomic<bool> signalThreadStop_;
         };
 
         /// @endcond


### PR DESCRIPTION
Running with thread sanitizer, `-fsanitize=thread`, exposed possible race conditions in PlannerTerminationCondition. I'm not too familiar with OMPL's threading model, but changing the offending bools to `std::atomic<bool>` seems to have resolved the issue.

``` Write of size 1 at 0x7b1400001949 by main thread:
    #0 ompl::base::PlannerTerminationCondition::PlannerTerminationConditionImpl::stopEvalThread() <null> (navigator_test+0xe89820)
    #1 ompl::base::PlannerTerminationCondition::PlannerTerminationConditionImpl::~PlannerTerminationConditionImpl() <null> (navigator_test+0xe895cb)
    #2 void __gnu_cxx::new_allocator<ompl::base::PlannerTerminationCondition::PlannerTerminationConditionImpl>::destroy<ompl::base::PlannerTerminationCondition::PlannerTerminationConditionImpl>(ompl::base::PlannerTerminationCondition::PlannerTerminationConditionImpl*) <null> (navigator_test+0xe8bc13)
    #3 void std::allocator_traits<std::allocator<ompl::base::PlannerTerminationCondition::PlannerTerminationConditionImpl> >::destroy<ompl::base::PlannerTerminationCondition::PlannerTerminationConditionImpl>(std::allocator<ompl::base::PlannerTerminationCondition::PlannerTerminationConditionImpl>&, ompl::base::PlannerTerminationCondition::PlannerTerminationConditionImpl*) <null> (navigator_test+0xe8bb85)
    #4 std::_Sp_counted_ptr_inplace<ompl::base::PlannerTerminationCondition::PlannerTerminationConditionImpl, std::allocator<ompl::base::PlannerTerminationCondition::PlannerTerminationConditionImpl>, (__gnu_cxx::_Lock_policy)2>::_M_dispose() <null> (navigator_test+0xe8b9ee)
    #5 std::_Sp_counted_base<(__gnu_cxx::_Lock_policy)2>::_M_release() /usr/include/c++/7/bits/shared_ptr_base.h:154 (navigator_test+0xd36fa)
    #6 std::__shared_count<(__gnu_cxx::_Lock_policy)2>::~__shared_count() /usr/include/c++/7/bits/shared_ptr_base.h:684 (navigator_test+0xce812)
    #7 std::__shared_ptr<ompl::base::PlannerTerminationCondition::PlannerTerminationConditionImpl, (__gnu_cxx::_Lock_policy)2>::~__shared_ptr() /usr/include/c++/7/bits/shared_ptr_base.h:1123 (navigator_test+0xe83d05)
    #8 std::shared_ptr<ompl::base::PlannerTerminationCondition::PlannerTerminationConditionImpl>::~shared_ptr() /usr/include/c++/7/bits/shared_ptr.h:93 (navigator_test+0xe83d31)
    #9 ompl::base::PlannerTerminationCondition::~PlannerTerminationCondition() bazel-out/k8-dbg/bin/external/com_github_ompl_ompl/_virtual_includes/ompl/ompl/base/PlannerTerminationCondition.h:76 (navigator_test+0xe83d5d)
    #10 ompl::base::Planner::solve(double) external/com_github_ompl_ompl/src/ompl/base/src/Planner.cpp:144 (navigator_test+0xe81187)


  Previous read of size 1 at 0x7b1400001949 by thread T1:
    #0 ompl::base::PlannerTerminationCondition::PlannerTerminationConditionImpl::periodicEval() <null> (navigator_test+0xe89a6d)
    #1 ompl::base::PlannerTerminationCondition::PlannerTerminationConditionImpl::startEvalThread()::{lambda()#1}::operator()() const <null> (navigator_test+0xe896ef)
    #2 void std::__invoke_impl<void, ompl::base::PlannerTerminationCondition::PlannerTerminationConditionImpl::startEvalThread()::{lambda()#1}>(std::__invoke_other, ompl::base::PlannerTerminationCondition::PlannerTerminationConditionImpl::startEvalThread()::{lambda()#1}&&) <null> (navigator_test+0xe8a133)
    #3 std::__invoke_result<ompl::base::PlannerTerminationCondition::PlannerTerminationConditionImpl::startEvalThread()::{lambda()#1}>::type std::__invoke<ompl::base::PlannerTerminationCondition::PlannerTerminationConditionImpl::startEvalThread()::{lambda()#1}>(std::__invoke_result&&, (ompl::base::PlannerTerminationCondition::PlannerTerminationConditionImpl::startEvalThread()::{lambda()#1}&&)...) <null> (navigator_test+0xe89c85)
    #4 decltype (__invoke((_S_declval<0ul>)())) std::thread::_Invoker<std::tuple<ompl::base::PlannerTerminationCondition::PlannerTerminationConditionImpl::startEvalThread()::{lambda()#1}> >::_M_invoke<0ul>(std::_Index_tuple<0ul>) <null> (navigator_test+0xe8bc50)
    #5 std::thread::_Invoker<std::tuple<ompl::base::PlannerTerminationCondition::PlannerTerminationConditionImpl::startEvalThread()::{lambda()#1}> >::operator()() <null> (navigator_test+0xe8bbb7)
    #6 std::thread::_State_impl<std::thread::_Invoker<std::tuple<ompl::base::PlannerTerminationCondition::PlannerTerminationConditionImpl::startEvalThread()::{lambda()#1}> > >::_M_run() <null> (navigator_test+0xe8bafe)
    #7 <null> <null> (libstdc++.so.6+0xbd6de)

  Location is heap block of size 80 at 0x7b1400001900 allocated by main thread:
    #0 operator new(unsigned long) <null> (libtsan.so.0+0x73dda)
    #1 __gnu_cxx::new_allocator<std::_Sp_counted_ptr_inplace<ompl::base::PlannerTerminationCondition::PlannerTerminationConditionImpl, std::allocator<ompl::base::PlannerTerminationCondition::PlannerTerminationConditionImpl>, (__gnu_cxx::_Lock_policy)2> >::allocate(unsigned long, void const*) /usr/include/c++/7/ext/new_allocator.h:111 (navigator_test+0xe8b43e)
    #2 std::allocator_traits<std::allocator<std::_Sp_counted_ptr_inplace<ompl::base::PlannerTerminationCondition::PlannerTerminationConditionImpl, std::allocator<ompl::base::PlannerTerminationCondition::PlannerTerminationConditionImpl>, (__gnu_cxx::_Lock_policy)2> > >::allocate(std::allocator<std::_Sp_counted_ptr_inplace<ompl::base::PlannerTerminationCondition::PlannerTerminationConditionImpl, std::allocator<ompl::base::PlannerTerminationCondition::PlannerTerminationConditionImpl>, (__gnu_cxx::_Lock_policy)2> >&, unsigned long) /usr/include/c++/7/bits/alloc_traits.h:436 (navigator_test+0xe8b193)
    #3 std::__allocated_ptr<std::allocator<std::_Sp_counted_ptr_inplace<ompl::base::PlannerTerminationCondition::PlannerTerminationConditionImpl, std::allocator<ompl::base::PlannerTerminationCondition::PlannerTerminationConditionImpl>, (__gnu_cxx::_Lock_policy)2> > > std::__allocate_guarded<std::allocator<std::_Sp_counted_ptr_inplace<ompl::base::PlannerTerminationCondition::PlannerTerminationConditionImpl, std::allocator<ompl::base::PlannerTerminationCondition::PlannerTerminationConditionImpl>, (__gnu_cxx::_Lock_policy)2> > >(std::allocator<std::_Sp_counted_ptr_inplace<ompl::base::PlannerTerminationCondition::PlannerTerminationConditionImpl, std::allocator<ompl::base::PlannerTerminationCondition::PlannerTerminationConditionImpl>, (__gnu_cxx::_Lock_policy)2> >&) /usr/include/c++/7/bits/allocated_ptr.h:104 (navigator_test+0xe8ad5d)
    #4 std::__shared_count<(__gnu_cxx::_Lock_policy)2>::__shared_count<ompl::base::PlannerTerminationCondition::PlannerTerminationConditionImpl, std::allocator<ompl::base::PlannerTerminationCondition::PlannerTerminationConditionImpl>, std::function<bool ()> const&, double&>(std::_Sp_make_shared_tag, ompl::base::PlannerTerminationCondition::PlannerTerminationConditionImpl*, std::allocator<ompl::base::PlannerTerminationCondition::PlannerTerminationConditionImpl> const&, std::function<bool ()> const&, double&) /usr/include/c++/7/bits/shared_ptr_base.h:635 (navigator_test+0xe8abad)
    #5 std::__shared_ptr<ompl::base::PlannerTerminationCondition::PlannerTerminationConditionImpl, (__gnu_cxx::_Lock_policy)2>::__shared_ptr<std::allocator<ompl::base::PlannerTerminationCondition::PlannerTerminationConditionImpl>, std::function<bool ()> const&, double&>(std::_Sp_make_shared_tag, std::allocator<ompl::base::PlannerTerminationCondition::PlannerTerminationConditionImpl> const&, std::function<bool ()> const&, double&) /usr/include/c++/7/bits/shared_ptr_base.h:1295 (navigator_test+0xe8a90d)
    #6 std::shared_ptr<ompl::base::PlannerTerminationCondition::PlannerTerminationConditionImpl>::shared_ptr<std::allocator<ompl::base::PlannerTerminationCondition::PlannerTerminationConditionImpl>, std::function<bool ()> const&, double&>(std::_Sp_make_shared_tag, std::allocator<ompl::base::PlannerTerminationCondition::PlannerTerminationConditionImpl> const&, std::function<bool ()> const&, double&) /usr/include/c++/7/bits/shared_ptr.h:344 (navigator_test+0xe8a68a)
    #7 std::shared_ptr<ompl::base::PlannerTerminationCondition::PlannerTerminationConditionImpl> std::allocate_shared<ompl::base::PlannerTerminationCondition::PlannerTerminationConditionImpl, std::allocator<ompl::base::PlannerTerminationCondition::PlannerTerminationConditionImpl>, std::function<bool ()> const&, double&>(std::allocator<ompl::base::PlannerTerminationCondition::PlannerTerminationConditionImpl> const&, std::function<bool ()> const&, double&) /usr/include/c++/7/bits/shared_ptr.h:691 (navigator_test+0xe8a31e)
    #8 std::shared_ptr<ompl::base::PlannerTerminationCondition::PlannerTerminationConditionImpl> std::make_shared<ompl::base::PlannerTerminationCondition::PlannerTerminationConditionImpl, std::function<bool ()> const&, double&>(std::function<bool ()> const&, double&) /usr/include/c++/7/bits/shared_ptr.h:707 (navigator_test+0xe89e78)
    #9 ompl::base::PlannerTerminationCondition::PlannerTerminationCondition(std::function<bool ()> const&, double) external/com_github_ompl_ompl/src/ompl/base/src/PlannerTerminationCondition.cpp:165 (navigator_test+0xe86884)
    #10 ompl::base::timedPlannerTerminationCondition(double, double) external/com_github_ompl_ompl/src/ompl/base/src/PlannerTerminationCondition.cpp:217 (navigator_test+0xe87054)
    #11 ompl::base::Planner::solve(double) external/com_github_ompl_ompl/src/ompl/base/src/Planner.cpp:144 

  Thread T1 (tid=19, running) created by main thread at:
    #0 pthread_create <null> (libtsan.so.0+0x2bcee)
    #1 std::thread::_M_start_thread(std::unique_ptr<std::thread::_State, std::default_delete<std::thread::_State> >, void (*)()) <null> (libstdc++.so.6+0xbd994)
    #2 ompl::base::PlannerTerminationCondition::PlannerTerminationConditionImpl::startEvalThread() <null> (navigator_test+0xe897a6)
    #3 ompl::base::PlannerTerminationCondition::PlannerTerminationConditionImpl::PlannerTerminationConditionImpl(std::function<bool ()>, double) <null> (navigator_test+0xe8957a)
    #4 void __gnu_cxx::new_allocator<ompl::base::PlannerTerminationCondition::PlannerTerminationConditionImpl>::construct<ompl::base::PlannerTerminationCondition::PlannerTerminationConditionImpl, std::function<bool ()> const&, double&>(ompl::base::PlannerTerminationCondition::PlannerTerminationConditionImpl*, std::function<bool ()> const&, double&) /usr/include/c++/7/ext/new_allocator.h:136 (navigator_test+0xe8b6c9)
    #5 void std::allocator_traits<std::allocator<ompl::base::PlannerTerminationCondition::PlannerTerminationConditionImpl> >::construct<ompl::base::PlannerTerminationCondition::PlannerTerminationConditionImpl, std::function<bool ()> const&, double&>(std::allocator<ompl::base::PlannerTerminationCondition::PlannerTerminationConditionImpl>&, ompl::base::PlannerTerminationCondition::PlannerTerminationConditionImpl*, std::function<bool ()> const&, double&) /usr/include/c++/7/bits/alloc_traits.h:475 (navigator_test+0xe8b3c5)
    #6 std::_Sp_counted_ptr_inplace<ompl::base::PlannerTerminationCondition::PlannerTerminationConditionImpl, std::allocator<ompl::base::PlannerTerminationCondition::PlannerTerminationConditionImpl>, (__gnu_cxx::_Lock_policy)2>::_Sp_counted_ptr_inplace<std::function<bool ()> const&, double&>(std::allocator<ompl::base::PlannerTerminationCondition::PlannerTerminationConditionImpl>, std::function<bool ()> const&, double&) /usr/include/c++/7/bits/shared_ptr_base.h:526 (navigator_test+0xe8b108)
    #7 std::__shared_count<(__gnu_cxx::_Lock_policy)2>::__shared_count<ompl::base::PlannerTerminationCondition::PlannerTerminationConditionImpl, std::allocator<ompl::base::PlannerTerminationCondition::PlannerTerminationConditionImpl>, std::function<bool ()> const&, double&>(std::_Sp_make_shared_tag, ompl::base::PlannerTerminationCondition::PlannerTerminationConditionImpl*, std::allocator<ompl::base::PlannerTerminationCondition::PlannerTerminationConditionImpl> const&, std::function<bool ()> const&, double&) /usr/include/c++/7/bits/shared_ptr_base.h:637 (navigator_test+0xe8ac22)
    #8 std::__shared_ptr<ompl::base::PlannerTerminationCondition::PlannerTerminationConditionImpl, (__gnu_cxx::_Lock_policy)2>::__shared_ptr<std::allocator<ompl::base::PlannerTerminationCondition::PlannerTerminationConditionImpl>, std::function<bool ()> const&, double&>(std::_Sp_make_shared_tag, std::allocator<ompl::base::PlannerTerminationCondition::PlannerTerminationConditionImpl> const&, std::function<bool ()> const&, double&) /usr/include/c++/7/bits/shared_ptr_base.h:1295 (navigator_test+0xe8a90d)
    #9 std::shared_ptr<ompl::base::PlannerTerminationCondition::PlannerTerminationConditionImpl>::shared_ptr<std::allocator<ompl::base::PlannerTerminationCondition::PlannerTerminationConditionImpl>, std::function<bool ()> const&, double&>(std::_Sp_make_shared_tag, std::allocator<ompl::base::PlannerTerminationCondition::PlannerTerminationConditionImpl> const&, std::function<bool ()> const&, double&) /usr/include/c++/7/bits/shared_ptr.h:344 (navigator_test+0xe8a68a)
    #10 std::shared_ptr<ompl::base::PlannerTerminationCondition::PlannerTerminationConditionImpl> std::allocate_shared<ompl::base::PlannerTerminationCondition::PlannerTerminationConditionImpl, std::allocator<ompl::base::PlannerTerminationCondition::PlannerTerminationConditionImpl>, std::function<bool ()> const&, double&>(std::allocator<ompl::base::PlannerTerminationCondition::PlannerTerminationConditionImpl> const&, std::function<bool ()> const&, double&) /usr/include/c++/7/bits/shared_ptr.h:691 (navigator_test+0xe8a31e)
    #11 std::shared_ptr<ompl::base::PlannerTerminationCondition::PlannerTerminationConditionImpl> std::make_shared<ompl::base::PlannerTerminationCondition::PlannerTerminationConditionImpl, std::function<bool ()> const&, double&>(std::function<bool ()> const&, double&) /usr/include/c++/7/bits/shared_ptr.h:707 (navigator_test+0xe89e78)
    #12 ompl::base::PlannerTerminationCondition::PlannerTerminationCondition(std::function<bool ()> const&, double) external/com_github_ompl_ompl/src/ompl/base/src/PlannerTerminationCondition.cpp:165 (navigator_test+0xe86884)
    #13 ompl::base::timedPlannerTerminationCondition(double, double) external/com_github_ompl_ompl/src/ompl/base/src/PlannerTerminationCondition.cpp:217 (navigator_test+0xe87054) 