### PR TITLE
Fix AIT* segfault when calling clear before setup

### DIFF
--- a/src/ompl/geometric/planners/informedtrees/src/AITstar.cpp
+++ b/src/ompl/geometric/planners/informedtrees/src/AITstar.cpp
@@ -203,9 +203,9 @@ namespace ompl
             graph_.clear();
             forwardQueue_.clear();
             reverseQueue_.clear();
-            solutionCost_ = objective_->infiniteCost();
-            approximateSolutionCost_ = objective_->infiniteCost();
-            approximateSolutionCostToGoal_ = objective_->infiniteCost();
+            solutionCost_ = ompl::base::Cost(std::numeric_limits<double>::signaling_NaN());
+            approximateSolutionCost_ = ompl::base::Cost(std::numeric_limits<double>::signaling_NaN());
+            approximateSolutionCostToGoal_ = ompl::base::Cost(std::numeric_limits<double>::signaling_NaN());
             numIterations_ = 0u;
             numInconsistentOrUnconnectedTargets_ = 0u;
             Planner::clear();

--- a/src/ompl/geometric/planners/informedtrees/src/AITstar.cpp
+++ b/src/ompl/geometric/planners/informedtrees/src/AITstar.cpp
@@ -203,9 +203,12 @@ namespace ompl
             graph_.clear();
             forwardQueue_.clear();
             reverseQueue_.clear();
-            solutionCost_ = ompl::base::Cost(std::numeric_limits<double>::signaling_NaN());
-            approximateSolutionCost_ = ompl::base::Cost(std::numeric_limits<double>::signaling_NaN());
-            approximateSolutionCostToGoal_ = ompl::base::Cost(std::numeric_limits<double>::signaling_NaN());
+            if (objective_)
+            {
+                solutionCost_ = objective_->infiniteCost();
+                approximateSolutionCost_ = objective_->infiniteCost();
+                approximateSolutionCostToGoal_ = objective_->infiniteCost();
+            }
             numIterations_ = 0u;
             numInconsistentOrUnconnectedTargets_ = 0u;
             Planner::clear();


### PR DESCRIPTION
Currently, the `objective_` pointer is only set when calling the `setup()` method. However, this pointer is referenced in the `clear()` method, which means that if the user calls `AITstar::clear()` before calling `AITstar::setup()` there will be a segmentation fault.

As the costs will be set to the `infinity cost` when the `setup()` method is called, I changed the `clear` method to set the costs as NaN.