### PR TITLE
Add pybindings to ST-RRT* planner

### DIFF
--- a/demos/SpaceTimePlanning.py
+++ b/demos/SpaceTimePlanning.py
@@ -1,0 +1,72 @@
+from os.path import abspath, dirname, join
+import sys
+import math
+try:
+    from ompl import util as ou
+    from ompl import base as ob
+    from ompl import geometric as og
+except ImportError:
+    # if the ompl module is not in the PYTHONPATH assume it is installed in a
+    # subdirectory of the parent directory called "py-bindings."
+    sys.path.insert(0, join(dirname(dirname(abspath(__file__))), 'py-bindings'))
+    from ompl import util as ou
+    from ompl import base as ob
+    from ompl import geometric as og
+from functools import partial
+
+def isStateValid(spaceInformation, state):
+    p = state[0][0]
+    t = spaceInformation.getStateSpace().getStateTime(state)
+    return t >= 0 and p < math.inf
+
+class SpaceTimeMotionValidator(ob.MotionValidator):
+    def checkMotion(self, s1, s2):
+      if not si.isValid(s2):
+        return False
+      delta_pos = si.getStateSpace().distanceSpace(s1, s2)
+      # delta_t = si.getStateSpace().distanceTime(s1, s2)
+      t1 = si.getStateSpace().getStateTime(s1)
+      t2 = si.getStateSpace().getStateTime(s2)
+      delta_t = t2 - t1
+      if delta_t <= 0 :
+        return False
+      if (delta_pos / delta_t) > si.getStateSpace().getVMax() :
+        return False
+      return True
+
+vMax = 0.2
+vector_space = ob.RealVectorStateSpace(1)
+bounds = ob.RealVectorBounds(1)
+bounds.setLow(-1.0)
+bounds.setHigh(1.0)
+vector_space.setBounds(bounds)
+
+space = ob.SpaceTimeStateSpace(vector_space, vMax)
+space.setTimeBounds(0.0, 10.0);
+
+si = ob.SpaceInformation(space)
+si.setMotionValidator(SpaceTimeMotionValidator(si))
+si.setStateValidityChecker(ob.StateValidityCheckerFn( \
+    partial(isStateValid, si)))
+
+pdef = ob.ProblemDefinition(si)
+
+start = ob.State(space)
+start()[0][0] = 0.0
+goal = ob.State(space)
+goal()[0][0] = 1.0
+pdef.setStartAndGoalStates(start, goal)
+
+strrt = og.STRRTstar(si)
+strrt.setRange(vMax)
+strrt.setProblemDefinition(pdef)
+strrt.setup()
+
+result = strrt.solve(1.0)
+print("Done planning.")
+
+if result:
+  print("Found path of length", pdef.getSolutionPath().length())
+  print("Path:", pdef.getSolutionPath().printAsMatrix())
+else:
+  print("No solution found.")

--- a/py-bindings/generate_bindings.py
+++ b/py-bindings/generate_bindings.py
@@ -168,10 +168,7 @@ class ompl_base_generator_t(code_generator_t):
         try:
             self.std_ns.class_('vector< ompl::base::State const* >').rename('vectorConstState')
         except declaration_not_found_t:
-            try:
-                self.std_ns.class_('vector< const ompl::base::State const >').rename('vectorConstState')
-            except declaration_not_found_t:
-                pass
+            pass
 
         self.std_ns.class_('vector< std::shared_ptr<ompl::base::StateSpace> >').rename(
             'vectorStateSpacePtr')

--- a/py-bindings/generate_bindings.py
+++ b/py-bindings/generate_bindings.py
@@ -164,10 +164,15 @@ class ompl_base_generator_t(code_generator_t):
             f'map< {self.string_decl}, std::shared_ptr< ompl::base::ProjectionEvaluator > >').rename(
                 'mapStringToProjectionEvaluator')
         self.std_ns.class_('vector< ompl::base::State * >').rename('vectorState')
+
         try:
             self.std_ns.class_('vector< ompl::base::State const* >').rename('vectorConstState')
         except declaration_not_found_t:
-            pass
+            try:
+                self.std_ns.class_('vector< const ompl::base::State const >').rename('vectorConstState')
+            except declaration_not_found_t:
+                pass
+
         self.std_ns.class_('vector< std::shared_ptr<ompl::base::StateSpace> >').rename(
             'vectorStateSpacePtr')
         #self.std_ns.class_('vector< <ompl::base::PlannerSolution> >').rename(
@@ -177,6 +182,9 @@ class ompl_base_generator_t(code_generator_t):
         self.std_ns.class_(f'map< {self.string_decl}, ompl::base::StateSpace::SubstateLocation >').rename(
             'mapStringToSubstateLocation')
         self.std_ns.class_('vector<ompl::base::PlannerSolution>').rename('vectorPlannerSolution')
+
+        self.std_ns.class_('vector< ompl::base::ConditionalStateSampler::Motion * >').rename(
+            'vectorConditionalStateSamplerMotionPtr')
 
         pairStateDouble = self.std_ns.class_('pair<ompl::base::State *, double>')
         pairStateDouble.rename('pairStateDouble')

--- a/py-bindings/headers_base.txt
+++ b/py-bindings/headers_base.txt
@@ -28,6 +28,7 @@ src/ompl/base/goals/GoalSpace.h
 src/ompl/base/DiscreteMotionValidator.h
 src/ompl/base/OptimizationObjective.h
 src/ompl/base/objectives/MinimaxObjective.h
+src/ompl/base/objectives/MinimizeArrivalTime.h
 src/ompl/base/objectives/MaximizeMinClearanceObjective.h
 src/ompl/base/objectives/MechanicalWorkOptimizationObjective.h
 src/ompl/base/objectives/PathLengthOptimizationObjective.h
@@ -40,13 +41,13 @@ src/ompl/base/PlannerDataStorage.h
 src/ompl/base/PlannerStatus.h
 src/ompl/base/Planner.h
 src/ompl/base/SolutionNonExistenceProof.h
