### PR TITLE
Fixing missing parens on trajectory output and error from --bias flag in constrained motion planning demos.

### DIFF
--- a/demos/constraint/ConstrainedPlanningCommon.py
+++ b/demos/constraint/ConstrainedPlanningCommon.py
@@ -173,8 +173,8 @@ class ConstrainedProblem(object):
             self.css.setAlpha(options.alpha)
             self.css.setMaxChartsPerExtension(options.charts)
             if options.bias:
-                self.css.setBiasFunction(lambda c, atlas=self.css:
-                                         atlas.getChartCount() - c.getNeighborCount() + 1.)
+                self.css.setBiasFunction(ob.AtlasChartBiasFunction(lambda c, atlas=self.css:
+                                         atlas.getChartCount() - c.getNeighborCount() + 1.))
             if spaceType == "AT":
                 self.css.setSeparated(not options.no_separate)
             self.css.setup()
@@ -250,7 +250,7 @@ class ConstrainedProblem(object):
             if output:
                 ou.OMPL_INFORM("Dumping path to `%s_path.txt`." % name)
                 with open('%s_path.txt' % name, 'w') as pathfile:
-                    print(path.printAsMatrix, file=pathfile)
+                    print(path.printAsMatrix(), file=pathfile)
 
                 ou.OMPL_INFORM(
                     "Dumping simplified path to `%s_simplepath.txt`." % name)


### PR DESCRIPTION
I was experimenting with the demos and fixed a couple of small issues:

(1) Non-simplified path output `.txt` file was the default `str()` signature for the `printAsMatrix` function. Fixed by adding parens.


(2) The following error occurs when running `python demos/constraint/ConstrainedPlanningSphere.py --space AT --bias`:

```
Traceback (most recent call last):
  File "demos/constraint/ConstrainedPlanningSphere.py", line 160, in <module>
    spherePlanning(parser.parse_args())
  File "demos/constraint/ConstrainedPlanningSphere.py", line 127, in spherePlanning
    cp = ConstrainedProblem(options.space, rvss, constraint, options)
  File "/home/seiji/Research/bimanual-ggcs-analytic-ik/ompl/demos/constraint/ConstrainedPlanningCommon.py", line 176, in __init__
    self.css.setBiasFunction(lambda c, atlas=self.css:
Boost.Python.ArgumentError: Python argument types in
    AtlasStateSpace.setBiasFunction(AtlasStateSpace, function)
did not match C++ signature:
    setBiasFunction(ompl::base::AtlasStateSpace {lvalue}, std::function<double (ompl::base::AtlasChart*)> biasFunction)
```

The error was fixed by casting the passed lambda using `ob.AtlasChartBiasFunction`.