### PR TITLE
Additional exclusions for EIT* Python bindings

### DIFF
--- a/py-bindings/generate_bindings.py
+++ b/py-bindings/generate_bindings.py
@@ -784,6 +784,8 @@ class ompl_geometric_generator_t(code_generator_t):
         cls.member_function('getReverseTree').exclude()
         cls.member_function('getNextForwardEdge').exclude()
         cls.member_function('getNextReverseEdge').exclude()
+        cls.member_function('isStart').exclude()
+        cls.member_function('isGoal').exclude()
 
         # needed to able to set connection strategy for PRM
         # the PRM::Vertex type is typedef-ed to boost::graph_traits<Graph>::vertex_descriptor. This


### PR DESCRIPTION
Removed two more functions from EIT*'s Python bindings that threw symbol not found errors when trying to load the library.