### PR TITLE
AIT*/EIT*: Add support for IntermediateSolutionCallback

### DIFF
--- a/src/ompl/geometric/planners/informedtrees/src/AITstar.cpp
+++ b/src/ompl/geometric/planners/informedtrees/src/AITstar.cpp
@@ -1159,6 +1159,15 @@ namespace ompl
                     // Let the problem definition know that a new solution exists.
                     pdef_->addSolutionPath(solution);
 
+                    // If enabled, pass the intermediate solution back through the callback:
+                    if (static_cast<bool>(pdef_->getIntermediateSolutionCallback()))
+                    {
+                        const auto& path = solution.path_->as<ompl::geometric::PathGeometric>()->getStates();
+                        // the callback requires a vector with const elements
+                        std::vector<const base::State *> const_path(path.begin(), path.end());
+                        pdef_->getIntermediateSolutionCallback()(this, const_path, solutionCost_);
+                    }
+
                     // Let the user know about the new solution.
                     informAboutNewSolution();
                 }

--- a/src/ompl/geometric/planners/informedtrees/src/EITstar.cpp
+++ b/src/ompl/geometric/planners/informedtrees/src/EITstar.cpp
@@ -1060,6 +1060,15 @@ namespace ompl
                     }
                 }
 
+                // If enabled, pass the intermediate solution back through the callback:
+                if (static_cast<bool>(pdef_->getIntermediateSolutionCallback()))
+                {
+                    const auto& path = solution.path_->as<ompl::geometric::PathGeometric>()->getStates();
+                    // the callback requires a vector with const elements
+                    std::vector<const base::State *> const_path(path.begin(), path.end());
+                    pdef_->getIntermediateSolutionCallback()(this, const_path, solutionCost_);
+                }
+
                 // Let the user know about the new solution.
                 informAboutNewSolution();
             }


### PR DESCRIPTION
Related to #874 

This PR adds a call to `getIntermediateSoluitionCallback` to AIT* and EIT* planners, so the `CostConvergenceTermination`  (and `CForest`) can be used with them.

On a side note, the planner specs were already setting `canReportIntermediateSolutions` as true.