### PR TITLE
fix detection of python module path and version

### DIFF
--- a/CMakeModules/FindPython.cmake
+++ b/CMakeModules/FindPython.cmake
@@ -116,7 +116,7 @@ function(find_python_module module)
         # it's a .so file.
         if (_minversion STREQUAL "")
             execute_process(COMMAND "${PYTHON_EXEC}" "-c"
-                "import re, inspect, ${module}; print(re.compile('/__init__.py.*').sub('',inspect.getfile(${module})))"
+                "from importlib.util import find_spec; print(find_spec('${module}').submodule_search_locations[0])"
                 RESULT_VARIABLE _status OUTPUT_VARIABLE _location
                 ERROR_QUIET OUTPUT_STRIP_TRAILING_WHITESPACE)
             if(NOT _status)
@@ -125,7 +125,7 @@ function(find_python_module module)
             endif(NOT _status)
         else (_minversion STREQUAL "")
             execute_process(COMMAND "${PYTHON_EXEC}" "-c"
-                "import re, inspect, ${module}; print(re.compile('/__init__.py.*').sub('',${module}.__version__+';'+inspect.getfile(${module})))"
+                "from importlib.metadata import version; from importlib.util import find_spec; print(version('${module}') + ';' + find_spec('${module}').submodule_search_locations[0])"
                 RESULT_VARIABLE _status
                 OUTPUT_VARIABLE _verloc
                 ERROR_QUIET OUTPUT_STRIP_TRAILING_WHITESPACE)


### PR DESCRIPTION
`inspect.getfile` doesn't seem to work with python3.10 and higher for modules like `PyQt5`:
```
Traceback (most recent call last):
  File "<string>", line 1, in <module>
  File "/opt/local/Library/Frameworks/Python.framework/Versions/3.10/lib/python3.10/inspect.py", line 778, in getfile
    raise TypeError('{!r} is a built-in module'.format(object))
TypeError: <module 'PyQt5' (<_frozen_importlib_external._NamespaceLoader object at 0x1100dd660>)> is a built-in module
```