### PR TITLE
Fix yaml-cpp target to be compatible with CMake <3.18

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.5)
+cmake_minimum_required(VERSION 3.11)
 project(ompl VERSION 1.6.0 LANGUAGES CXX)
 set(OMPL_ABI_VERSION 17)
 

--- a/demos/CMakeLists.txt
+++ b/demos/CMakeLists.txt
@@ -64,6 +64,12 @@ if (OMPL_BUILD_DEMOS)
         # https://github.com/jbeder/yaml-cpp/issues/1025
         # https://github.com/jbeder/yaml-cpp/pull/1196
         if(NOT TARGET yaml-cpp::yaml-cpp AND TARGET yaml-cpp)
+            # Aliasing local imported targets is only supported in CMake >=3.18.
+            # Promoting yaml-cpp to the global scope here prevents errors on
+            # older CMake versions.
+            # (see: https://cmake.org/cmake/help/latest/command/add_library.html#alias-libraries)
+            set_target_properties(yaml-cpp PROPERTIES IMPORTED_GLOBAL TRUE)
+
             add_library(yaml-cpp::yaml-cpp ALIAS yaml-cpp)
         endif()
 

--- a/tests/cmake_export/CMakeLists.txt
+++ b/tests/cmake_export/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.5)
+cmake_minimum_required(VERSION 3.11)
 project(ompl_cmake_export LANGUAGES CXX)
 
 find_package(ompl REQUIRED)


### PR DESCRIPTION
Modifies the yaml-cpp CMake target to be IMPORTED_GLOBAL, which is required in order to define it as an ALIAS in CMake <3.18. However, setting this property requires CMake >=3.11 so the minimum version is bumped.

Test it yourself under an Ubuntu 20.04 container. `main` currently fails with the error described in https://github.com/ompl/ompl/issues/1105. This branch successfully compiles. Seems to have no adverse effects on 22.04.

```
docker run --mount type=bind,source="$(pwd)",target=/ompl --rm -it ubuntu:20.04

export DEBIAN_FRONTEND=noninteractive

apt-get update
apt-get -y install g++ cmake pkg-config libboost-serialization-dev libboost-filesystem-dev libboost-system-dev libboost-program-options-dev libboost-test-dev libeigen3-dev libode-dev wget libyaml-cpp-dev
mkdir -p /ompl/build/Release && cd /ompl/build/Release/
cmake ../.. && cmake --build .
```