### PR TITLE
Python bindings for ARM and M1 Mac

### DIFF
--- a/CMakeModules/Findcastxml.cmake
+++ b/CMakeModules/Findcastxml.cmake
@@ -20,11 +20,11 @@ if (CASTXML)
     endif()
 
     # workaround for problem between Xcode and castxml on Mojave
-    if (APPLE AND CMAKE_CXX_COMPILER MATCHES "/Applications/Xcode.app/Contents/Developer/Toolchains/.*")
-        set(CASTXMLCOMPILER_PATH "/usr/bin/clang++")
-    else()
-        set(CASTXMLCOMPILER_PATH "${CMAKE_CXX_COMPILER}")
-    endif()
+    # if (APPLE AND CMAKE_CXX_COMPILER MATCHES "/Applications/Xcode.app/Contents/Developer/Toolchains/.*")
+    #     set(CASTXMLCOMPILER_PATH "/usr/bin/clang++")
+    # else()
+    set(CASTXMLCOMPILER_PATH "${CMAKE_CXX_COMPILER}")
+        # endif()
 
     set(CASTXMLCONFIG "[xml_generator]
 xml_generator=castxml
@@ -53,6 +53,20 @@ compiler_path=${CASTXMLCOMPILER_PATH}
             "${_path}/lib/gcc/mingw32/${_version}/include/c++"
             "${_path}/lib/gcc/mingw32/${_version}/include/c++/mingw32")
     endif()
+
+    if("${CMAKE_SYSTEM_PROCESSOR}" STREQUAL "aarch64" OR "${CMAKE_SYSTEM_PROCESSOR}" STREQUAL "arm64")
+      # Some shell magic to extract out the default includes that are NOT included in castxml by default.
+      # Note there may be some issue with the `cut` if a path has spaces, hopefully not since these are system includes
+      execute_process(COMMAND bash "-c" "${CASTXMLCOMPILER} -E -x c++ - -v < /dev/null 2>&1 | awk '/#include <...> search starts here:/{flag=1;next}/End of search list./{flag=0}flag' - | cut -f 2 -d' ' - | paste -sd\; -"
+        OUTPUT_VARIABLE _system_include_paths OUTPUT_STRIP_TRAILING_WHITESPACE)
+
+      # Append those default includes
+      list(APPEND _candidate_include_path ${_system_include_paths})
+
+      # Some issues with ARM Neon intrinsics breaking in the castxml parse step, ignore in this part
+      set(CASTXMLCFLAGS "${CASTXMLCFLAGS} -DEIGEN_DONT_VECTORIZE")
+    endif()
+
     list(REMOVE_DUPLICATES _candidate_include_path)
     set(CASTXMLINCLUDEPATH ".")
     foreach(dir ${_candidate_include_path})

--- a/py-bindings/ompl_py_tools.h
+++ b/py-bindings/ompl_py_tools.h
@@ -37,6 +37,14 @@
 #ifndef PY_BINDINGS_OMPL_PY_TOOLS_
 #define PY_BINDINGS_OMPL_PY_TOOLS_
 
+#include <boost/graph/adjacency_list.hpp>
 #include "py_std_function.hpp"
+
+namespace ompl
+{
+    namespace tools
+    {
+    }
+}
 
 #endif


### PR DESCRIPTION
WIP PR for Python bindings on arm64/aarch64 platforms, primarily addressing issues M1 Mac users have had with compiling the Python bindings. I have gotten the bindings to generate and compile on an M1 Mac Mini with some changes to:
- CastXML invocation, to include the default system includes that are missing. This uses the default CastXML available from homebrew.
- Remove Eigen vectorization in the binding generation (not during the actual compilation) to deal with some issues with Neon intrinsics.
- Variety of changes to the bindings to handle platform differences with strings and declarations.
- A mysterious load-bearing include in `ompl_py_tools.h` that otherwise results in a compilation error in CastXML with including `boost/python.hpp` - there probably is some include order shenanigans going on, but I didn't want to spend time to figure out the precise file necessary to fix.

Marking this PR as WIP until I have confirmation of it working on other setups and machines.