### PR TITLE
Fix termination before planner termination condition is met.

### DIFF
--- a/src/ompl/multilevel/datastructures/BundleSpaceSequenceImpl.h
+++ b/src/ompl/multilevel/datastructures/BundleSpaceSequenceImpl.h
@@ -190,10 +190,10 @@ ompl::multilevel::BundleSpaceSequence<T>::solve(const ompl::base::PlannerTermina
         if (priorityQueue_.size() <= currentBundleSpaceLevel_)
             priorityQueue_.push(kBundle);
 
-        ompl::base::PlannerTerminationCondition ptcOrSolutionFound(
-            [this, &ptc] { return ptc || foundKLevelSolution_; });
+        ompl::base::PlannerTerminationCondition ptcAndSolutionFound(
+            [this, &ptc] { return ptc && foundKLevelSolution_; });
 
-        while (!ptcOrSolutionFound())
+        while (!ptcAndSolutionFound())
         {
             BundleSpace *jBundle = priorityQueue_.top();
             priorityQueue_.pop();

--- a/src/ompl/multilevel/datastructures/BundleSpaceSequenceImpl.h
+++ b/src/ompl/multilevel/datastructures/BundleSpaceSequenceImpl.h
@@ -190,10 +190,10 @@ ompl::multilevel::BundleSpaceSequence<T>::solve(const ompl::base::PlannerTermina
         if (priorityQueue_.size() <= currentBundleSpaceLevel_)
             priorityQueue_.push(kBundle);
 
-        ompl::base::PlannerTerminationCondition ptcAndSolutionFound(
-            [this, &ptc] { return ptc && foundKLevelSolution_; });
+        ompl::base::PlannerTerminationCondition ptcOrSolutionFound(
+            [this, &ptc, k] { return ptc || (foundKLevelSolution_ && k < bundleSpaces_.size() - 1); });
 
-        while (!ptcAndSolutionFound())
+        while (!ptcOrSolutionFound())
         {
             BundleSpace *jBundle = priorityQueue_.top();
             priorityQueue_.pop();


### PR DESCRIPTION
The current implementation of the multilevel planner's solve function terminates as soon as a valid path is found, rendering the user-defined termination parameter ineffective in many scenarios. For instance, when attempting to optimize a solution for a specific duration using the timedPlannerTerminationCondition, the planner terminates prematurely upon finding an initial solution.

To address this issue, the proposed pull request introduces a modification to the termination condition logic. The existing implementation uses an 'or' condition, causing the planner to terminate if either a valid path is found or the user-defined termination parameter is satisfied. The proposed fix adjusts this logic to use an 'and' condition, ensuring that the planner will only terminate when both conditions are met.