### PR TITLE
Allow allocating custom state sampler in rejection sampler

### DIFF
--- a/src/ompl/base/samplers/informed/src/RejectionInfSampler.cpp
+++ b/src/ompl/base/samplers/informed/src/RejectionInfSampler.cpp
@@ -46,7 +46,7 @@ namespace ompl
           : InformedSampler(probDefn, maxNumberCalls)
         {
             // Create the basic sampler
-            baseSampler_ = InformedSampler::space_->allocDefaultStateSampler();
+            baseSampler_ = InformedSampler::space_->allocStateSampler();
 
             // Warn if a cost-to-go heuristic is not defined
             if (!InformedSampler::opt_->hasCostToGoHeuristic())


### PR DESCRIPTION
The rejection sampler currently uses the default state sampler of the state space as base sampler even if the user provided the space with a custom sampler via `StateSpace::setStateSamplerAllocator`. I think it would be more intuitive for the rejection sampler to only fall back to the default state sampler if the user didn't provide a custom one. This would also make it easier to get BIT* et al. to use a custom (uninformed) sampler. Does anyone have any concerns with the proposed change? @gammell?