### PR TITLE
Only prune goal in BIT* if it is not part of the current best solution

### DIFF
--- a/src/ompl/geometric/planners/informedtrees/bitstar/src/ImplicitGraph.cpp
+++ b/src/ompl/geometric/planners/informedtrees/bitstar/src/ImplicitGraph.cpp
@@ -1093,8 +1093,14 @@ namespace ompl
                 // Run until at the end:
                 while (goalIter != goalEnd)
                 {
-                    // Check if this goal has met the criteria to be pruned
-                    if (this->canSampleBePruned(*goalIter))
+                    // Check if this goal has met the criteria to be pruned, but make sure it is not the goal that is
+                    // the current best solution. The current goal can satisfy the condition for pruning if the
+                    // heuristic is perfect, since samples are pruned unless the combined costs of the heuristic
+                    // cost-to-come and heuristic cost-to-go is (strictly) lower than the current solution cost. If the
+                    // heuristic is perfect, then the heuristic cost-to-come is equal to the solution cost (and the
+                    // heuristic cost-to-go is zero, since this is a goal).
+                    if (this->canSampleBePruned(*goalIter) &&
+                        costHelpPtr_->isCostNotEquivalentTo((*goalIter)->getCost(), solutionCost_))
                     {
                         // It has, remove the goal vertex completely
                         // Check if this vertex is in the tree

--- a/src/ompl/geometric/planners/informedtrees/bitstar/src/ImplicitGraph.cpp
+++ b/src/ompl/geometric/planners/informedtrees/bitstar/src/ImplicitGraph.cpp
@@ -527,6 +527,9 @@ namespace ompl
                         // Add it back to the vector
                         startVertices_.push_back(*prunedStartIter);
 
+                        // Add as a sample
+                        this->addToSamples(*prunedStartIter);
+
                         // Add this vertex to the queue.
                         // queuePtr_->enqueueVertex(*prunedStartIter);
 


### PR DESCRIPTION
This hopefully fixes #949.

The errors reported in #949 suggest that the start and goal of a trivial solution (direct start to goal connection) are sometimes pruned. If there are multiple goals and if the heuristic is perfect for a trivial solution (e.g., Euclidean distance heuristic for path length objective in an environment that allows for the trivial solution), then the current code will indeed prune the start and goal. The proposed change directly prevents this by checking the cost of the goal and by adding previously pruned starts back to the samples if necessary.