-src/ompl/base/samplers/UniformValidStateSampler.h
 src/ompl/base/spaces/RealVectorStateSpace.h
 src/ompl/base/spaces/RealVectorStateProjections.h
 src/ompl/base/spaces/SO2StateSpace.h
 src/ompl/base/spaces/SO3StateSpace.h
 src/ompl/base/spaces/SE2StateSpace.h
 src/ompl/base/spaces/SE3StateSpace.h
+src/ompl/base/spaces/SpaceTimeStateSpace.h
 src/ompl/base/spaces/DiscreteStateSpace.h
 src/ompl/base/spaces/TimeStateSpace.h
 src/ompl/base/spaces/DubinsStateSpace.h
@@ -58,6 +59,7 @@ src/ompl/base/spaces/constraint/AtlasChart.h
 src/ompl/base/spaces/constraint/TangentBundleStateSpace.h
 src/ompl/base/ConstrainedSpaceInformation.h
 src/ompl/base/spaces/constraint/ProjectedStateSpace.h
+src/ompl/base/samplers/ConditionalStateSampler.h
 src/ompl/base/samplers/BridgeTestValidStateSampler.h
 src/ompl/base/samplers/GaussianValidStateSampler.h
 src/ompl/base/samplers/MinimumClearanceValidStateSampler.h

--- a/py-bindings/headers_geometric.txt
+++ b/py-bindings/headers_geometric.txt
@@ -27,6 +27,7 @@ src/ompl/geometric/planners/rrt/LBTRRT.h
 src/ompl/geometric/planners/rrt/LazyLBTRRT.h
 src/ompl/geometric/planners/rrt/InformedRRTstar.h
 src/ompl/geometric/planners/rrt/SORRTstar.h
+src/ompl/geometric/planners/rrt/STRRTstar.h
 src/ompl/geometric/planners/informedtrees/BITstar.h
 src/ompl/geometric/planners/informedtrees/ABITstar.h
 src/ompl/geometric/planners/informedtrees/AITstar.h

--- a/py-bindings/ompl_py_base.h
+++ b/py-bindings/ompl_py_base.h
@@ -40,6 +40,7 @@
 #include "ompl/base/ScopedState.h"
 #include "ompl/base/spaces/SE2StateSpace.h"
 #include "ompl/base/spaces/SE3StateSpace.h"
+#include "ompl/base/spaces/SpaceTimeStateSpace.h"
 #include "ompl/base/spaces/DiscreteStateSpace.h"
 #include "ompl/base/spaces/TimeStateSpace.h"
 #include "ompl/base/spaces/DubinsStateSpace.h"

--- a/src/ompl/base/samplers/ConditionalStateSampler.h
+++ b/src/ompl/base/samplers/ConditionalStateSampler.h
@@ -46,31 +46,35 @@ namespace ompl
 {
     namespace base
     {
-        /** \brief Representation of a motion */
-        class Motion
-        {
-        public:
-            Motion() = default;
-
-            explicit Motion(const SpaceInformationPtr &si) : state(si->allocState()) {}
-
-            ~Motion() = default;
-
-            const base::State *root{nullptr};
-            base::State *state{nullptr};
-            Motion *parent{nullptr};
-            /** \brief The set of motions descending from the current motion */
-            std::vector<Motion *> children{};
-            // only used by goal tree
-            Motion *connectionPoint{nullptr};  // the start tree motion, if there is a direct connection
-            int numConnections{0};  // number of connections to the start tree of self and all descendants
-        };
 
         /** \brief The Conditional Sampler samples feasible Space-Time States. First, a space configuration is
-         * sampled. Then, a feasible time conditioned on the start and goal states is sampled for the space configuration.*/
+         * sampled. Then, a feasible time conditioned on the start and goal states is sampled for the space
+         * configuration.*/
         class ConditionalStateSampler : public ValidStateSampler
         {
         public:
+            /** \brief Representation of a motion */
+            class Motion
+            {
+            public:
+                Motion() = default;
+
+                explicit Motion(const SpaceInformationPtr &si) : state(si->allocState())
+                {
+                }
+
+                ~Motion() = default;
+
+                const base::State *root{nullptr};
+                base::State *state{nullptr};
+                Motion *parent{nullptr};
+                /** \brief The set of motions descending from the current motion */
+                std::vector<Motion *> children{};
+                // only used by goal tree
+                Motion *connectionPoint{nullptr};  // the start tree motion, if there is a direct connection
+                int numConnections{0};  // number of connections to the start tree of self and all descendants
+            };
+
             /** \brief The constructor. */
             ConditionalStateSampler(const SpaceInformation *si, Motion *&startMotion,
                                     std::vector<Motion *> &goalMotions, std::vector<Motion *> &newBatchGoalMotions,
@@ -96,15 +100,13 @@ namespace ompl
             bool &sampleOldBatch_;
 
             /** \brief Maximum tries to sample a new state, if no new state could be sampled, force a new goal
-                 * sample. */
+             * sample. */
             int maxTries_ = 10;
 
             /** \brief The random number generator. */
             ompl::RNG rng_;
         };
-    }
-}
-
-
+    }  // namespace base
+}  // namespace ompl
 
 #endif  // OMPL_CONDITIONALSTATESAMPLER_H

--- a/src/ompl/base/samplers/src/ConditionalStateSampler.cpp
+++ b/src/ompl/base/samplers/src/ConditionalStateSampler.cpp
@@ -37,7 +37,7 @@
 #include "ompl/base/samplers/ConditionalStateSampler.h"
 
 ompl::base::ConditionalStateSampler::ConditionalStateSampler(const ompl::base::SpaceInformation *si,
-                                                             ompl::base::Motion *&startMotion,
+                                                             Motion *&startMotion,
                                                              std::vector<Motion *> &goalMotions,
                                                              std::vector<Motion *> &newBatchGoalMotions,
                                                              bool &sampleOldBatch)

