### PR TITLE
Use of Dubins Set Classification for faster distance computations in DubinsStateSpace

### DIFF
--- a/src/ompl/base/spaces/DubinsStateSpace.h
+++ b/src/ompl/base/spaces/DubinsStateSpace.h
@@ -71,6 +71,26 @@ namespace ompl
                 DUBINS_STRAIGHT = 1,
                 DUBINS_RIGHT = 2
             };
+
+            enum DubinsClass
+            {
+                A11 = 0,
+                A12 = 1,
+                A13 = 2,
+                A14 = 3,
+                A21 = 4,
+                A22 = 5,
+                A23 = 6,
+                A24 = 7,
+                A31 = 8,
+                A32 = 9,
+                A33 = 10,
+                A34 = 11,
+                A41 = 12,
+                A42 = 13,
+                A43 = 14,
+                A44 = 15
+            };
             /** \brief Dubins path types */
             static const DubinsPathSegmentType dubinsPathType[6][3];
             /** \brief Complete description of a Dubins path */

--- a/src/ompl/base/spaces/DubinsStateSpace.h
+++ b/src/ompl/base/spaces/DubinsStateSpace.h
@@ -72,25 +72,6 @@ namespace ompl
                 DUBINS_RIGHT = 2
             };
 
-            enum DubinsClass
-            {
-                A11 = 0,
-                A12 = 1,
-                A13 = 2,
-                A14 = 3,
-                A21 = 4,
-                A22 = 5,
-                A23 = 6,
-                A24 = 7,
-                A31 = 8,
-                A32 = 9,
-                A33 = 10,
-                A34 = 11,
-                A41 = 12,
-                A42 = 13,
-                A43 = 14,
-                A44 = 15
-            };
             /** \brief Dubins path types */
             static const DubinsPathSegmentType dubinsPathType[6][3];
             /** \brief Complete description of a Dubins path */

--- a/src/ompl/base/spaces/src/DubinsStateSpace.cpp
+++ b/src/ompl/base/spaces/src/DubinsStateSpace.cpp
@@ -673,6 +673,8 @@ DubinsStateSpace::DubinsPath dubins(double d, double alpha, double beta)
 {
     if (d < DUBINS_EPS && fabs(alpha - beta) < DUBINS_EPS)
         return {DubinsStateSpace::dubinsPathType[0], 0, d, 0};
+    alpha = mod2pi(alpha);
+    beta = mod2pi(beta);
     return is_longpath_case(d, alpha, beta) ? ::dubins_classification(d, alpha, beta) :
                                               ::dubins_exhaustive(d, alpha, beta);
 }

--- a/src/ompl/base/spaces/src/DubinsStateSpace.cpp
+++ b/src/ompl/base/spaces/src/DubinsStateSpace.cpp
@@ -165,7 +165,12 @@ namespace
         return {};
     }
 
-    DubinsStateSpace::DubinsPath dubins(double d, double alpha, double beta)
+    bool is_longpath_case(double d, double alpha, double beta) {
+        return (std::abs(std::sin(alpha)) + std::abs(std::sin(beta)) 
+        + std::sqrt(4 - std::pow(std::cos(alpha) + std::sin(beta), 2)) - d) < 0;
+    }
+
+    DubinsStateSpace::DubinsPath dubins_exhaustive(const double d, const double alpha, const double beta)
     {
         if (d < DUBINS_EPS && fabs(alpha - beta) < DUBINS_EPS)
             return {DubinsStateSpace::dubinsPathType[0], 0, d, 0};
@@ -201,6 +206,20 @@ namespace
             path = tmp;
         return path;
     }
