### PR TITLE
Fix incorrect validSegmentCount in DubinsStateSpace

### DIFF
--- a/src/ompl/base/spaces/DubinsStateSpace.h
+++ b/src/ompl/base/spaces/DubinsStateSpace.h
@@ -128,6 +128,8 @@ namespace ompl
                 return isSymmetric_;
             }
 
+            unsigned int validSegmentCount(const State *state1, const State *state2) const override;
+
             void sanityChecks() const override
             {
                 double zero = std::numeric_limits<double>::epsilon();

--- a/src/ompl/base/spaces/src/DubinsStateSpace.cpp
+++ b/src/ompl/base/spaces/src/DubinsStateSpace.cpp
@@ -318,6 +318,12 @@ void ompl::base::DubinsStateSpace::interpolate(const State *from, const DubinsPa
     freeState(s);
 }
 
+unsigned int ompl::base::DubinsStateSpace::validSegmentCount(const State *state1,
+                                                             const State *state2) const
+{
+    return StateSpace::validSegmentCount(state1, state2);
+}
+
 ompl::base::DubinsStateSpace::DubinsPath ompl::base::DubinsStateSpace::dubins(const State *state1,
                                                                               const State *state2) const
 {


### PR DESCRIPTION
`validSegmentCount` is used to determine the number of interpolation points to use for collision checking a segment.

`DubinsStateSpace` incorrectly delegated to the default `CompoundStateSpace::validSegmentCount` implementation, which evaluates each subspace independently and returns the highest value.

This patch returns to the basic `StateSpace` behavior, computing a count based on edge length -- in this case, the length of the Dubins path.

Fixes #811.