### PR TITLE
Add ARM Ubuntu triplet

### DIFF
--- a/CMakeModules/FindPython.cmake
+++ b/CMakeModules/FindPython.cmake
@@ -77,7 +77,7 @@ find_library(PYTHON_LIBRARIES
     PATHS
         "${PYTHON_PREFIX}/lib"
         [HKEY_LOCAL_MACHINE\\SOFTWARE\\Python\\PythonCore\\${PYTHON_VERSION}\\InstallPath]/libs
-    PATH_SUFFIXES "" "python${PYTHON_VERSION}/config" "x86_64-linux-gnu" "i386-linux-gnu"
+    PATH_SUFFIXES "" "python${PYTHON_VERSION}/config" "x86_64-linux-gnu" "i386-linux-gnu" "aarch64-linux-gnu"
     DOC "Python libraries" NO_DEFAULT_PATH)
 
 find_path(PYTHON_INCLUDE_DIRS "Python.h"


### PR DESCRIPTION
This PR enables OMPL Python bindings to be compiled on Ubuntu for ARM. To be able to build ompl.Dockerfile, you would additionally need to remove libspot, as the PPA doesn't have an `arm64` package.

- Further discussion can be found in #958 