--- a/src/ompl/geometric/planners/rrt/STRRTstar.h
+++ b/src/ompl/geometric/planners/rrt/STRRTstar.h
@@ -124,10 +124,9 @@ namespace ompl
 
             void setup() override;
 
-        protected:
-
             /** \brief A nearest-neighbor datastructure representing a tree of motions */
             using TreeData = std::shared_ptr<ompl::NearestNeighbors<base::Motion *>>;
+        protected:
 
             /** \brief Information attached to growing a tree of motions (used internally) */
             struct TreeGrowingInfo

--- a/src/ompl/geometric/planners/rrt/STRRTstar.h
+++ b/src/ompl/geometric/planners/rrt/STRRTstar.h
@@ -65,6 +65,8 @@ namespace ompl
         class STRRTstar : public base::Planner
         {
         public:
+            using Motion = base::ConditionalStateSampler::Motion;
+
             /** \brief Constructor */
             explicit STRRTstar(const ompl::base::SpaceInformationPtr &si);
 
@@ -125,14 +127,14 @@ namespace ompl
             void setup() override;
 
             /** \brief A nearest-neighbor datastructure representing a tree of motions */
-            using TreeData = std::shared_ptr<ompl::NearestNeighbors<base::Motion *>>;
+            using TreeData = std::shared_ptr<ompl::NearestNeighbors<Motion *>>;
         protected:
 
             /** \brief Information attached to growing a tree of motions (used internally) */
             struct TreeGrowingInfo
             {
                 base::State *xstate;
-                base::Motion *xmotion;
+                Motion *xmotion;
                 bool start;
             };
 
@@ -148,14 +150,14 @@ namespace ompl
             };
 
             /** \brief Grow a tree towards a random state for a single nearest state */
-            GrowState growTreeSingle(TreeData &tree, TreeGrowingInfo &tgi, base::Motion *rmotion, base::Motion *nmotion);
+            GrowState growTreeSingle(TreeData &tree, TreeGrowingInfo &tgi, Motion *rmotion, Motion *nmotion);
 
             /** \brief Attempt to grow a tree towards a random state for the neighborhood of the random state. The
              * neighborhood is determined by the used rewire state. For the start tree closest state with respect to
              * distance are tried first. For the goal tree states with the minimum time root node are tried first. If
              * connect is true, multiple vertices can be added to the tree until the random state is reached or an
              * basestacle is met. If connect is false, the tree is only extended by a single new state. */
-            GrowState growTree(TreeData &tree, TreeGrowingInfo &tgi, base::Motion *rmotion, std::vector<base::Motion *> &nbh,
+            GrowState growTree(TreeData &tree, TreeGrowingInfo &tgi, Motion *rmotion, std::vector<Motion *> &nbh,
                                bool connect);
 
             /** \brief  */
@@ -163,13 +165,13 @@ namespace ompl
                                    bool &startTree, unsigned int &batchSize, int &numBatchSamples);
 
             /** \brief Gets the neighbours of a given motion, using either k-nearest or radius_ as appropriate. */
-            void getNeighbors(TreeData &tree, base::Motion *motion, std::vector<base::Motion *> &nbh) const;
+            void getNeighbors(TreeData &tree, Motion *motion, std::vector<Motion *> &nbh) const;
 
             /** \brief Free the memory allocated by this planner */
             void freeMemory();
 
             /** \brief Compute distance between motions (actually distance between contained states) */
-            double distanceFunction(const base::Motion *a, const base::Motion *b) const
+            double distanceFunction(const Motion *a, const Motion *b) const
             {
                 return si_->distance(a->state, b->state);
             }
@@ -180,13 +182,13 @@ namespace ompl
             /** \brief Prune the goal tree after a solution was found.
              * Return the goal motion, that is connected to the start tree, if a new solution was found.
              * If no new solution was found, return nullpointer. */
-            base::Motion *pruneGoalTree();
+            Motion *pruneGoalTree();
 
             /** \brief Find the solution (connecting) motion for a motion that is indirectly connected. */
-            static base::Motion *computeSolutionMotion(base::Motion *motion);
+            static Motion *computeSolutionMotion(Motion *motion);
 
             /** \brief Remove invalid goal states from the goal set. */
-            void removeInvalidGoals(const std::vector<base::Motion *> &invalidGoals);
+            void removeInvalidGoals(const std::vector<Motion *> &invalidGoals);
 
             /** \brief State sampler */
             base::ConditionalStateSampler sampler_;
@@ -225,14 +227,14 @@ namespace ompl
             double optimumApproxFactor_ = 1.0;
 
             /** \brief The start Motion, used for conditional sampling and start tree pruning. */
-            base::Motion *startMotion_{nullptr};
+            Motion *startMotion_{nullptr};
 
             /** \brief The goal Motions, used for conditional sampling and pruning. */
-            std::vector<base::Motion *> goalMotions_{};
+            std::vector<Motion *> goalMotions_{};
 
             /** \brief The goal Motions, that were added in the current expansion step, used for uniform sampling over a
              * growing region. */
-            std::vector<base::Motion *> newBatchGoalMotions_{};
+            std::vector<Motion *> newBatchGoalMotions_{};
 
             /**
              * Goal Sampling is not handled by PlannerInputStates, but directly by the SpaceTimeRRT,
@@ -258,13 +260,13 @@ namespace ompl
             bool sampleGoalTime(base::State *goal, double oldBatchTimeBoundFactor, double newBatchTimeBoundFactor);
 
             /** \brief Removes the given motion from the parent's child list. */
-            static void removeFromParent(base::Motion *m);
+            static void removeFromParent(Motion *m);
 
             /** \brief Adds given all descendants of the given motion to given tree and checks whether one of the added
              * motions is the goal motion. */
-            static void addDescendants(base::Motion *m, const TreeData &tree);
+            static void addDescendants(Motion *m, const TreeData &tree);
 
