### PR TITLE
Fix use-after-free in PlannerInputStates::clear()

### DIFF
--- a/src/ompl/base/Planner.h
+++ b/src/ompl/base/Planner.h
@@ -128,13 +128,6 @@ namespace ompl
                 (different problem definition) and clear() was called. */
             bool use(const ProblemDefinitionPtr &pdef);
 
-            /** \brief Set the problem definition this class operates on.
-                If a planner is not set in the constructor argument, a call
-                to this function is needed before any calls to nextStart()
-                or nextGoal() are made. Returns true if changes were found
-                (different problem definition) and clear() was called. */
-            bool use(const ProblemDefinition *pdef);
-
             /** \brief Check if the problem definition was set, start
                 state are available and goal was set */
             void checkValidity() const;
@@ -183,7 +176,7 @@ namespace ompl
             unsigned int sampledGoalsCount_;
             State *tempState_;
 
-            const ProblemDefinition *pdef_;
+            ProblemDefinitionPtr pdef_;
             const SpaceInformation *si_;
         };
 

--- a/src/ompl/base/src/Planner.cpp
+++ b/src/ompl/base/src/Planner.cpp
@@ -173,7 +173,7 @@ void ompl::base::PlannerInputStates::clear()
     }
     addedStartStates_ = 0;
     sampledGoalsCount_ = 0;
-    pdef_ = nullptr;
+    pdef_.reset();
     si_ = nullptr;
 }
 
@@ -215,16 +215,7 @@ void ompl::base::PlannerInputStates::checkValidity() const
 
 bool ompl::base::PlannerInputStates::use(const ProblemDefinitionPtr &pdef)
 {
-    if (pdef)
-        return use(pdef.get());
-
-    clear();
-    return true;
-}
-
-bool ompl::base::PlannerInputStates::use(const ProblemDefinition *pdef)
-{
-    if (pdef_ != pdef)
+    if (pdef && pdef_ != pdef)
     {
         clear();
         pdef_ = pdef;


### PR DESCRIPTION
Signed-off-by: Tyler Weaver <tyler@picknik.ai>

This fixes a bug that occurs with this call stack:

```
#3 0x7f9ad6386df1 in ompl::base::SpaceInformation::freeState(ompl::base::State*) const /home/tyler/code/ws_miso_asan/src/ompl/src/ompl/base/SpaceInformation.h:240
#4 0x7f9ad6607711 in ompl::base::PlannerInputStates::clear() /home/tyler/code/ws_miso_asan/src/ompl/src/ompl/base/src/Planner.cpp:171
#5 0x7f9ad6607fae in ompl::base::PlannerInputStates::use(ompl::base::ProblemDefinition const*) /home/tyler/code/ws_miso_asan/src/ompl/src/ompl/base/src/Planner.cpp:229
#6 0x7f9ad6607f41 in ompl::base::PlannerInputStates::use(std::shared_ptr<ompl::base::ProblemDefinition> const&) /home/tyler/code/ws_miso_asan/src/ompl/src/ompl/base/src/Planner.cpp:219
#7 0x7f9ad6607a90 in ompl::base::PlannerInputStates::update() /home/tyler/code/ws_miso_asan/src/ompl/src/ompl/base/src/Planner.cpp:190
#8 0x7f9ad66062b4 in ompl::base::Planner::setProblemDefinition(std::shared_ptr<ompl::base::ProblemDefinition> const&) /home/tyler/code/ws_miso_asan/src/ompl/src/ompl/base/src/Planner.cpp:84
#9 0x7f9ad6e1bef6 in ompl::geometric::PRM::setProblemDefinition(std::shared_ptr<ompl::base::ProblemDefinition> const&) /home/tyler/code/ws_miso_asan/src/ompl/src/ompl/geometric/planners/prm/src/PRM.cpp:226
```

The simplest way to understand the problem is that there are two raw pointers in `PlannerInputStates` that you need to pay attention to:
```cpp
const ProblemDefinition *pdef_;
const SpaceInformation *si_;
```

`si_` is set in `ompl::base::PlannerInputStates::use` on this line:
```cpp
si_ = pdef->getSpaceInformation().get();
```

So you see that the lifetime of `si_` is tied to the lifetime of `pdef_` as it is a pointer to the internal state of `pdef`.

The first time this is called all is fine because `tempState_` is nullptr set so when the code gets to the `clear()` function it doesn't try to call `si->freeState`.

When this code path is executed a second time we start at this function that is called by PRM:
```cpp
void ompl::base::Planner::setProblemDefinition(const ProblemDefinitionPtr &pdef)
{
    pdef_ = pdef;
    pis_.update();
}
```

The first line of this will deallocate the old value that was stored in `pdef_` because this is a shared_ptr and the only place this is used. At this point `si_` is now pointing to invalid memory as it points to a value inside of what used to be kept alive by `pdef_`.

The way I patched away this bug is to preserve the lifetime of `pdef` by converting the raw pointer inside `ompl::base::PlannerInputStates` to a shared_ptr and getting rid of the interface to update it with a raw pointer.