### PR TITLE
WrapperStateSpace::getValueAddressAtLocation override StateSpace's one

### DIFF
--- a/src/ompl/base/StateSpace.h
+++ b/src/ompl/base/StateSpace.h
@@ -376,28 +376,28 @@ namespace ompl
             virtual double *getValueAddressAtIndex(State *state, unsigned int index) const;
 
             /** \brief Const variant of the same function as above; */
-            const double *getValueAddressAtIndex(const State *state, unsigned int index) const;
+            virtual const double *getValueAddressAtIndex(const State *state, unsigned int index) const;
 
             /** \brief Get the locations of values of type double contained in a state from this space. The order of the
                values is
                 consistent with getValueAddressAtIndex(). The setup() function must have been previously called. */
-            const std::vector<ValueLocation> &getValueLocations() const;
+            virtual const std::vector<ValueLocation> &getValueLocations() const;
 
             /** \brief Get the named locations of values of type double contained in a state from this space.
                 The setup() function must have been previously called. */
-            const std::map<std::string, ValueLocation> &getValueLocationsByName() const;
+            virtual const std::map<std::string, ValueLocation> &getValueLocationsByName() const;
 
             /** \brief Get a pointer to the double value in \e state that \e loc points to */
-            double *getValueAddressAtLocation(State *state, const ValueLocation &loc) const;
+            virtual double *getValueAddressAtLocation(State *state, const ValueLocation &loc) const;
 
             /** \brief Const variant of the same function as above; */
-            const double *getValueAddressAtLocation(const State *state, const ValueLocation &loc) const;
+            virtual const double *getValueAddressAtLocation(const State *state, const ValueLocation &loc) const;
 
             /** \brief Get a pointer to the double value in \e state that \e name points to */
-            double *getValueAddressAtName(State *state, const std::string &name) const;
+            virtual double *getValueAddressAtName(State *state, const std::string &name) const;
 
             /** \brief Const variant of the same function as above; */
-            const double *getValueAddressAtName(const State *state, const std::string &name) const;
+            virtual const double *getValueAddressAtName(const State *state, const std::string &name) const;
 
             /** \brief Copy all the real values from a state \e source to the array \e reals using
              * getValueAddressAtLocation() */

--- a/src/ompl/base/spaces/WrapperStateSpace.h
+++ b/src/ompl/base/spaces/WrapperStateSpace.h
@@ -324,37 +324,37 @@ namespace ompl
                 return space_->getValueAddressAtIndex(state->as<StateType>()->getState(), index);
             }
 
-            const double *getValueAddressAtIndex(const State *state, unsigned int index) const
+            const double *getValueAddressAtIndex(const State *state, unsigned int index) const override
             {
                 return space_->getValueAddressAtIndex(state->as<StateType>()->getState(), index);
             }
 
-            const std::vector<ValueLocation> &getValueLocations() const
+            const std::vector<ValueLocation> &getValueLocations() const override
             {
                 return space_->getValueLocations();
             }
 
-            const std::map<std::string, ValueLocation> &getValueLocationsByName() const
+            const std::map<std::string, ValueLocation> &getValueLocationsByName() const override
             {
                 return space_->getValueLocationsByName();
             }
 
-            double *getValueAddressAtLocation(State *state, const ValueLocation &loc) const
+            double *getValueAddressAtLocation(State *state, const ValueLocation &loc) const override
             {
                 return space_->getValueAddressAtLocation(state->as<StateType>()->getState(), loc);
             }
 
-            const double *getValueAddressAtLocation(const State *state, const ValueLocation &loc) const
+            const double *getValueAddressAtLocation(const State *state, const ValueLocation &loc) const override
             {
                 return space_->getValueAddressAtLocation(state->as<StateType>()->getState(), loc);
             }
 
-            double *getValueAddressAtName(State *state, const std::string &name) const
+            double *getValueAddressAtName(State *state, const std::string &name) const override
             {
                 return space_->getValueAddressAtName(state->as<StateType>()->getState(), name);
             }
 
-            const double *getValueAddressAtName(const State *state, const std::string &name) const
+            const double *getValueAddressAtName(const State *state, const std::string &name) const override
             {
                 return space_->getValueAddressAtName(state->as<StateType>()->getState(), name);
             }


### PR DESCRIPTION
Hi. I'm a user of constrained planning of ompl.

I found a strange behavior of WrapperStateSpace. 

source code
```c++
#include <ompl/base/spaces/constraint/ProjectedStateSpace.h>
#include <ompl/base/spaces/RealVectorStateSpace.h>
#include <ompl/base/ConstrainedSpaceInformation.h>

class Sphere : public ompl::base::Constraint
{
public:
  Sphere() : ompl::base::Constraint(3, 1)
  {
  }

  void function(const Eigen::Ref<const Eigen::VectorXd> &x, Eigen::Ref<Eigen::VectorXd> out) const override
  {
    out[0] = x.norm() - 1;
  }
};


int main(){
  auto rvss = std::make_shared<ompl::base::RealVectorStateSpace>(3);

  ompl::base::RealVectorBounds bounds(3);
  bounds.setLow(-2);
  bounds.setHigh(2);

  rvss->setBounds(bounds);

  auto constraint = std::make_shared<Sphere>();

  ompl::base::StateSpacePtr css = std::make_shared<ompl::base::ProjectedStateSpace>(rvss, constraint);
  auto csi = std::make_shared<ompl::base::ConstrainedSpaceInformation>(css);

  csi->setup();

  ompl::base::State* state = css->allocState();
  for(int i=0;i<3;i++) *(css->getValueAddressAtIndex(state,i)) = 0.57735;
  std::cout << "getValueAddressAtIndex" << std::endl;
  for(int i=0;i<3;i++) std::cout<< *(css->getValueAddressAtIndex(state,i)) << std::endl;
  std::cout << "getValueAddressAtLocations" << std::endl;
  for(int i=0;i<3;i++) std::cout<< *(css->getValueAddressAtLocation(state,css->getValueLocations()[i])) << std::endl;

  return 0;
}
```

result
```shell
getValueAddressAtIndex
0.57735
0.57735
0.57735
getValueAddressAtLocations
6.89861e-310 # strange! 0.57735 is expected
4.6491e-310 # strange! 0.57735 is expected
1.04362e-312 # strange! 0.57735 is expected
```

I think this is because `WrapperStateSpace::getValueAddressAtLocation` does not override `StateSpace::getValueAddressAtLocation`.

This pull request fixes this problem.