+}
+
+DubinsStateSpace::DubinsPath dubins_classification(const double d, const double alpha, const double beta) {
+    if (d < DUBINS_EPS && fabs(alpha - beta) < DUBINS_EPS)
+        return {DubinsStateSpace::dubinsPathType[0], 0, d, 0};
+    ///TODO: Implement dubins set classification
+    return ::dubins_exhaustive(d, alpha, beta);
+}
+
+DubinsStateSpace::DubinsPath dubins(double d, double alpha, double beta)
+{
+    if (d < DUBINS_EPS && fabs(alpha - beta) < DUBINS_EPS)
+        return {DubinsStateSpace::dubinsPathType[0], 0, d, 0};
+    return is_longpath_case(d, alpha, beta) ? ::dubins_classification(d, alpha, beta) : ::dubins_exhaustive(d, alpha, beta);
 }
 
 const ompl::base::DubinsStateSpace::DubinsPathSegmentType ompl::base::DubinsStateSpace::dubinsPathType[6][3] = {

--- a/src/ompl/base/spaces/src/DubinsStateSpace.cpp
+++ b/src/ompl/base/spaces/src/DubinsStateSpace.cpp
@@ -53,8 +53,176 @@ namespace
         if (x < 0 && x > DUBINS_ZERO)
             return 0;
         double xm = x - twopi * floor(x / twopi);
-        if (twopi - xm < .5 * DUBINS_EPS) xm = 0.;
+        if (twopi - xm < .5 * DUBINS_EPS)
+            xm = 0.;
         return xm;
+    }
+
+    inline double t_lsr(double d, double alpha, double beta)
+    {
+        double ca = cos(alpha), sa = sin(alpha), cb = cos(beta), sb = sin(beta);
+        const double tmp = -2.0 + d * d + 2.0 * (ca * cb + sa * sb + d * (sa + sb));
+        const double p = sqrtf(std::max(tmp, 0.0));
+        const double theta = atan2f(-ca - cb, d + sa + sb) - atan2f(-2.0, p);
+        return mod2pi(-alpha + theta);  // t
+    }
+
+    inline double p_lsr(double d, double alpha, double beta)
+    {
+        double ca = cos(alpha), sa = sin(alpha), cb = cos(beta), sb = sin(beta);
+        const double tmp = -2.0 + d * d + 2.0 * (ca * cb + sa * sb + d * (sa + sb));
+        return sqrtf(std::max(tmp, 0.0));  // p
+    }
+
+    inline double q_lsr(double d, double alpha, double beta)
+    {
+        double ca = cos(alpha), sa = sin(alpha), cb = cos(beta), sb = sin(beta);
+        const double tmp = -2.0 + d * d + 2.0 * (ca * cb + sa * sb + d * (sa + sb));
+        const double p = sqrtf(std::max(tmp, 0.0));
+        const double theta = atan2f(-ca - cb, d + sa + sb) - atan2f(-2.0, p);
+        return mod2pi(-beta + theta);  // q
+    }
+
+    inline double t_rsl(double d, double alpha, double beta)
+    {
+        double ca = cos(alpha), sa = sin(alpha), cb = cos(beta), sb = sin(beta);
+        const double tmp = d * d - 2.0 + 2.0 * (ca * cb + sa * sb - d * (sa + sb));
+        const double p = sqrtf(std::max(tmp, 0.0));
+        const double theta = atan2f(ca + cb, d - sa - sb) - atan2f(2.0, p);
+        return mod2pi(alpha - theta);  // t
+    }
+
+    inline double p_rsl(double d, double alpha, double beta)
+    {
+        double ca = cos(alpha), sa = sin(alpha), cb = cos(beta), sb = sin(beta);
+        const double tmp = d * d - 2.0 + 2.0 * (ca * cb + sa * sb - d * (sa + sb));
+        return sqrtf(std::max(tmp, 0.0));  // p
+    }
+
+    inline double q_rsl(double d, double alpha, double beta)
+    {
+        double ca = cos(alpha), sa = sin(alpha), cb = cos(beta), sb = sin(beta);
+        const double tmp = d * d - 2.0 + 2.0 * (ca * cb + sa * sb - d * (sa + sb));
+        const double p = sqrtf(std::max(tmp, 0.));
+        const double theta = atan2f(ca + cb, d - sa - sb) - atan2f(2.0, p);
+        return mod2pi(beta - theta);  // q
+    }
+
+    inline double t_rsr(double d, double alpha, double beta)
+    {
+        double ca = cos(alpha), sa = sin(alpha), cb = cos(beta), sb = sin(beta);
+        const double theta = atan2f(ca - cb, d - sa + sb);
+        return mod2pi(alpha - theta);  // t
+    }
+
+    inline double p_rsr(double d, double alpha, double beta)
+    {
+        double ca = cos(alpha), sa = sin(alpha), cb = cos(beta), sb = sin(beta);
+        const double tmp = 2.0 + d * d - 2.0 * (ca * cb + sa * sb - d * (sb - sa));
+        return sqrtf(std::max(tmp, 0.0));  // p
+    }
+
+    inline double q_rsr(double d, double alpha, double beta)
+    {
+        double ca = cos(alpha), sa = sin(alpha), cb = cos(beta), sb = sin(beta);
+        const double theta = atan2f(ca - cb, d - sa + sb);
+        return mod2pi(-beta + theta);  // q
+    }
+
+    inline double t_lsl(double d, double alpha, double beta)
+    {
+        double ca = cos(alpha), sa = sin(alpha), cb = cos(beta), sb = sin(beta);
+        const double theta = atan2f(cb - ca, d + sa - sb);
+        return mod2pi(-alpha + theta);  // t
+    }
+
+    inline double p_lsl(double d, double alpha, double beta)
+    {
+        double ca = cos(alpha), sa = sin(alpha), cb = cos(beta), sb = sin(beta);
+        const double tmp = 2.0 + d * d - 2.0 * (ca * cb + sa * sb - d * (sa - sb));
+        return sqrtf(std::max(tmp, 0.0));  // p
+    }
+
+    inline double q_lsl(double d, double alpha, double beta)
+    {
+        double ca = cos(alpha), sa = sin(alpha), cb = cos(beta), sb = sin(beta);
+        const double theta = atan2f(cb - ca, d + sa - sb);
+        return mod2pi(beta - theta);  // q
+    }
+
+    inline double s_12(double d, double alpha, double beta)
+    {
+        return p_rsr(d, alpha, beta) - p_rsl(d, alpha, beta) - 2.0 * (q_rsl(d, alpha, beta) - boost::math::constants::pi<double>());
+    }
+
+    inline double s_13(double d, double alpha, double beta)
+    {  // t_rsr - pi
+        return t_rsr(d, alpha, beta) - boost::math::constants::pi<double>();
+    }
+
+    inline double s_14_1(double d, double alpha, double beta)
+    {
+        return t_rsr(d, alpha, beta) - boost::math::constants::pi<double>();
+    }
+
+    inline double s_21(double d, double alpha, double beta)
+    {
+        return p_lsl(d, alpha, beta) - p_rsl(d, alpha, beta) - 2.0 * (t_rsl(d, alpha, beta) - boost::math::constants::pi<double>());
+    }
+
+    inline double s_22_1(double d, double alpha, double beta)
+    {
+        return p_lsl(d, alpha, beta) - p_rsl(d, alpha, beta) - 2.0 * (t_rsl(d, alpha, beta) - boost::math::constants::pi<double>());
+    }
+
+    inline double s_22_2(double d, double alpha, double beta)
+    {
+        return p_rsr(d, alpha, beta) - p_rsl(d, alpha, beta) - 2.0 * (q_rsl(d, alpha, beta) - boost::math::constants::pi<double>());
+    }
+
+    inline double s_24(double d, double alpha, double beta)
+    {
+        return q_rsr(d, alpha, beta) - boost::math::constants::pi<double>();
+    }
+
+    inline double s_31(double d, double alpha, double beta)
+    {
+        return q_lsl(d, alpha, beta) - boost::math::constants::pi<double>();
+    }
+
+    inline double s_33_1(double d, double alpha, double beta)
+    {
+        return p_rsr(d, alpha, beta) - p_lsr(d, alpha, beta) - 2.0 * (t_lsr(d, alpha, beta) - boost::math::constants::pi<double>());
+    }
+
+    inline double s_33_2(double d, double alpha, double beta)
+    {
+        return p_lsl(d, alpha, beta) - p_lsr(d, alpha, beta) - 2.0 * (q_lsr(d, alpha, beta) - boost::math::constants::pi<double>());
+    }
+
+    inline double s_34(double d, double alpha, double beta)
+    {
+        return p_rsr(d, alpha, beta) - p_lsr(d, alpha, beta) - 2.0 * (t_lsr(d, alpha, beta) - boost::math::constants::pi<double>());
+    }
+
+    inline double s_41_1(double d, double alpha, double beta)
+    {
+        return t_lsl(d, alpha, beta) - boost::math::constants::pi<double>();
+    }
+
+    inline double s_41_2(double d, double alpha, double beta)
+    {
+        return q_lsl(d, alpha, beta) - boost::math::constants::pi<double>();
+    }
+
+    inline double s_42(double d, double alpha, double beta)
+    {
+        return t_lsl(d, alpha, beta) - boost::math::constants::pi<double>();
+    }
+
+    inline double s_43(double d, double alpha, double beta)
+    {
+        return p_lsl(d, alpha, beta) - p_lsr(d, alpha, beta) - 2.0 * (q_lsr(d, alpha, beta) - boost::math::constants::pi<double>());
     }
 
     DubinsStateSpace::DubinsPath dubinsLSL(double d, double alpha, double beta)