-            void constructSolution(base::Motion *startMotion, base::Motion *goalMotion,
+            void constructSolution(Motion *startMotion, Motion *goalMotion,
                                    const base::ReportIntermediateSolutionFn &intermediateSolutionCallback,
                                    const ompl::base::PlannerTerminationCondition& ptc);
 
@@ -293,7 +295,7 @@ namespace ompl
             /** \brief Calculate the k_RRG* and r_RRG* terms */
             void calculateRewiringLowerBounds();
 
-            bool rewireGoalTree(base::Motion *addedMotion);
+            bool rewireGoalTree(Motion *addedMotion);
 
             /** \brief Whether the time is bounded or not. The first solution automatically bounds the time. */
             bool isTimeBounded_;

--- a/src/ompl/geometric/planners/rrt/src/STRRTstar.cpp
+++ b/src/ompl/geometric/planners/rrt/src/STRRTstar.cpp
@@ -1,36 +1,36 @@
 /*********************************************************************
-* Software License Agreement (BSD License)
-*
-*  Copyright (c) 2021, Technische Universität Berlin (TU Berlin)
-*  All rights reserved.
-*
-*  Redistribution and use in source and binary forms, with or without
-*  modification, are permitted provided that the following conditions
-*  are met:
-*
-*   * Redistributions of source code must retain the above copyright
-*     notice, this list of conditions and the following disclaimer.
-*   * Redistributions in binary form must reproduce the above
-*     copyright notice, this list of conditions and the following
-*     disclaimer in the documentation and/or other materials provided
-*     with the distribution.
-*   * Neither the name of the TU Berlin nor the names of its
-*     contributors may be used to endorse or promote products derived
-*     from this software without specific prior written permission.
-*
-*  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
-*  "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
-*  LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
-*  FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
-*  COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
-*  INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
-*  BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
-*  LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
-*  CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
-*  LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
-*  ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
-*  POSSIBILITY OF SUCH DAMAGE.
-*********************************************************************/
+ * Software License Agreement (BSD License)
+ *
+ *  Copyright (c) 2021, Technische Universität Berlin (TU Berlin)
+ *  All rights reserved.
+ *
+ *  Redistribution and use in source and binary forms, with or without
+ *  modification, are permitted provided that the following conditions
+ *  are met:
+ *
+ *   * Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *   * Redistributions in binary form must reproduce the above
+ *     copyright notice, this list of conditions and the following
+ *     disclaimer in the documentation and/or other materials provided
+ *     with the distribution.
+ *   * Neither the name of the TU Berlin nor the names of its
+ *     contributors may be used to endorse or promote products derived
+ *     from this software without specific prior written permission.
+ *
+ *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ *  "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ *  LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ *  FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ *  COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ *  INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ *  BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ *  LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ *  CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ *  LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ *  ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ *  POSSIBILITY OF SUCH DAMAGE.
+ *********************************************************************/
 
 /* Author: Francesco Grothe */
 
@@ -40,7 +40,8 @@
 ompl::geometric::STRRTstar::STRRTstar(const ompl::base::SpaceInformationPtr &si)
   : Planner(si, "SpaceTimeRRT"), sampler_(&(*si), startMotion_, goalMotions_, newBatchGoalMotions_, sampleOldBatch_)
 {
-    if (std::dynamic_pointer_cast<ompl::base::SpaceTimeStateSpace>(si->getStateSpace()) == nullptr) {
+    if (std::dynamic_pointer_cast<ompl::base::SpaceTimeStateSpace>(si->getStateSpace()) == nullptr)
+    {
         OMPL_ERROR("%s: State Space needs to be of type SpaceTimeStateSpace.", getName().c_str());
         throw ompl::Exception("Non-SpaceTimeStateSpace");
     }
@@ -62,11 +63,11 @@ void ompl::geometric::STRRTstar::setup()
     sc.configurePlannerRange(maxDistance_);
 
     if (!tStart_)
-        tStart_.reset(new ompl::NearestNeighborsLinear<base::Motion *>());
+        tStart_.reset(new ompl::NearestNeighborsLinear<Motion *>());
     if (!tGoal_)
-        tGoal_.reset(new ompl::NearestNeighborsLinear<base::Motion *>());
-    tStart_->setDistanceFunction([this](const base::Motion *a, const base::Motion *b) { return distanceFunction(a, b); });
-    tGoal_->setDistanceFunction([this](const base::Motion *a, const base::Motion *b) { return distanceFunction(a, b); });
+        tGoal_.reset(new ompl::NearestNeighborsLinear<Motion *>());
+    tStart_->setDistanceFunction([this](const Motion *a, const Motion *b) { return distanceFunction(a, b); });
+    tGoal_->setDistanceFunction([this](const Motion *a, const Motion *b) { return distanceFunction(a, b); });
 
     if (si_->getStateSpace()->as<ompl::base::SpaceTimeStateSpace>()->getTimeComponent()->isBounded())
     {
@@ -88,7 +89,7 @@ void ompl::geometric::STRRTstar::setup()
 
 void ompl::geometric::STRRTstar::freeMemory()
 {
-    std::vector<base::Motion *> motions;
+    std::vector<Motion *> motions;
 
     if (tStart_)
     {
@@ -129,7 +130,7 @@ ompl::base::PlannerStatus ompl::geometric::STRRTstar::solve(const ompl::base::Pl
 
     while (const ompl::base::State *st = pis_.nextStart())
     {
-        auto *motion = new base::Motion(si_);
+        auto *motion = new Motion(si_);
         si_->copyState(motion->state, st);
         motion->root = motion->state;
         tStart_->add(motion);
@@ -138,7 +139,7 @@ ompl::base::PlannerStatus ompl::geometric::STRRTstar::solve(const ompl::base::Pl
 
     if (tStart_->size() == 0)
     {
-        OMPL_ERROR("%s: base::Motion planning start tree could not be initialized!", getName().c_str());
+        OMPL_ERROR("%s: Motion planning start tree could not be initialized!", getName().c_str());
         return ompl::base::PlannerStatus::INVALID_START;
     }
 
@@ -154,13 +155,13 @@ ompl::base::PlannerStatus ompl::geometric::STRRTstar::solve(const ompl::base::Pl
     TreeGrowingInfo tgi;
     tgi.xstate = si_->allocState();
 
-    std::vector<base::Motion *> nbh;
+    std::vector<Motion *> nbh;
     const ompl::base::ReportIntermediateSolutionFn intermediateSolutionCallback =
         pdef_->getIntermediateSolutionCallback();
 
-    base::Motion *approxsol = nullptr;
+    Motion *approxsol = nullptr;
     double approxdif = std::numeric_limits<double>::infinity();
-    auto *rmotion = new base::Motion(si_);
+    auto *rmotion = new Motion(si_);
     ompl::base::State *rstate = rmotion->state;
     bool startTree = true;
     bool solved = false;
@@ -205,8 +206,8 @@ ompl::base::PlannerStatus ompl::geometric::STRRTstar::solve(const ompl::base::Pl
                 firstBatch = false;
                 oldBatchSampleProb = 0.5 * (1 / timeBoundFactorIncrease_);
             }
-            increaseTimeBound(false, oldBatchTimeBoundFactor, newBatchTimeBoundFactor, startTree,
-                              batchSize, numBatchSamples);
+            increaseTimeBound(false, oldBatchTimeBoundFactor, newBatchTimeBoundFactor, startTree, batchSize,
+                              numBatchSamples);
             // transfer new batch goals to old batch
             if (!newBatchGoalMotions_.empty())
             {
@@ -235,8 +236,8 @@ ompl::base::PlannerStatus ompl::geometric::STRRTstar::solve(const ompl::base::Pl
                 // the goal region is most likely blocked for this time period -> increase upper time bound
                 if (goalState == nullptr)
                 {
-                    increaseTimeBound(true, oldBatchTimeBoundFactor, newBatchTimeBoundFactor, startTree,
-                                      batchSize, numBatchSamples);
+                    increaseTimeBound(true, oldBatchTimeBoundFactor, newBatchTimeBoundFactor, startTree, batchSize,
+                                      numBatchSamples);
                     continue;
                 }
             }
@@ -256,12 +257,13 @@ ompl::base::PlannerStatus ompl::geometric::STRRTstar::solve(const ompl::base::Pl
                 // the goal region is most likely blocked for this time period -> increase upper time bound
                 if (goalState == nullptr)
                 {
-                    increaseTimeBound(false, oldBatchTimeBoundFactor, newBatchTimeBoundFactor, startTree,
-                                      batchSize, numBatchSamples);
+                    increaseTimeBound(false, oldBatchTimeBoundFactor, newBatchTimeBoundFactor, startTree, batchSize,
+                                      numBatchSamples);
                     continue;
                 }
             }
-            else if (forceGoalSample || newBatchGoalMotions_.size() < (unsigned long)(newBatchGoalSamples / goalStateSampleRatio_))
+            else if (forceGoalSample ||
+                     newBatchGoalMotions_.size() < (unsigned long)(newBatchGoalSamples / goalStateSampleRatio_))
             {
                 goalState = nextGoal(1, oldBatchTimeBoundFactor, newBatchTimeBoundFactor);
                 forceGoalSample = false;
@@ -270,7 +272,7 @@ ompl::base::PlannerStatus ompl::geometric::STRRTstar::solve(const ompl::base::Pl
 
         if (goalState != nullptr)
         {
-            auto *motion = new base::Motion(si_);
+            auto *motion = new Motion(si_);
             si_->copyState(motion->state, goalState);
             motion->root = motion->state;
             tGoal_->add(motion);
@@ -304,9 +306,9 @@ ompl::base::PlannerStatus ompl::geometric::STRRTstar::solve(const ompl::base::Pl
         {
             numBatchSamples++;
             /* remember which motion was just added */
-            base::Motion *addedMotion = tgi.xmotion;
-            base::Motion *startMotion;
-            base::Motion *goalMotion;
+            Motion *addedMotion = tgi.xmotion;
+            Motion *startMotion;
+            Motion *goalMotion;
 
             /* rewire the goal tree */
             bool newSolution = false;
@@ -316,7 +318,7 @@ ompl::base::PlannerStatus ompl::geometric::STRRTstar::solve(const ompl::base::Pl
                 if (newSolution)
                 {
                     // find connection point
-                    std::queue<base::Motion *> queue;
+                    std::queue<Motion *> queue;
                     queue.push(addedMotion);
                     while (!queue.empty())
                     {
@@ -328,7 +330,7 @@ ompl::base::PlannerStatus ompl::geometric::STRRTstar::solve(const ompl::base::Pl
                         }
                         else
                         {
-                            for (base::Motion *c : queue.front()->children)
+                            for (Motion *c : queue.front()->children)
                                 queue.push(c);
                         }
                         queue.pop();
@@ -410,7 +412,7 @@ ompl::base::PlannerStatus ompl::geometric::STRRTstar::solve(const ompl::base::Pl
     if (approxsol && !solved)
     {
         /* construct the solution path */
-        std::vector<base::Motion *> mpath;
+        std::vector<Motion *> mpath;
         while (approxsol != nullptr)
         {
             mpath.push_back(approxsol);
@@ -429,7 +431,8 @@ ompl::base::PlannerStatus ompl::geometric::STRRTstar::solve(const ompl::base::Pl
         ompl::base::PlannerSolution psol(bestSolution_);
         psol.setPlannerName(getName());
 
-        ompl::base::OptimizationObjectivePtr optimizationObjective = std::make_shared<ompl::base::MinimizeArrivalTime>(si_);
+        ompl::base::OptimizationObjectivePtr optimizationObjective =
+            std::make_shared<ompl::base::MinimizeArrivalTime>(si_);
         psol.setOptimized(optimizationObjective, ompl::base::Cost(bestTime_), false);
         pdef_->addSolutionPath(psol);
     }
@@ -438,8 +441,8 @@ ompl::base::PlannerStatus ompl::geometric::STRRTstar::solve(const ompl::base::Pl
 }
 
 ompl::geometric::STRRTstar::GrowState ompl::geometric::STRRTstar::growTree(
-    ompl::geometric::STRRTstar::TreeData &tree, ompl::geometric::STRRTstar::TreeGrowingInfo &tgi,
-    base::Motion *rmotion, std::vector<base::Motion *> &nbh, bool connect)
+    ompl::geometric::STRRTstar::TreeData &tree, ompl::geometric::STRRTstar::TreeGrowingInfo &tgi, Motion *rmotion,
+    std::vector<Motion *> &nbh, bool connect)
 {
     // If connect, advance from single nearest neighbor until the random state is reached or trapped
     if (connect)
@@ -448,14 +451,14 @@ ompl::geometric::STRRTstar::GrowState ompl::geometric::STRRTstar::growTree(
         while (gsc == ADVANCED)
         {
             // get nearest motion
-            base::Motion *nmotion = tree->nearest(rmotion);
+            Motion *nmotion = tree->nearest(rmotion);
             gsc = growTreeSingle(tree, tgi, rmotion, nmotion);
         }
         return gsc;
     }
     if (rewireState_ == OFF)
     {
-        base::Motion *nmotion = tree->nearest(rmotion);
+        Motion *nmotion = tree->nearest(rmotion);
         return growTreeSingle(tree, tgi, rmotion, nmotion);
     }
     // get Neighborhood of random state
@@ -464,7 +467,7 @@ ompl::geometric::STRRTstar::GrowState ompl::geometric::STRRTstar::growTree(
     if (tgi.start)
     {
         std::sort(nbh.begin(), nbh.end(),
-                  [this, &rmotion](base::Motion *a, base::Motion *b)
+                  [this, &rmotion](Motion *a, Motion *b)
                   { return si_->distance(a->state, rmotion->state) < si_->distance(b->state, rmotion->state); });
     }
     // in goal tree sort by time of root node
@@ -472,7 +475,7 @@ ompl::geometric::STRRTstar::GrowState ompl::geometric::STRRTstar::growTree(
     {
         std::sort(
             nbh.begin(), nbh.end(),
-            [](base::Motion *a, base::Motion *b)
+            [](Motion *a, Motion *b)
             {
                 auto t1 =
                     a->root->as<ompl::base::CompoundState>()->as<ompl::base::TimeStateSpace::StateType>(1)->position;
@@ -485,7 +488,7 @@ ompl::geometric::STRRTstar::GrowState ompl::geometric::STRRTstar::growTree(
     // attempt to grow the tree for all neighbors in sorted order
     GrowState gs = TRAPPED;
     auto rt = rmotion->state->as<ompl::base::CompoundState>()->as<ompl::base::TimeStateSpace::StateType>(1)->position;
-    for (base::Motion *nmotion : nbh)
+    for (Motion *nmotion : nbh)
     {
         auto nt =
             nmotion->state->as<ompl::base::CompoundState>()->as<ompl::base::TimeStateSpace::StateType>(1)->position;
@@ -499,7 +502,7 @@ ompl::geometric::STRRTstar::GrowState ompl::geometric::STRRTstar::growTree(
     // when radius_ is used for neighborhood calculation, the neighborhood might be empty
     if (nbh.empty())
     {
-        base::Motion *nmotion = tree->nearest(rmotion);
+        Motion *nmotion = tree->nearest(rmotion);
         return growTreeSingle(tree, tgi, rmotion, nmotion);
     }
     // can't grow Tree
@@ -507,8 +510,8 @@ ompl::geometric::STRRTstar::GrowState ompl::geometric::STRRTstar::growTree(
 }
 
 ompl::geometric::STRRTstar::GrowState ompl::geometric::STRRTstar::growTreeSingle(
-    ompl::geometric::STRRTstar::TreeData &tree, ompl::geometric::STRRTstar::TreeGrowingInfo &tgi,
-    base::Motion *rmotion, base::Motion *nmotion)
+    ompl::geometric::STRRTstar::TreeData &tree, ompl::geometric::STRRTstar::TreeGrowingInfo &tgi, Motion *rmotion,
+    Motion *nmotion)
 {
     /* assume we can reach the state we go towards */
     bool reach = true;
@@ -535,7 +538,7 @@ ompl::geometric::STRRTstar::GrowState ompl::geometric::STRRTstar::growTreeSingle
     if (!validMotion)
         return TRAPPED;
 
-    auto *motion = new base::Motion(si_);
+    auto *motion = new Motion(si_);
     si_->copyState(motion->state, dstate);
     motion->parent = nmotion;
     motion->root = nmotion->root;
@@ -550,24 +553,26 @@ void ompl::geometric::STRRTstar::increaseTimeBound(bool hasSameBounds, double &o
                                                    double &newBatchTimeBoundFactor, bool &startTree,
                                                    unsigned int &batchSize, int &numBatchSamples)
 {
-    oldBatchTimeBoundFactor = hasSameBounds ? newBatchTimeBoundFactor * timeBoundFactorIncrease_ : newBatchTimeBoundFactor;
+    oldBatchTimeBoundFactor =
+        hasSameBounds ? newBatchTimeBoundFactor * timeBoundFactorIncrease_ : newBatchTimeBoundFactor;
     newBatchTimeBoundFactor *= timeBoundFactorIncrease_;
     startTree = true;
     if (sampleUniformForUnboundedTime_)
-        batchSize = std::ceil(2.0 * (timeBoundFactorIncrease_ - 1.0) *
-                              static_cast<double>(tStart_->size() + tGoal_->size()));
+        batchSize =
+            std::ceil(2.0 * (timeBoundFactorIncrease_ - 1.0) * static_cast<double>(tStart_->size() + tGoal_->size()));
     numBatchSamples = 0;
     OMPL_INFORM("%s: Increased time bound factor to %.2f", getName().c_str(), newBatchTimeBoundFactor);
 }
 
 void ompl::geometric::STRRTstar::constructSolution(
-    base::Motion *startMotion, base::Motion *goalMotion,
-    const ompl::base::ReportIntermediateSolutionFn &intermediateSolutionCallback, const ompl::base::PlannerTerminationCondition& ptc)
+    Motion *startMotion, Motion *goalMotion,
+    const ompl::base::ReportIntermediateSolutionFn &intermediateSolutionCallback,
+    const ompl::base::PlannerTerminationCondition &ptc)
 {
     if (goalMotion->connectionPoint == nullptr)
     {
         goalMotion->connectionPoint = startMotion;
-        base::Motion *tMotion = goalMotion;
+        Motion *tMotion = goalMotion;
         while (tMotion != nullptr)
         {
             tMotion->numConnections++;
@@ -589,8 +594,8 @@ void ompl::geometric::STRRTstar::constructSolution(
     }
 
     /* construct the solution path */
-    base::Motion *solution = startMotion;
-    std::vector<base::Motion *> mpath1;
+    Motion *solution = startMotion;
+    std::vector<Motion *> mpath1;
     while (solution != nullptr)
     {
         mpath1.push_back(solution);
@@ -598,7 +603,7 @@ void ompl::geometric::STRRTstar::constructSolution(
     }
 
     solution = goalMotion;
-    std::vector<base::Motion *> mpath2;
+    std::vector<Motion *> mpath2;
     while (solution != nullptr)
     {
         mpath2.push_back(solution);
@@ -636,7 +641,7 @@ void ompl::geometric::STRRTstar::constructSolution(
         return;
     // Prune Start and Goal Trees
     pruneStartTree();
-    base::Motion *newSolution = pruneGoalTree();
+    Motion *newSolution = pruneGoalTree();
 
     // loop as long as a new solution is found by rewiring the goal tree
     if (newSolution != nullptr)
@@ -645,7 +650,7 @@ void ompl::geometric::STRRTstar::constructSolution(
 
 void ompl::geometric::STRRTstar::pruneStartTree()
 {
-    std::queue<base::Motion *> queue;
+    std::queue<Motion *> queue;
 
     tStart_->clear();
     tStart_->add(startMotion_);
@@ -665,22 +670,22 @@ void ompl::geometric::STRRTstar::pruneStartTree()
             if (deltaT < timeToNearestGoal)
                 timeToNearestGoal = deltaT;
         }
-        // base::Motion is still valid, re-add to tree
+        // Motion is still valid, re-add to tree
         if (t + timeToNearestGoal <= upperTimeBound_)
         {
             tStart_->add(queue.front());
             for (auto &c : queue.front()->children)
                 queue.push(c);
         }
-        // base::Motion is invalid due to the new time limit, delete motion
+        // Motion is invalid due to the new time limit, delete motion
         else
         {
             // Remove the motion from its parent
             removeFromParent(queue.front());
 
             // for deletion first construct list of all descendants
-            std::queue<base::Motion *> deletionQueue;
-            std::vector<base::Motion *> deletionList;
+            std::queue<Motion *> deletionQueue;
+            std::vector<Motion *> deletionList;
 
             deletionQueue.push(queue.front());
             while (!deletionQueue.empty())
@@ -707,20 +712,20 @@ void ompl::geometric::STRRTstar::pruneStartTree()
     }
 }
 
-ompl::base::Motion *ompl::geometric::STRRTstar::pruneGoalTree()
+ompl::base::ConditionalStateSampler::Motion *ompl::geometric::STRRTstar::pruneGoalTree()
 {
     // it's possible to get multiple new solutions during the rewiring process. Store the best.
     double bestSolutionTime = upperTimeBound_;
-    base::Motion *solutionMotion{nullptr};
+    Motion *solutionMotion{nullptr};
 
     tGoal_->clear();
-    std::vector<base::Motion *> validGoals;
-    std::vector<base::Motion *> invalidGoals;
+    std::vector<Motion *> validGoals;
+    std::vector<Motion *> invalidGoals;
 
     // re-add goals with smallest time first
     std::sort(
         goalMotions_.begin(), goalMotions_.end(),
-        [](base::Motion *a, base::Motion *b)
+        [](Motion *a, Motion *b)
         {
             return a->state->as<ompl::base::CompoundState>()->as<ompl::base::TimeStateSpace::StateType>(1)->position <
                    b->state->as<ompl::base::CompoundState>()->as<ompl::base::TimeStateSpace::StateType>(1)->position;
@@ -739,7 +744,7 @@ ompl::base::Motion *ompl::geometric::STRRTstar::pruneGoalTree()
         else
         {
             invalidGoals.push_back(m);
-            std::queue<base::Motion *> queue;
+            std::queue<Motion *> queue;
             for (auto &c : m->children)
                 queue.push(c);
             while (!queue.empty())
@@ -766,7 +771,7 @@ ompl::base::Motion *ompl::geometric::STRRTstar::pruneGoalTree()
                         TreeGrowingInfo tgi{};
                         tgi.xstate = si_->allocState();
                         tgi.start = false;
-                        std::vector<base::Motion *> nbh;
+                        std::vector<Motion *> nbh;
                         GrowState gsc = growTree(tGoal_, tgi, queue.front(), nbh, true);
                         // connection successful, add all descendants and check if a new solution was found.
                         if (gsc == REACHED)
@@ -780,7 +785,7 @@ ompl::base::Motion *ompl::geometric::STRRTstar::pruneGoalTree()
                             }
                             tgi.xmotion->connectionPoint = queue.front()->connectionPoint;
                             tgi.xmotion->numConnections = queue.front()->numConnections;
-                            base::Motion *p = tgi.xmotion->parent;
+                            Motion *p = tgi.xmotion->parent;
                             while (p != nullptr)
                             {
                                 p->numConnections += tgi.xmotion->numConnections;
@@ -825,10 +830,9 @@ ompl::base::Motion *ompl::geometric::STRRTstar::pruneGoalTree()
     return solutionMotion;
 }
 
-ompl::base::Motion*
-ompl::geometric::STRRTstar::computeSolutionMotion(base::Motion *motion)
+ompl::base::ConditionalStateSampler::Motion *ompl::geometric::STRRTstar::computeSolutionMotion(Motion *motion)
 {
-    std::queue<base::Motion *> connectionQueue;
+    std::queue<Motion *> connectionQueue;
     connectionQueue.push(motion);
     while (!connectionQueue.empty())
     {
@@ -838,7 +842,7 @@ ompl::geometric::STRRTstar::computeSolutionMotion(base::Motion *motion)
         }
         else
         {
-            for (base::Motion *c : connectionQueue.front()->children)
+            for (Motion *c : connectionQueue.front()->children)
                 connectionQueue.push(c);
         }
         connectionQueue.pop();
@@ -847,7 +851,7 @@ ompl::geometric::STRRTstar::computeSolutionMotion(base::Motion *motion)
     return nullptr;
 }
 
-void ompl::geometric::STRRTstar::removeInvalidGoals(const std::vector<base::Motion *> &invalidGoals)
+void ompl::geometric::STRRTstar::removeInvalidGoals(const std::vector<Motion *> &invalidGoals)
 {
     for (auto &g : invalidGoals)
     {
@@ -864,7 +868,6 @@ void ompl::geometric::STRRTstar::removeInvalidGoals(const std::vector<base::Moti
         delete g;
     }
 }
-
 
 void ompl::geometric::STRRTstar::clear()
 {
@@ -894,7 +897,7 @@ void ompl::geometric::STRRTstar::getPlannerData(ompl::base::PlannerData &data) c
 {
     Planner::getPlannerData(data);
 
-    std::vector<base::Motion *> motions;
+    std::vector<Motion *> motions;
     if (tStart_)
         tStart_->list(motions);
 
@@ -932,7 +935,7 @@ void ompl::geometric::STRRTstar::getPlannerData(ompl::base::PlannerData &data) c
     data.properties["approx goal distance REAL"] = ompl::toString(distanceBetweenTrees_);
 }
 
-void ompl::geometric::STRRTstar::removeFromParent(base::Motion *m)
+void ompl::geometric::STRRTstar::removeFromParent(Motion *m)
 {
     for (auto it = m->parent->children.begin(); it != m->parent->children.end(); ++it)
     {
@@ -951,10 +954,9 @@ void ompl::geometric::STRRTstar::removeFromParent(base::Motion *m)
  * @param tree The tree that the motions are added to
 
  */
-void ompl::geometric::STRRTstar::addDescendants(base::Motion *m,
-                                                const ompl::geometric::STRRTstar::TreeData &tree)
+void ompl::geometric::STRRTstar::addDescendants(Motion *m, const ompl::geometric::STRRTstar::TreeData &tree)
 {
-    std::queue<base::Motion *> queue;
+    std::queue<Motion *> queue;
     for (auto &c : m->children)
         queue.push(c);
     while (!queue.empty())
@@ -967,9 +969,8 @@ void ompl::geometric::STRRTstar::addDescendants(base::Motion *m,
     }
 }
 
-void ompl::geometric::STRRTstar::getNeighbors(ompl::geometric::STRRTstar::TreeData &tree,
-                                              base::Motion *motion,
-                                              std::vector<base::Motion *> &nbh) const
+void ompl::geometric::STRRTstar::getNeighbors(ompl::geometric::STRRTstar::TreeData &tree, Motion *motion,
+                                              std::vector<Motion *> &nbh) const
 {
     auto card = static_cast<double>(tree->size() + 1u);
     if (rewireState_ == RADIUS)
@@ -988,17 +989,17 @@ void ompl::geometric::STRRTstar::getNeighbors(ompl::geometric::STRRTstar::TreeDa
     }
 }
 
-bool ompl::geometric::STRRTstar::rewireGoalTree(base::Motion *addedMotion)
+bool ompl::geometric::STRRTstar::rewireGoalTree(Motion *addedMotion)
 {
     bool solved = false;
-    std::vector<base::Motion *> nbh;
+    std::vector<Motion *> nbh;
     getNeighbors(tGoal_, addedMotion, nbh);
     double nodeT =
         addedMotion->state->as<ompl::base::CompoundState>()->as<ompl::base::TimeStateSpace::StateType>(1)->position;
     double goalT =
         addedMotion->root->as<ompl::base::CompoundState>()->as<ompl::base::TimeStateSpace::StateType>(1)->position;
 
-    for (base::Motion *otherMotion : nbh)
+    for (Motion *otherMotion : nbh)
     {
         double otherNodeT =
             otherMotion->state->as<ompl::base::CompoundState>()->as<ompl::base::TimeStateSpace::StateType>(1)->position;
@@ -1009,7 +1010,7 @@ bool ompl::geometric::STRRTstar::rewireGoalTree(base::Motion *addedMotion)
         {
             if (otherMotion->numConnections > 0)
             {
-                base::Motion *p = otherMotion->parent;
+                Motion *p = otherMotion->parent;
                 while (p != nullptr)
                 {
                     p->numConnections--;
@@ -1023,7 +1024,7 @@ bool ompl::geometric::STRRTstar::rewireGoalTree(base::Motion *addedMotion)
             // increase connection count of new ancestors
             if (otherMotion->numConnections > 0)
             {
-                base::Motion *p = otherMotion->parent;
+                Motion *p = otherMotion->parent;
                 while (p != nullptr)
                 {
                     p->numConnections++;


### PR DESCRIPTION
This MR creates pybindings so that the ST-RRT* planner is usable using python. 

I also translated the cpp demo example to a py demo example.