### PR TITLE
fix: AIT* infinite loop

### DIFF
--- a/src/ompl/geometric/planners/informedtrees/aitstar/src/ImplicitGraph.cpp
+++ b/src/ompl/geometric/planners/informedtrees/aitstar/src/ImplicitGraph.cpp
@@ -336,7 +336,7 @@ namespace ompl
 
                         // Count how many states we've checked.
                         ++numSampledStates_;
-                    } while (!spaceInformation_->getStateValidityChecker()->isValid(newSamples_.back()->getState()));
+                    } while (!spaceInformation_->getStateValidityChecker()->isValid(newSamples_.back()->getState()) && !terminationCondition);
 
                     // If this state happens to satisfy the goal condition, add it as such.
                     if (problemDefinition_->getGoal()->isSatisfied(newSamples_.back()->getState()))


### PR DESCRIPTION
Executing AIT* with my environment is in an infinite loop.
In a simple environment, it doesn't have any problems, but in a high-complexity environment planner is stuck.

A similar issue was reported in the moveit repo [[moveit#3329](https://github.com/ros-planning/moveit/issues/3329)](https://github.com/ros-planning/moveit/issues/3329).

I added a termination condition to prevent this situation.