### PR TITLE
Use more conservative types in PLY files

### DIFF
--- a/src/ompl/base/spaces/constraint/src/AtlasStateSpace.cpp
+++ b/src/ompl/base/spaces/constraint/src/AtlasStateSpace.cpp
@@ -540,7 +540,7 @@ void ompl::base::AtlasStateSpace::printPLY(std::ostream &out) const
     out << "property float y\n";
     out << "property float z\n";
     out << "element face " << fcount << "\n";
-    out << "property list uint uint vertex_index\n";
+    out << "property list uchar int vertex_index\n";
     out << "end_header\n";
     out << v.str() << f.str();
 }

--- a/src/ompl/base/src/PlannerData.cpp
+++ b/src/ompl/base/src/PlannerData.cpp
@@ -842,7 +842,7 @@ void ompl::base::PlannerData::printPLY(std::ostream &out, const bool asIs) const
         out << "property float z\n";
 
     out << "element face " << fcount << "\n";
-    out << "property list uint uint vertex_index\n";
+    out << "property list uchar int vertex_index\n";
     out << "end_header\n";
     out << v.str() << f.str();
 }


### PR DESCRIPTION
In PLY files it is more common and well supported to use a `uchar` for the number of face vertices and an `int` for the vertex indices. These are also the types used in the PLY format description. Certain software (e.g. [Meshlab](https://www.meshlab.net/)) doesn't support using a `uint` for either type.

Although this is arguably a bug in Meshlab, it doesn't hurt if OMPL outputs PLY files in a more widely supported format, especially considering there are no drawbacks for doing so.

http://paulbourke.net/dataformats/ply/