@@ -85,7 +253,7 @@ namespace
             double t = mod2pi(alpha - theta);
             double p = sqrt(std::max(tmp, 0.));
             double q = mod2pi(-beta + theta);
-            assert(fabs(p * cos(alpha - t) + sa - sb - d) < 2* DUBINS_EPS);
+            assert(fabs(p * cos(alpha - t) + sa - sb - d) < 2 * DUBINS_EPS);
             assert(fabs(p * sin(alpha - t) - ca + cb) < 2 * DUBINS_EPS);
             assert(mod2pi(alpha - t - q - beta + .5 * DUBINS_EPS) < DUBINS_EPS);
             return DubinsStateSpace::DubinsPath(DubinsStateSpace::dubinsPathType[1], t, p, q);
@@ -165,9 +333,10 @@ namespace
         return {};
     }
 
-    bool is_longpath_case(double d, double alpha, double beta) {
-        return (std::abs(std::sin(alpha)) + std::abs(std::sin(beta)) 
-        + std::sqrt(4 - std::pow(std::cos(alpha) + std::sin(beta), 2)) - d) < 0;
+    bool is_longpath_case(double d, double alpha, double beta)
+    {
+        return (std::abs(std::sin(alpha)) + std::abs(std::sin(beta)) +
+                std::sqrt(4 - std::pow(std::cos(alpha) + std::cos(beta), 2)) - d) < 0;
     }
 
     DubinsStateSpace::DubinsPath dubins_exhaustive(const double d, const double alpha, const double beta)
@@ -206,29 +375,312 @@ namespace
             path = tmp;
         return path;
     }
