### PR TITLE
Added try/except for string SpecificParam

### DIFF
--- a/py-bindings/generate_bindings.py
+++ b/py-bindings/generate_bindings.py
@@ -191,7 +191,10 @@ class ompl_base_generator_t(code_generator_t):
         self.ompl_ns.class_('SpecificParam< float >').rename('SpecificParamFloat')
         self.ompl_ns.class_('SpecificParam< double >').rename('SpecificParamDouble')
         self.ompl_ns.class_('SpecificParam< long double >').rename('SpecificParamLongDouble')
-        self.ompl_ns.class_(f'SpecificParam< {self.string_decl} >').rename('SpecificParamString')
+        try:
+            self.ompl_ns.class_(f'SpecificParam< std::string >').rename('SpecificParamString')
+        except:
+            self.ompl_ns.class_(f'SpecificParam< std::basic_string< char > >').rename('SpecificParamString')
         for cls in self.ompl_ns.classes(lambda decl: decl.name.startswith('SpecificParam')):
             cls.constructors().exclude()
         # don't export variables that need a wrapper


### PR DESCRIPTION
For some reason, `SpecificParam<std::string>` appears as either `SpecificParam<std::string>` or `SpecificParam<std::basic_string<char>>` - there is some code to try and figure out what strings are in castxml, but for some reason it is inconsistent for `SpecificParam`, particularly on Ubuntu 20.04.