### PR TITLE
Fix for RRTConnect with intermediate states

### DIFF
--- a/src/ompl/geometric/planners/rrt/src/RRTConnect.cpp
+++ b/src/ompl/geometric/planners/rrt/src/RRTConnect.cpp
@@ -154,21 +154,30 @@ ompl::geometric::RRTConnect::GrowState ompl::geometric::RRTConnect::growTree(Tre
         const unsigned int count = si_->getStateSpace()->validSegmentCount(astate, bstate);
 
         if (si_->getMotionStates(astate, bstate, states, count, true, true))
-            si_->freeState(states[0]);
+        {
+            // if coming from start, don't add the start state (start->goal)
+            if (tgi.start)
+                si_->freeState(states[0]);
+            // if coming from the goal, don't add the start state (goal->start)
+            else
+                si_->freeState(states[states.size() - 1]);
+        }
 
         // Add states forwards if from start, backwards if from goal
-        for (std::size_t i = tgi.start ? 1 : states.size() - 1;  //
-             (tgi.start) ? i < states.size() : i > 0;            //
-             i += 2 * tgi.start - 1)
+        const auto &add_state = [&](const auto &state)
         {
             auto *motion = new Motion;
-            motion->state = states[i];
+            motion->state = state;
             motion->parent = nmotion;
             motion->root = nmotion->root;
             tree->add(motion);
-
             nmotion = motion;
-        }
+        };
+
+        if (tgi.start)
+            std::for_each(++std::begin(states), std::end(states), add_state);
+        else
+            std::for_each(++std::rbegin(states), std::rend(states), add_state);
 
         tgi.xmotion = nmotion;
     }

--- a/src/ompl/geometric/planners/rrt/src/RRTConnect.cpp
+++ b/src/ompl/geometric/planners/rrt/src/RRTConnect.cpp
@@ -156,7 +156,10 @@ ompl::geometric::RRTConnect::GrowState ompl::geometric::RRTConnect::growTree(Tre
         if (si_->getMotionStates(astate, bstate, states, count, true, true))
             si_->freeState(states[0]);
 
-        for (std::size_t i = 1; i < states.size(); ++i)
+        // Add states forwards if from start, backwards if from goal
+        for (std::size_t i = tgi.start ? 1 : states.size() - 1;  //
+             (tgi.start) ? i < states.size() : i > 0;            //
+             i += 2 * tgi.start - 1)
         {
             auto *motion = new Motion;
             motion->state = states[i];


### PR DESCRIPTION
Fixes #712 - adding states should be reversed when extending goal tree.