### PR TITLE
Fix EIT* failing to sample the goal region

### DIFF
--- a/src/ompl/geometric/planners/informedtrees/eitstar/RandomGeometricGraph.h
+++ b/src/ompl/geometric/planners/informedtrees/eitstar/RandomGeometricGraph.h
@@ -184,7 +184,7 @@ namespace ompl
 
             private:
                 /** \brief Returns a sample either from the buffer or a newly generated one. */
-                std::shared_ptr<State> getNewSample();
+                std::shared_ptr<State> getNewSample(const ompl::base::PlannerTerminationCondition& terminationCondition);
 
                 /** \brief Returns the number of states in the informed set. */
                 std::size_t countSamplesInInformedSet() const;

--- a/src/ompl/geometric/planners/informedtrees/eitstar/RandomGeometricGraph.h
+++ b/src/ompl/geometric/planners/informedtrees/eitstar/RandomGeometricGraph.h
@@ -183,7 +183,9 @@ namespace ompl
                 unsigned int inadmissibleEffortToCome(const std::shared_ptr<State> &state) const;
 
             private:
-                /** \brief Returns a sample either from the buffer or a newly generated one. */
+                /** \brief Returns a sample either from the buffer or a newly generated one.
+                 * If the termination condition is met before a valid sample is found, nullptr is returned.
+                */
                 std::shared_ptr<State> getNewSample(const ompl::base::PlannerTerminationCondition& terminationCondition);
 
                 /** \brief Returns the number of states in the informed set. */

--- a/src/ompl/geometric/planners/informedtrees/eitstar/src/RandomGeometricGraph.cpp
+++ b/src/ompl/geometric/planners/informedtrees/eitstar/src/RandomGeometricGraph.cpp
@@ -494,7 +494,7 @@ namespace ompl
                 whitelistedStates_.push_back(state);
             }
 
-            std::shared_ptr<State> RandomGeometricGraph::getNewSample()
+            std::shared_ptr<State> RandomGeometricGraph::getNewSample(const ompl::base::PlannerTerminationCondition& terminationCondition)
             {
                 // Allocate a new state.
                 auto state = std::make_shared<State>(spaceInfo_, objective_);
@@ -510,6 +510,11 @@ namespace ompl
                 {
                     do  // Sample randomly until a valid state is found.
                     {
+                        if (!terminationCondition)
+                        {
+                            // We've been asked to stop.
+                            return nullptr;
+                        }
                         if (isMultiqueryEnabled_)
                         {
                             // If we are doing multiquery planning, we sample uniformly, and reject samples that can
@@ -555,11 +560,11 @@ namespace ompl
                 {
                     do
                     {
-                        const auto state = getNewSample();
+                        const auto state = getNewSample(terminationCondition);
 
                         // Since we do not do informed sampling, we need to check if the sample could improve
                         // the current solution.
-                        if (!canBePruned(state))
+                        if (state && !canBePruned(state))
                         {
                             newSamples_.emplace_back(state);
 

--- a/src/ompl/geometric/planners/informedtrees/eitstar/src/RandomGeometricGraph.cpp
+++ b/src/ompl/geometric/planners/informedtrees/eitstar/src/RandomGeometricGraph.cpp
@@ -510,7 +510,7 @@ namespace ompl
                 {
                     do  // Sample randomly until a valid state is found.
                     {
-                        if (!terminationCondition)
+                        if (terminationCondition)
                         {
                             // We've been asked to stop.
                             return nullptr;
@@ -564,7 +564,7 @@ namespace ompl
 
                         // Since we do not do informed sampling, we need to check if the sample could improve
                         // the current solution.
-                        if (state && !canBePruned(state))
+                        if (state != nullptr && !canBePruned(state))
                         {
                             newSamples_.emplace_back(state);
 

--- a/src/ompl/geometric/planners/informedtrees/eitstar/src/RandomGeometricGraph.cpp
+++ b/src/ompl/geometric/planners/informedtrees/eitstar/src/RandomGeometricGraph.cpp
@@ -209,7 +209,7 @@ namespace ompl
                     {
                         // Get a new goal. If there are none, or the underlying state is invalid this will be a nullptr.
                         const auto newGoalState =
-                            inputStates->nextGoal(ompl::base::plannerAlwaysTerminatingCondition());
+                            inputStates->nextGoal(terminationCondition);
 
                         // If there was a new valid goal, register it as such and remember that a goal has been added.
                         if (static_cast<bool>(newGoalState))


### PR DESCRIPTION
I am currently trying to use the informed tree planners in MoveIt, however, when testing EIT*/EIRM* the planner is failing to sample the goal region. I get the following error:

```shell
[ERROR] [1676514489.653650246]: arm/arm[EITstar]: No solution can be found as no goal states are available
[ERROR] [1676514489.653739781]: arm/arm[EITstar]: No solution can be found as no goal states are available
[ERROR] [1676514489.653818728]: arm/arm[EITstar]: No solution can be found as no goal states are available
[ERROR] [1676514489.653867118]: arm/arm[EITstar]: No solution can be found as no goal states are available
[ WARN] [1676514489.653914669]: ParallelPlan::solve(): Unable to find solution by any of the threads in 0.000329 seconds
[ WARN] [1676514489.653941393]: Timed out
[ WARN] [1676514489.662968340]: Goal sampling thread never did any work.
[ WARN] [1676514489.806632313]: Fail: ABORTED: TIMED_OUT
```

After analyzing the AIT* code I noticed that [AIT* forwards the termination condition to the goal sampler](https://github.com/ompl/ompl/blob/main/src/ompl/geometric/planners/informedtrees/aitstar/src/ImplicitGraph.cpp#L172), while EIT* create a new `plannerAlwaysTerminatingCondition`. After performing this change, the planner was able to successfully sample the goal region. The terminating condition sent by the parent caller is also a `plannerAlwaysTerminatingCondition`, so I am not sure why sending a new object causes the sampler to fail.

I tested this changes using this code: https://github.com/yurirocha15/testing_informed_planners_example