### PR TITLE
CMake: Switch to exported namespace targets and prefer config mode

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -48,9 +48,7 @@ set_package_properties(Boost PROPERTIES
     URL "https://www.boost.org"
     PURPOSE "Used throughout OMPL for data serialization, graphs, etc.")
 set(Boost_USE_MULTITHREADED ON)
-set(Boost_NO_BOOST_CMAKE ON)
-find_package(Boost 1.58 QUIET REQUIRED COMPONENTS serialization filesystem system program_options)
-include_directories(SYSTEM ${Boost_INCLUDE_DIR})
+find_package(Boost 1.58 REQUIRED COMPONENTS serialization filesystem system program_options)
 
 # Add support in Boost::Python for std::shared_ptr
 # This is a hack that replaces boost::shared_ptr related code with std::shared_ptr.

--- a/src/ompl/CMakeLists.txt
+++ b/src/ompl/CMakeLists.txt
@@ -36,15 +36,20 @@ source_group("OMPL Headers" FILES "${OMPL_HEADERS}")
 # build the library
 if(MSVC)
     add_library(ompl STATIC ${OMPL_SOURCE_CODE})
-else(MSVC)
+else()
     add_library(ompl SHARED ${OMPL_SOURCE_CODE})
-endif(MSVC)
+endif()
 target_link_libraries(ompl
     ${OMPL_LINK_LIBRARIES}
     ${Boost_SERIALIZATION_LIBRARY}
     ${Boost_FILESYSTEM_LIBRARY}
     ${Boost_SYSTEM_LIBRARY}
-    ${CMAKE_THREAD_LIBS_INIT})
+    ${CMAKE_THREAD_LIBS_INIT}
+    Boost::filesystem
+    Boost::serialization
+    Boost::filesystem
+    Boost::system
+    Boost::program_options)
 
 if (OMPL_HAVE_SPOT)
     target_link_libraries(ompl ${SPOT_LIBRARIES})

--- a/src/ompl/CMakeLists.txt
+++ b/src/ompl/CMakeLists.txt
@@ -41,15 +41,11 @@ else()
 endif()
 target_link_libraries(ompl
     ${OMPL_LINK_LIBRARIES}
-    ${Boost_SERIALIZATION_LIBRARY}
-    ${Boost_FILESYSTEM_LIBRARY}
-    ${Boost_SYSTEM_LIBRARY}
     ${CMAKE_THREAD_LIBS_INIT}
     Boost::filesystem
+    Boost::program_options
     Boost::serialization
-    Boost::filesystem
-    Boost::system
-    Boost::program_options)
+    Boost::system)
 
 if (OMPL_HAVE_SPOT)
     target_link_libraries(ompl ${SPOT_LIBRARIES})


### PR DESCRIPTION
This allows use of config mode in boost to find it. Regardless of whether boost is found via config or module, the alias targets can, and are preferred, to be used in CMake. 

Reference: https://cmake.org/cmake/help/latest/module/FindBoost.html#boost-cmake
Relates to https://github.com/ompl/ompl/issues/1065