### PR TITLE
LazyPRM: Check termination criteria while trying to construct a solution

### DIFF
--- a/src/ompl/geometric/planners/prm/src/LazyPRM.cpp
+++ b/src/ompl/geometric/planners/prm/src/LazyPRM.cpp
@@ -393,7 +393,7 @@ ompl::base::PlannerStatus ompl::geometric::LazyPRM::solve(const base::PlannerTer
             do
             {
                 solution = constructSolution(startV, goalV);
-            } while (!solution && vertexComponentProperty_[startV] == vertexComponentProperty_[goalV]);
+            } while (!solution && vertexComponentProperty_[startV] == vertexComponentProperty_[goalV] && !ptc);
             if (solution)
             {
                 someSolutionFound = true;


### PR DESCRIPTION
While using LazyPRM I encountered the issue that the planner sometimes ignored max planning time. As pointed out by #852 this is caused by a while loop that tries to construct a solution and this might exceed a specified max. planning time and thus violate a termination criteria. This PR fixes the issue by additionally checking the criteria as part of the while loop. It partially fixes #943 although I have not figured out why so many new states get created.