-}
 
-DubinsStateSpace::DubinsPath dubins_classification(const double d, const double alpha, const double beta) {
+    DubinsStateSpace::DubinsClass getDubinsClass(const double d, const double alpha, const double beta)
+    {
+        int row(0), column(0);
+        if (0 <= alpha && alpha <= boost::math::constants::half_pi<double>())
+        {
+            row = 1;
+        }
+        else if (boost::math::constants::half_pi<double>() < alpha && alpha <= boost::math::constants::pi<double>())
+        {
+            row = 2;
+        }
+        else if (boost::math::constants::pi<double>() < alpha && alpha <= 3 * boost::math::constants::half_pi<double>())
+        {
+            row = 3;
+        }
+        else if (3 * boost::math::constants::half_pi<double>() < alpha && alpha <= twopi)
+        {
+            row = 4;
+        }
+
+        if (0 <= beta && beta <= boost::math::constants::half_pi<double>())
+        {
+            column = 1;
+        }
+        else if (boost::math::constants::half_pi<double>() < beta && beta <= boost::math::constants::pi<double>())
+        {
+            column = 2;
+        }
+        else if (boost::math::constants::pi<double>() < beta && beta <= 3 * boost::math::constants::half_pi<double>())
+        {
+            column = 3;
+        }
+        else if (3 * boost::math::constants::half_pi<double>() < beta &&
+                 beta <= 2.0 * boost::math::constants::pi<double>())
+        {
+            column = 4;
+        }
+
+        assert(row >= 1 && row <= 4 &&
+               "alpha is not in the range of [0,2pi] in classifyPath(double alpha, double beta).");
+        assert(column >= 1 && column <= 4 &&
+               "beta is not in the range of [0,2pi] in classifyPath(double alpha, double beta).");
+        assert((column - 1) + 4 * (row - 1) >= 0 && (column - 1) + 4 * (row - 1) <= 15 &&
+               "class is not in range [0,15].");
+        return (DubinsStateSpace::DubinsClass)((column - 1) + 4 * (row - 1));
+    }
+}  // namespace
+
+DubinsStateSpace::DubinsPath dubins_classification(const double d, const double alpha, const double beta)
+{
     if (d < DUBINS_EPS && fabs(alpha - beta) < DUBINS_EPS)
         return {DubinsStateSpace::dubinsPathType[0], 0, d, 0};
-    ///TODO: Implement dubins set classification
-    return ::dubins_exhaustive(d, alpha, beta);
+    // Dubins set classification scheme
+    // Shkel, Andrei M., and Vladimir Lumelsky. "Classification of the Dubins set."
+    //   Robotics and Autonomous Systems 34.4 (2001): 179-202.
+    // Lim, Jaeyoung, et al. "Circling Back: Dubins set Classification Revisited."
+    //   Workshop on Energy Efficient Aerial Robotic Systems, International Conference on Robotics and Automation 2023.
+    //   2023.
+    DubinsStateSpace::DubinsPath path;
+    auto dubins_class = getDubinsClass(d, alpha, beta);
+    switch (dubins_class)
+    {
+        case DubinsStateSpace::DubinsClass::A11:
+        {
+            path = dubinsRSL(d, alpha, beta);
+            break;
+        }
+        case DubinsStateSpace::DubinsClass::A12:
+        {
+            if (s_13(d, alpha, beta) < 0.0)
+            {
+                path = (s_12(d, alpha, beta) < 0.0) ? dubinsRSR(d, alpha, beta) : dubinsRSL(d, alpha, beta);
+            }
+            else
+            {
+                path = dubinsLSR(d, alpha, beta);
+                DubinsStateSpace::DubinsPath tmp = dubinsRSL(d, alpha, beta);
+                if (path.length() > tmp.length())
+                {
+                    path = tmp;
+                }
+            }
+            break;
+        }
+        case DubinsStateSpace::DubinsClass::A13:
+        {
+            if (s_13(d, alpha, beta) < 0.0)
+            {
+                path = dubinsRSR(d, alpha, beta);
+            }
+            else
+            {
+                path = dubinsLSR(d, alpha, beta);
+            }
+            break;
+        }
+        case DubinsStateSpace::DubinsClass::A14:
+        {
+            if (s_14_1(d, alpha, beta) > 0.0)
+            {
+                path = dubinsLSR(d, alpha, beta);
+            }
+            else if (s_24(d, alpha, beta) > 0.0)
+            {
+                path = dubinsRSL(d, alpha, beta);
+            }
+            else
+            {
+                path = dubinsRSR(d, alpha, beta);
+            }
+            break;
+        }
+        case DubinsStateSpace::DubinsClass::A21:
+        {
+            if (s_31(d, alpha, beta) < 0.0)
+            {
+                if (s_21(d, alpha, beta) < 0.0)
+                {
+                    path = dubinsLSL(d, alpha, beta);
+                }
+                else
+                {
+                    path = dubinsRSL(d, alpha, beta);
+                }
+            }
+            else
+            {
+                path = dubinsLSR(d, alpha, beta);
+                DubinsStateSpace::DubinsPath tmp = dubinsRSL(d, alpha, beta);
+                if (path.length() > tmp.length())
+                {
+                    path = tmp;
+                }
+            }
+            break;
+        }
+        case DubinsStateSpace::DubinsClass::A22:
+        {
+            if (alpha > beta)
+            {
+                path = (s_22_1(d, alpha, beta) < 0.0) ? dubinsLSL(d, alpha, beta) : dubinsRSL(d, alpha, beta);
+            }
+            else
+            {
+                path = (s_22_2(d, alpha, beta) < 0.0) ? dubinsRSR(d, alpha, beta) : dubinsRSL(d, alpha, beta);
+            }
+            break;
+        }
+        case DubinsStateSpace::DubinsClass::A23:
+        {
+            path = dubinsRSR(d, alpha, beta);
+            break;
+        }
+        case DubinsStateSpace::DubinsClass::A24:
+        {
+            if (s_24(d, alpha, beta) < 0.0)
+            {
+                path = dubinsRSR(d, alpha, beta);
+            }
+            else
+            {
+                path = dubinsRSL(d, alpha, beta);
+            }
+            break;
+        }
+        case DubinsStateSpace::DubinsClass::A31:
+        {
+            if (s_31(d, alpha, beta) < 0.0)
+            {
+                path = dubinsLSL(d, alpha, beta);
+            }
+            else
+            {
+                path = dubinsLSR(d, alpha, beta);
+            }
+            break;
+        }
+        case DubinsStateSpace::DubinsClass::A32:
+        {
+            path = dubinsLSL(d, alpha, beta);
+            break;
+        }
+        case DubinsStateSpace::DubinsClass::A33:
+        {
+            if (alpha < beta)
+            {
+                if (s_33_1(d, alpha, beta) < 0.0)
+                {
+                    path = dubinsRSR(d, alpha, beta);
+                }
+                else
+                {
+                    path = dubinsLSR(d, alpha, beta);
+                }
+            }
+            else
+            {
+                if (s_33_2(d, alpha, beta) < 0.0)
+                {
+                    path = dubinsLSL(d, alpha, beta);
+                }
+                else
+                {
+                    path = dubinsLSR(d, alpha, beta);
+                }
+            }
+            break;
+        }
+        case DubinsStateSpace::DubinsClass::A34:
+        {
+            if (s_24(d, alpha, beta) < 0.0)
+            {
+                if (s_34(d, alpha, beta) < 0.0)
+                {
+                    path = dubinsRSR(d, alpha, beta);
+                }
+                else
+                {
+                    path = dubinsLSR(d, alpha, beta);
+                }
+            }
+            else
+            {
+                path = dubinsLSR(d, alpha, beta);
+                DubinsStateSpace::DubinsPath tmp = dubinsRSL(d, alpha, beta);
+                if (path.length() > tmp.length())
+                {
+                    path = tmp;
+                }
+            }
+            break;
+        }
+        case DubinsStateSpace::DubinsClass::A41:
+        {
+            if (s_41_1(d, alpha, beta) > 0.0)
+            {
+                path = dubinsRSL(d, alpha, beta);
+            }
+            else if (s_41_2(d, alpha, beta) > 0.0)
+            {
+                path = dubinsLSR(d, alpha, beta);
+            }
+            else
+            {
+                path = dubinsLSL(d, alpha, beta);
+            }
+            break;
+        }
+        case DubinsStateSpace::DubinsClass::A42:
+        {
+            if (s_42(d, alpha, beta) < 0.0)
+            {
+                path = dubinsLSL(d, alpha, beta);
+            }
+            else
+            {
+                path = dubinsRSL(d, alpha, beta);
+            }
+            break;
+        }
+        case DubinsStateSpace::DubinsClass::A43:
+        {
+            if (s_42(d, alpha, beta) < 0.0)
+            {
+                if (s_43(d, alpha, beta) < 0.0)
+                {
+                    path = dubinsLSL(d, alpha, beta);
+                }
+                else
+                {
+                    path = dubinsLSR(d, alpha, beta);
+                }
+            }
+            else
+            {
+                path = dubinsLSR(d, alpha, beta);
+                DubinsStateSpace::DubinsPath tmp = dubinsRSL(d, alpha, beta);
+                if (path.length() > tmp.length())
+                {
+                    path = tmp;
+                }
+            }
+            break;
+        }
+        case DubinsStateSpace::DubinsClass::A44:
+        {
+            path = dubinsLSR(d, alpha, beta);
+            break;
+        }
+    }
+    return path;
 }
 
 DubinsStateSpace::DubinsPath dubins(double d, double alpha, double beta)
 {
     if (d < DUBINS_EPS && fabs(alpha - beta) < DUBINS_EPS)
         return {DubinsStateSpace::dubinsPathType[0], 0, d, 0};
-    return is_longpath_case(d, alpha, beta) ? ::dubins_classification(d, alpha, beta) : ::dubins_exhaustive(d, alpha, beta);
+    return is_longpath_case(d, alpha, beta) ? ::dubins_classification(d, alpha, beta) :
+                                              ::dubins_exhaustive(d, alpha, beta);
 }
 
 const ompl::base::DubinsStateSpace::DubinsPathSegmentType ompl::base::DubinsStateSpace::dubinsPathType[6][3] = {
-    {DUBINS_LEFT, DUBINS_STRAIGHT, DUBINS_LEFT},
-    {DUBINS_RIGHT, DUBINS_STRAIGHT, DUBINS_RIGHT},
-    {DUBINS_RIGHT, DUBINS_STRAIGHT, DUBINS_LEFT},
-    {DUBINS_LEFT, DUBINS_STRAIGHT, DUBINS_RIGHT},
-    {DUBINS_RIGHT, DUBINS_LEFT, DUBINS_RIGHT},
-    {DUBINS_LEFT, DUBINS_RIGHT, DUBINS_LEFT}};
+    {DUBINS_LEFT, DUBINS_STRAIGHT, DUBINS_LEFT},  {DUBINS_RIGHT, DUBINS_STRAIGHT, DUBINS_RIGHT},
+    {DUBINS_RIGHT, DUBINS_STRAIGHT, DUBINS_LEFT}, {DUBINS_LEFT, DUBINS_STRAIGHT, DUBINS_RIGHT},
+    {DUBINS_RIGHT, DUBINS_LEFT, DUBINS_RIGHT},    {DUBINS_LEFT, DUBINS_RIGHT, DUBINS_LEFT}};
 
 double ompl::base::DubinsStateSpace::distance(const State *state1, const State *state2) const
 {
@@ -337,8 +789,7 @@ void ompl::base::DubinsStateSpace::interpolate(const State *from, const DubinsPa
     freeState(s);
 }
 
-unsigned int ompl::base::DubinsStateSpace::validSegmentCount(const State *state1,
-                                                             const State *state2) const
+unsigned int ompl::base::DubinsStateSpace::validSegmentCount(const State *state1, const State *state2) const
 {
     return StateSpace::validSegmentCount(state1, state2);
 }

--- a/src/ompl/base/spaces/src/DubinsStateSpace.cpp
+++ b/src/ompl/base/spaces/src/DubinsStateSpace.cpp
@@ -48,6 +48,26 @@ namespace
     const double DUBINS_EPS = 1e-6;
     const double DUBINS_ZERO = -1e-7;
 
+    enum DubinsClass
+    {
+        A11 = 0,
+        A12 = 1,
+        A13 = 2,
+        A14 = 3,
+        A21 = 4,
+        A22 = 5,
+        A23 = 6,
+        A24 = 7,
+        A31 = 8,
+        A32 = 9,
+        A33 = 10,
+        A34 = 11,
+        A41 = 12,
+        A42 = 13,
+        A43 = 14,
+        A44 = 15
+    };
+
     inline double mod2pi(double x)
     {
         if (x < 0 && x > DUBINS_ZERO)
@@ -376,7 +396,7 @@ namespace
         return path;
     }
 
-    DubinsStateSpace::DubinsClass getDubinsClass(const double d, const double alpha, const double beta)
+    DubinsClass getDubinsClass(const double d, const double alpha, const double beta)
     {
         int row(0), column(0);
         if (0 <= alpha && alpha <= boost::math::constants::half_pi<double>())
@@ -420,7 +440,7 @@ namespace
                "beta is not in the range of [0,2pi] in classifyPath(double alpha, double beta).");
         assert((column - 1) + 4 * (row - 1) >= 0 && (column - 1) + 4 * (row - 1) <= 15 &&
                "class is not in range [0,15].");
-        return (DubinsStateSpace::DubinsClass)((column - 1) + 4 * (row - 1));
+        return (DubinsClass)((column - 1) + 4 * (row - 1));
     }
 }  // namespace
 
