### PR TITLE
fix: EIGEN3_INCLUDE_DIR is not defined when Eigen3 is installed from source code.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -108,6 +108,9 @@ set_package_properties(Eigen3 PROPERTIES
     URL "http://eigen.tuxfamily.org"
     PURPOSE "A linear algebra library used throughout OMPL.")
 find_package(Eigen3 REQUIRED)
+if (NOT DEFINED EIGEN3_INCLUDE_DIR)
+    get_target_property(EIGEN3_INCLUDE_DIR Eigen3::Eigen INTERFACE_INCLUDE_DIRECTORIES)
+endif ()
 include_directories(SYSTEM "${EIGEN3_INCLUDE_DIR}")
 
 set_package_properties(Triangle PROPERTIES


### PR DESCRIPTION
The latest Eigen3 version 3.4.90 does not define `EIGEN3_INCLUDE_DIR` but embeds everything in an imported target `Eigen3::Eigen`.