### PR TITLE
Fix for constrained planning python bindings

### DIFF
--- a/demos/constraint/ConstrainedPlanningCommon.py
+++ b/demos/constraint/ConstrainedPlanningCommon.py
@@ -60,6 +60,7 @@ except ImportError:
         from ompl import tools as ot
     except ImportError:
         pass
+
 import datetime
 
 

--- a/demos/constraint/ConstrainedPlanningCommon.py
+++ b/demos/constraint/ConstrainedPlanningCommon.py
@@ -41,7 +41,11 @@ try:
     from ompl import util as ou
     from ompl import base as ob
     from ompl import geometric as og
-    from ompl import tools as ot
+    try:
+        from ompl import tools as ot
+    except ImportError:
+        pass
+
 except ImportError:
     # if the ompl module is not in the PYTHONPATH assume it is installed in a
     # subdirectory of the parent directory called "py-bindings."
@@ -52,7 +56,10 @@ except ImportError:
     from ompl import util as ou
     from ompl import base as ob
     from ompl import geometric as og
-    from ompl import tools as ot
+    try:
+        from ompl import tools as ot
+    except ImportError:
+        pass
 import datetime
 
 
@@ -254,6 +261,10 @@ class ConstrainedProblem(object):
         return stat
 
     def setupBenchmark(self, planners, problem):
+        if ot:
+            print("Benchmarking not available, no ompl.tools")
+            return
+
         self.bench = ot.Benchmark(self.ss, problem)
 
         self.bench.addExperimentParameter(

--- a/demos/constraint/ConstrainedPlanningCommon.py
+++ b/demos/constraint/ConstrainedPlanningCommon.py
@@ -264,7 +264,7 @@ class ConstrainedProblem(object):
     def setupBenchmark(self, planners, problem):
         if not ot:
             print("Benchmarking not available, no ompl.tools")
-            return
+            exit(0)
 
         self.bench = ot.Benchmark(self.ss, problem)
 

--- a/demos/constraint/ConstrainedPlanningCommon.py
+++ b/demos/constraint/ConstrainedPlanningCommon.py
@@ -262,7 +262,7 @@ class ConstrainedProblem(object):
         return stat
 
     def setupBenchmark(self, planners, problem):
-        if ot:
+        if not ot:
             print("Benchmarking not available, no ompl.tools")
             return
 

--- a/demos/constraint/ConstrainedPlanningCommon.py
+++ b/demos/constraint/ConstrainedPlanningCommon.py
@@ -264,7 +264,7 @@ class ConstrainedProblem(object):
     def setupBenchmark(self, planners, problem):
         if not ot:
             print("Benchmarking not available, no ompl.tools")
-            exit(0)
+            sys.exit(0)
 
         self.bench = ot.Benchmark(self.ss, problem)
 

--- a/demos/constraint/ConstrainedPlanningTorus.py
+++ b/demos/constraint/ConstrainedPlanningTorus.py
@@ -37,6 +37,8 @@
 # Author: Mark Moll
 
 from __future__ import print_function
+
+from os.path import dirname, join
 import argparse
 import math
 from functools import partial

--- a/py-bindings/generate_bindings.py
+++ b/py-bindings/generate_bindings.py
@@ -331,17 +331,13 @@ class ompl_base_generator_t(code_generator_t):
 #                        self.ompl_ns.class_('ConstraintIntersection')]:
                 for method in ['function', 'jacobian']:
                     cls.member_function(method, arg_types=[
-                        '::Eigen::Ref<const Eigen::Matrix<double, -1, 1, 0, -1, 1>, '
-                        '0, Eigen::InnerStride<1> > const &',
+                        '::Eigen::Ref<const Eigen::Matrix<double, -1, 1, 0>, 0, Eigen::InnerStride<1>> const &',
                         None]).add_transformation(FT.input(0))
             cls = self.ompl_ns.class_('Constraint')
             for method in ['distance', 'isSatisfied']:
                 cls.member_function(method, arg_types=[
-                    '::Eigen::Ref<const Eigen::Matrix<double, -1, 1, 0, -1, 1>, '
-                    '0, Eigen::InnerStride<1> > const &']).add_transformation(FT.input(0))
-        except:
-            # python bindings for constrained planning code is only generated
-            # if boost.numpy was found
+                    '::Eigen::Ref<const Eigen::Matrix<double, -1, 1, 0>, 0, Eigen::InnerStride<1>> const &',]).add_transformation(FT.input(0))
+        except Exception as e:
             pass
 
         # Exclude PlannerData::getEdges function that returns a map of PlannerDataEdge* for now


### PR DESCRIPTION
- Update to the signature needed to find & replace in Python binding generation needed for constrained planning.
- Optional tool import

Fixes #1007 