@@ -438,12 +458,12 @@ DubinsStateSpace::DubinsPath dubins_classification(const double d, const double 
     auto dubins_class = getDubinsClass(d, alpha, beta);
     switch (dubins_class)
     {
-        case DubinsStateSpace::DubinsClass::A11:
+        case DubinsClass::A11:
         {
             path = dubinsRSL(d, alpha, beta);
             break;
         }
-        case DubinsStateSpace::DubinsClass::A12:
+        case DubinsClass::A12:
         {
             if (s_13(d, alpha, beta) < 0.0)
             {
@@ -460,7 +480,7 @@ DubinsStateSpace::DubinsPath dubins_classification(const double d, const double 
             }
             break;
         }
-        case DubinsStateSpace::DubinsClass::A13:
+        case DubinsClass::A13:
         {
             if (s_13(d, alpha, beta) < 0.0)
             {
@@ -472,7 +492,7 @@ DubinsStateSpace::DubinsPath dubins_classification(const double d, const double 
             }
             break;
         }
-        case DubinsStateSpace::DubinsClass::A14:
+        case DubinsClass::A14:
         {
             if (s_14_1(d, alpha, beta) > 0.0)
             {
@@ -488,7 +508,7 @@ DubinsStateSpace::DubinsPath dubins_classification(const double d, const double 
             }
             break;
         }
-        case DubinsStateSpace::DubinsClass::A21:
+        case DubinsClass::A21:
         {
             if (s_31(d, alpha, beta) < 0.0)
             {
@@ -512,7 +532,7 @@ DubinsStateSpace::DubinsPath dubins_classification(const double d, const double 
             }
             break;
         }
-        case DubinsStateSpace::DubinsClass::A22:
+        case DubinsClass::A22:
         {
             if (alpha > beta)
             {
@@ -524,12 +544,12 @@ DubinsStateSpace::DubinsPath dubins_classification(const double d, const double 
             }
             break;
         }
-        case DubinsStateSpace::DubinsClass::A23:
+        case DubinsClass::A23:
         {
             path = dubinsRSR(d, alpha, beta);
             break;
         }
-        case DubinsStateSpace::DubinsClass::A24:
+        case DubinsClass::A24:
         {
             if (s_24(d, alpha, beta) < 0.0)
             {
@@ -541,7 +561,7 @@ DubinsStateSpace::DubinsPath dubins_classification(const double d, const double 
             }
             break;
         }
-        case DubinsStateSpace::DubinsClass::A31:
+        case DubinsClass::A31:
         {
             if (s_31(d, alpha, beta) < 0.0)
             {
@@ -553,12 +573,12 @@ DubinsStateSpace::DubinsPath dubins_classification(const double d, const double 
             }
             break;
         }
-        case DubinsStateSpace::DubinsClass::A32:
+        case DubinsClass::A32:
         {
             path = dubinsLSL(d, alpha, beta);
             break;
         }
-        case DubinsStateSpace::DubinsClass::A33:
+        case DubinsClass::A33:
         {
             if (alpha < beta)
             {
@@ -584,7 +604,7 @@ DubinsStateSpace::DubinsPath dubins_classification(const double d, const double 
             }
             break;
         }
-        case DubinsStateSpace::DubinsClass::A34:
+        case DubinsClass::A34:
         {
             if (s_24(d, alpha, beta) < 0.0)
             {
@@ -608,7 +628,7 @@ DubinsStateSpace::DubinsPath dubins_classification(const double d, const double 
             }
             break;
         }
-        case DubinsStateSpace::DubinsClass::A41:
+        case DubinsClass::A41:
         {
             if (s_41_1(d, alpha, beta) > 0.0)
             {
@@ -624,7 +644,7 @@ DubinsStateSpace::DubinsPath dubins_classification(const double d, const double 
             }
             break;
         }
-        case DubinsStateSpace::DubinsClass::A42:
+        case DubinsClass::A42:
         {
             if (s_42(d, alpha, beta) < 0.0)
             {
@@ -636,7 +656,7 @@ DubinsStateSpace::DubinsPath dubins_classification(const double d, const double 
             }
             break;
         }
-        case DubinsStateSpace::DubinsClass::A43:
+        case DubinsClass::A43:
         {
             if (s_42(d, alpha, beta) < 0.0)
             {
@@ -660,7 +680,7 @@ DubinsStateSpace::DubinsPath dubins_classification(const double d, const double 
             }
             break;
         }
-        case DubinsStateSpace::DubinsClass::A44:
+        case DubinsClass::A44:
         {
             path = dubinsLSR(d, alpha, beta);
             break;


### PR DESCRIPTION
**Problem Description**
Currently, the Dubins distance computation is done by going through all six path types exhaustively. This is quite inefficient for applications such as sampling-based planners, as the Dubins distance need to be computed many times repeatedly.

It has been proposed by Shkel(2001) that certain Dubins path types can be excluded by looking at the start and end configurations of the path. While the current OMPL implementation of DubinsStateSpace references the paper from Shkel(2001), the implementation goes through every Dubins path type exhaustively. This was discussed previously in an issue: https://github.com/ompl/ompl/issues/1014 with @zkingston and @mamoll 

**Proposed Solution**
The proposed solution is to implement the Dubins Set Classification theme in the `DubinsStateSpace`.

While trying to implement the Dubins Set Classification method, I ran into some issues where the Dubins Set Classification results were not correct for some cases.

I realized these were related to some issues with the original Dubins set classifications scheme proposed in Shkel(2001), and presented the corrections in the [Workshop on Energy Efficient Robotic Systems](https://aerial-robotics-workshop-icra2023.com/agenda/) at [ICRA 2023](https://www.icra2023.org/)
- Paper: [Paper](https://www.research-collection.ethz.ch/handle/20.500.11850/615185)

This work was done with @acfloria @nrjl @rikba

This PR adds an implementation of the DubinsSetClassification including the corrections regarding the long path case classification and the classification of Dubins Path types for equivalency group a_12, a_21, a_34, a_43

**Evaluation**
The following shows a comparison between the Dubins Set Classification and exhaustive Dubins calculations. (Ours being the Dubins set classification)
![image](https://github.com/ompl/ompl/assets/5248102/76092362-f66c-4dd6-b91a-5e1bb3e38e80)



The results show that the set classification takes 42% of the time compared to exhaustive Dubins calculations, while always returning the same answer with the exhaustive Dubins path calculations