### PR TITLE
Fix for ompl::geometric Python bindings

### DIFF
--- a/py-bindings/generate_bindings.py
+++ b/py-bindings/generate_bindings.py
@@ -40,6 +40,7 @@ from os.path import join, dirname
 from sys import argv, setrecursionlimit
 from pygccxml import declarations
 from pygccxml.declarations.runtime_errors import declaration_not_found_t
+import pygccxml.declarations as pd
 from pyplusplus.module_builder import call_policies
 from pyplusplus import function_transformers as FT
 from ompl.bindings_generator import code_generator_t, default_replacement
@@ -693,12 +694,19 @@ class ompl_geometric_generator_t(code_generator_t):
         self.ompl_ns.namespace('geometric').class_('SimpleSetup').add_registration_code( \
             'def("getPlannerAllocator", &ompl::geometric::SimpleSetup::getPlannerAllocator, ' \
             'bp::return_value_policy< bp::copy_const_reference >())')
+        self.std_ns.class_('vector<const ompl::base::State *>').exclude()
+        self.std_ns.class_('vector< std::shared_ptr<ompl::base::SpaceInformation> >').rename('vectorSpaceInformation')
+
+
         self.std_ns.class_('vector< std::shared_ptr<ompl::geometric::BITstar::Vertex> >').exclude()
         self.std_ns.class_('vector< std::shared_ptr<ompl::geometric::aitstar::Vertex> >').exclude()
         self.std_ns.class_('vector< std::shared_ptr<ompl::geometric::eitstar::Vertex> >').exclude()
-        self.std_ns.class_('vector<const ompl::base::State *>').exclude()
+        self.std_ns.class_('vector< std::shared_ptr<ompl::geometric::eitstar::State> >').exclude()
 
-        self.std_ns.class_('vector< std::shared_ptr<ompl::base::SpaceInformation> >').rename('vectorSpaceInformation')
+        self.std_ns.class_('vector< std::shared_ptr<ompl::geometric::BITstar::Vertex> >').rename("vectorBITstarVertex")
+        self.std_ns.class_('vector< std::shared_ptr<ompl::geometric::aitstar::Vertex> >').rename("vectorAITstarVertex")
+        self.std_ns.class_('vector< std::shared_ptr<ompl::geometric::eitstar::Vertex> >').rename("vectorEITstarVertex")
+        self.std_ns.class_('vector< std::shared_ptr<ompl::geometric::eitstar::State> >').rename("vectorEITstarState")
 
         # Using nullptr as a default value in method arguments causes
         # problems with Boost.Python.
@@ -731,6 +739,20 @@ class ompl_geometric_generator_t(code_generator_t):
             planner.add_registration_code("""
             def("checkValidity",&::ompl::base::Planner::checkValidity,
                 &%s::default_checkValidity )""" % planner.wrapper_alias)
+
+            # There is also some issues with Motions, States, and other internal planner data
+            # structures being leaked into the main namespace
+            try:
+                mc = planner.class_("Motion")
+                mc.rename(f"{planner.name}Motion")
+                mc.exclude()
+                vc = self.std_ns.class_(f'vector< ompl::geometric::{planner.name}::Motion * >')
+                vc.rename(f"vector{planner.name}Motion")
+                vc.exclude()
+
+                planner.class_('BiDirMotion').exclude()
+            except:
+                pass
 
         # The OMPL implementation of PRM uses two threads: one for constructing
         # the roadmap and another for checking for a solution. This causes
@@ -825,6 +847,7 @@ class ompl_geometric_generator_t(code_generator_t):
             self.ompl_ns.class_('KStrategy<unsigned long>').rename('KStrategy')
             self.ompl_ns.class_('KStarStrategy<unsigned long>').rename('KStarStrategy')
             self.ompl_ns.class_('KBoundedStrategy<unsigned long>').rename('KBoundedStrategy')
+
         except declaration_not_found_t:
             self.ompl_ns.class_('NearestNeighbors<unsigned int>').include()
             self.ompl_ns.class_('NearestNeighbors<unsigned int>').rename('NearestNeighbors')

--- a/py-bindings/generate_bindings.py
+++ b/py-bindings/generate_bindings.py
@@ -703,10 +703,15 @@ class ompl_geometric_generator_t(code_generator_t):
         self.std_ns.class_('vector< std::shared_ptr<ompl::geometric::eitstar::Vertex> >').exclude()
         self.std_ns.class_('vector< std::shared_ptr<ompl::geometric::eitstar::State> >').exclude()
 
-        self.std_ns.class_('vector< std::shared_ptr<ompl::geometric::BITstar::Vertex> >').rename("vectorBITstarVertex")
-        self.std_ns.class_('vector< std::shared_ptr<ompl::geometric::aitstar::Vertex> >').rename("vectorAITstarVertex")
-        self.std_ns.class_('vector< std::shared_ptr<ompl::geometric::eitstar::Vertex> >').rename("vectorEITstarVertex")
-        self.std_ns.class_('vector< std::shared_ptr<ompl::geometric::eitstar::State> >').rename("vectorEITstarState")
+        try:
+            self.ompl_ns.class_(f'NearestNeighbors<std::shared_ptr<ompl::geometric::aitstar::Vertex>>').exclude()
+        except:
+            pass
+
+        try:
+            self.ompl_ns.class_(f'NearestNeighbors<std::shared_ptr<ompl::geometric::eitstar::State>>').exclude()
+        except:
+            pass
 
         # Using nullptr as a default value in method arguments causes
         # problems with Boost.Python.
@@ -744,15 +749,30 @@ class ompl_geometric_generator_t(code_generator_t):
             # structures being leaked into the main namespace
             try:
                 mc = planner.class_("Motion")
-                mc.rename(f"{planner.name}Motion")
                 mc.exclude()
-                vc = self.std_ns.class_(f'vector< ompl::geometric::{planner.name}::Motion * >')
-                vc.rename(f"vector{planner.name}Motion")
-                vc.exclude()
+
+                try:
+                    vc = self.std_ns.class_(f'vector< ompl::geometric::{planner.name}::Motion * >')
+                    vc.exclude()
+                except:
+                    pass
+
+                try:
+                    nn = self.ompl_ns.class_(f'NearestNeighbors<ompl::geometric::{planner.name}::Motion *>')
+                    nn.exclude()
+                except:
+                    pass
 
                 planner.class_('BiDirMotion').exclude()
             except:
                 pass
+
+
+        try:
+            nn = self.ompl_ns.class_(f'NearestNeighbors<void *>')
+            nn.exclude()
+        except:
+            pass
 
         # The OMPL implementation of PRM uses two threads: one for constructing
         # the roadmap and another for checking for a solution. This causes


### PR DESCRIPTION
On some platforms, internal classes such as `Motion`, etc. are leaked into global namespaces due to their use in vectors, NNs, etc. - this pull filters these declarations out.