### PR TITLE
fix default value for goal bias fraction in EST planner

### DIFF
--- a/src/ompl/geometric/planners/est/EST.h
+++ b/src/ompl/geometric/planners/est/EST.h
@@ -165,7 +165,7 @@ namespace ompl
 
             /// \brief The fraction of time the goal is picked as the state to expand towards (if such a state is
             /// available)
-            double goalBias_{0.5};
+            double goalBias_{0.05};
 
             /// \brief The maximum length of a motion to be added to a tree
             double maxDistance_{0.};


### PR DESCRIPTION
Fix a bug I introduced 7 years ago (!).