### PR TITLE
Add back in alternative signature for Python bindings for constrained planning

### DIFF
--- a/py-bindings/generate_bindings.py
+++ b/py-bindings/generate_bindings.py
@@ -327,16 +327,28 @@ class ompl_base_generator_t(code_generator_t):
                 'ConstrainedStateSpace').class_('StateType'), 'double')
             # \todo: figure why commented-out code causes a problem.
             self.ompl_ns.class_('ConstraintIntersection').exclude()
+
+            signatures = ['::Eigen::Ref<const Eigen::Matrix<double, -1, 1, 0, -1, 1>, 0, Eigen::InnerStride<1> > const &',
+                          '::Eigen::Ref<const Eigen::Matrix<double, -1, 1, 0>, 0, Eigen::InnerStride<1>> const &']
+
             for cls in [self.ompl_ns.class_('Constraint')]: #,
 #                        self.ompl_ns.class_('ConstraintIntersection')]:
                 for method in ['function', 'jacobian']:
-                    cls.member_function(method, arg_types=[
-                        '::Eigen::Ref<const Eigen::Matrix<double, -1, 1, 0>, 0, Eigen::InnerStride<1>> const &',
-                        None]).add_transformation(FT.input(0))
+                    for signature in signatures:
+                        try:
+                            cls.member_function(method, arg_types=[signature, None]).add_transformation(FT.input(0))
+                        except Exception as e:
+                            pass
+
             cls = self.ompl_ns.class_('Constraint')
             for method in ['distance', 'isSatisfied']:
-                cls.member_function(method, arg_types=[
-                    '::Eigen::Ref<const Eigen::Matrix<double, -1, 1, 0>, 0, Eigen::InnerStride<1>> const &',]).add_transformation(FT.input(0))
+
+                for signature in signatures:
+                    try:
+                        cls.member_function(method, arg_types=[signature]).add_transformation(FT.input(0))
+                    except Exception as e:
+                        pass
+
         except Exception as e:
             pass
 


### PR DESCRIPTION
Fixes #1031 