### PR TITLE
avoid dangling reference to CostConvergence parameters

### DIFF
--- a/src/ompl/base/terminationconditions/src/CostConvergenceTerminationCondition.cpp
+++ b/src/ompl/base/terminationconditions/src/CostConvergenceTerminationCondition.cpp
@@ -43,9 +43,10 @@ ompl::base::CostConvergenceTerminationCondition::CostConvergenceTerminationCondi
       solutionsWindow_(solutionsWindow),
       epsilon_(epsilon)
 {
+    auto& c = *this;
     pdef_->setIntermediateSolutionCallback(
-	    [this](const Planner* /*planner*/, const std::vector<const State*>& /*states*/, const Cost cost) {
-	        this->processNewSolution(cost);
+        [c](const Planner* /*planner*/, const std::vector<const State*>& /*states*/, const Cost cost) mutable {
+            c.processNewSolution(cost);
 	    });
 }
 


### PR DESCRIPTION
Currently the captured `this` pointer becomes a dangling reference as soon the original `CostConvergenceTerminationCondition` goes out of scope. This lead to a `solutionsWindow` of 0 which made this quite useless, current average being always `inf`.

Relates to #907 

@rhaschke tagging you due to initiating #906 