### PR TITLE
PyPI upload for OMPL wheels

### DIFF
--- a/.github/workflows/wheels.yaml
+++ b/.github/workflows/wheels.yaml
@@ -33,6 +33,21 @@ jobs:
           name: wheels
           path: wheelhouse
 
+  upload_all:
+    needs: [build_wheels]
+    environment: pypi
+    permissions:
+      id-token: write
+    runs-on: ubuntu-latest
+    if: github.event_name == 'release' && github.event.action == 'published'
+    steps:
+    - uses: actions/download-artifact@v3
+      with:
+        name: artifact
+        path: dist
+
+    - uses: pypa/gh-action-pypi-publish@release/v1
+
   prerelease:
     if: github.ref == 'refs/heads/main'
     runs-on: ubuntu-latest


### PR DESCRIPTION
Thanks to @kylc's work in #1103, we now have consistently building OMPL Python wheels. The next step for `pip`-installable OMPL, I think, is to get these wheels automatically deploying to PyPI.

This PR adapts the basic upload action example from the `cibuildwheel` docs for this purpose. It seems pretty straightforward, but I'm not very experienced with GH Actions, so we should verify that I've not missed anything.

There are two (that I know of) outlying tasks:
- [ ] We need to set up an OMPL project on PyPI following: https://docs.pypi.org/trusted-publishers/creating-a-project-through-oidc/
- [ ] We need to resolve #1121, or at least add a warning that this package is known to conflict with system-level OMPL installations

Then, we should be able to cut a new release, and see the wheels upload.
