### PR TITLE
More relevant return code

### DIFF
--- a/src/ompl/control/planners/kpiece/src/KPIECE1.cpp
+++ b/src/ompl/control/planners/kpiece/src/KPIECE1.cpp
@@ -214,7 +214,7 @@ ompl::base::PlannerStatus ompl::control::KPIECE1::solve(const base::PlannerTermi
     // samples that were found to be the best, so far
     CloseSamples closeSamples(nCloseSamples_);
 
-    while (ptc == false)
+    while (!ptc)
     {
         tree_.iteration++;
 

--- a/src/ompl/control/planners/pdst/src/PDST.cpp
+++ b/src/ompl/control/planners/pdst/src/PDST.cpp
@@ -60,6 +60,18 @@ ompl::base::PlannerStatus ompl::control::PDST::solve(const base::PlannerTerminat
     base::Goal *goal = pdef_->getGoal().get();
     goalSampler_ = dynamic_cast<ompl::base::GoalSampleableRegion *>(goal);
 
+    if (goalSampler_ == nullptr)
+    {
+        OMPL_ERROR("%s: Unknown type of goal", getName().c_str());
+        return base::PlannerStatus::UNRECOGNIZED_GOAL_TYPE;
+    }
+
+    if (!goalSampler_->couldSample())
+    {
+        OMPL_ERROR("%s: Insufficient states in sampleable goal region", getName().c_str());
+        return base::PlannerStatus::INVALID_GOAL;
+    }
+
     // Ensure that we have a state sampler AND a control sampler
     if (!sampler_)
         sampler_ = si_->allocStateSampler();

--- a/src/ompl/control/planners/rrt/src/RRT.cpp
+++ b/src/ompl/control/planners/rrt/src/RRT.cpp
@@ -138,7 +138,7 @@ ompl::base::PlannerStatus ompl::control::RRT::solve(const base::PlannerTerminati
     Control *rctrl = rmotion->control;
     base::State *xstate = si_->allocState();
 
-    while (ptc == false)
+    while (!ptc)
     {
         /* sample random state (with goal biasing) */
         if (rng_.uniform01() < goalBias_ && goal_s->canSample())

--- a/src/ompl/control/planners/rrt/src/RRT.cpp
+++ b/src/ompl/control/planners/rrt/src/RRT.cpp
@@ -96,6 +96,12 @@ ompl::base::PlannerStatus ompl::control::RRT::solve(const base::PlannerTerminati
     base::Goal *goal = pdef_->getGoal().get();
     auto *goal_s = dynamic_cast<base::GoalSampleableRegion *>(goal);
 
+    if (goal_s == nullptr)
+    {
+        OMPL_ERROR("%s: Unknown type of goal", getName().c_str());
+        return base::PlannerStatus::UNRECOGNIZED_GOAL_TYPE;
+    }
+
     while (const base::State *st = pis_.nextStart())
     {
         auto *motion = new Motion(siC_);
@@ -108,6 +114,12 @@ ompl::base::PlannerStatus ompl::control::RRT::solve(const base::PlannerTerminati
     {
         OMPL_ERROR("%s: There are no valid initial states!", getName().c_str());
         return base::PlannerStatus::INVALID_START;
+    }
+
+    if (!goal_s->couldSample())
+    {
+        OMPL_ERROR("%s: Insufficient states in sampleable goal region", getName().c_str());
+        return base::PlannerStatus::INVALID_GOAL;
     }
 
     if (!sampler_)
@@ -129,7 +141,7 @@ ompl::base::PlannerStatus ompl::control::RRT::solve(const base::PlannerTerminati
     while (ptc == false)
     {
         /* sample random state (with goal biasing) */
-        if (goal_s && rng_.uniform01() < goalBias_ && goal_s->canSample())
+        if (rng_.uniform01() < goalBias_ && goal_s->canSample())
             goal_s->sampleGoal(rstate);
         else
             sampler_->sampleUniform(rstate);

--- a/src/ompl/geometric/planners/AnytimePathShortening.cpp
+++ b/src/ompl/geometric/planners/AnytimePathShortening.cpp
@@ -210,7 +210,12 @@ ompl::geometric::AnytimePathShortening::solve(const ompl::base::PlannerTerminati
         thread.join();
 
     msg::setLogLevel(currentLogLevel);
-    return pdef_->getSolutionCount() > 0 ? base::PlannerStatus::EXACT_SOLUTION : base::PlannerStatus::UNKNOWN;
+    base::PlannerStatus::StatusType status = base::PlannerStatus::UNKNOWN;
+    if (invalidStartStateCount_ > 0)
+        status = base::PlannerStatus::INVALID_START;
+    else if (invalidGoalCount_ > 0)
+        status = base::PlannerStatus::INVALID_GOAL;
+    return (pdef_->getSolutionCount() > 0) ? base::PlannerStatus::EXACT_SOLUTION : status;
 }
 
 void ompl::geometric::AnytimePathShortening::threadSolve(base::Planner *planner,
@@ -237,6 +242,17 @@ void ompl::geometric::AnytimePathShortening::threadSolve(base::Planner *planner,
                 || (status == base::PlannerStatus::UNRECOGNIZED_GOAL_TYPE))
         {
             // there is not point in trying again with these error types that will repeat.
+            {
+                std::lock_guard<std::mutex> _(invalidStartOrGoalLock_);
+                if (status == base::PlannerStatus::INVALID_START)
+                {
+                    ++invalidStartStateCount_;
+                }
+                else if (status == base::PlannerStatus::INVALID_GOAL)
+                {
+                    ++invalidGoalCount_;
+                }
+            }
             planner->clear();
             pdef->clearSolutionPaths();
             break;
@@ -253,6 +269,8 @@ void ompl::geometric::AnytimePathShortening::clear()
     for (auto &planner : planners_)
         planner->clear();
     bestCost_ = base::Cost(std::numeric_limits<double>::quiet_NaN());
+    invalidStartStateCount_ = 0;
+    invalidGoalCount_ = 0;
 }
 
 void ompl::geometric::AnytimePathShortening::getPlannerData(ompl::base::PlannerData &data) const

--- a/src/ompl/geometric/planners/AnytimePathShortening.h
+++ b/src/ompl/geometric/planners/AnytimePathShortening.h
@@ -215,6 +215,15 @@ namespace ompl
             /// \brief The list of planners used for solving the problem.
             std::vector<base::PlannerPtr> planners_;
 
+            /// \brief The number of times (1 per planner) INVALID_START_STATE is returned by a planner.
+            unsigned int invalidStartStateCount_{0};
+
+            /// \brief The number of times (1 per planner) INVALID_GOAL is returned by a planner.
+            unsigned int invalidGoalCount_{0};
+
+            /// \brief Mutex for `invalidStartStateCount_`, `invalidGoalCount_`.
+            std::mutex invalidStartOrGoalLock_;
+
             /// \brief Flag indicating whether to shortcut paths
             bool shortcut_{true};
 

--- a/src/ompl/geometric/planners/est/src/BiEST.cpp
+++ b/src/ompl/geometric/planners/est/src/BiEST.cpp
@@ -160,6 +160,7 @@ ompl::base::PlannerStatus ompl::geometric::BiEST::solve(const base::PlannerTermi
 
     bool startTree = true;
     bool solved = false;
+    base::PlannerStatus::StatusType status = base::PlannerStatus::TIMEOUT;
 
     while (!ptc && !solved)
     {
@@ -180,6 +181,7 @@ ompl::base::PlannerStatus ompl::geometric::BiEST::solve(const base::PlannerTermi
             if (goalMotions_.empty())
             {
                 OMPL_ERROR("%s: Unable to sample any valid states for goal tree", getName().c_str());
+                status = base::PlannerStatus::INVALID_GOAL;
                 break;
             }
         }
@@ -273,7 +275,7 @@ ompl::base::PlannerStatus ompl::geometric::BiEST::solve(const base::PlannerTermi
 
     OMPL_INFORM("%s: Created %u states (%u start + %u goal)", getName().c_str(),
                 startMotions_.size() + goalMotions_.size(), startMotions_.size(), goalMotions_.size());
-    return solved ? base::PlannerStatus::EXACT_SOLUTION : base::PlannerStatus::TIMEOUT;
+    return solved ? base::PlannerStatus::EXACT_SOLUTION : status;
 }
 
 void ompl::geometric::BiEST::addMotion(Motion *motion, std::vector<Motion *> &motions, PDF<Motion *> &pdf,

--- a/src/ompl/geometric/planners/est/src/EST.cpp
+++ b/src/ompl/geometric/planners/est/src/EST.cpp
@@ -101,6 +101,18 @@ ompl::base::PlannerStatus ompl::geometric::EST::solve(const base::PlannerTermina
     base::Goal *goal = pdef_->getGoal().get();
     auto *goal_s = dynamic_cast<base::GoalSampleableRegion *>(goal);
 
+    if (goal_s == nullptr)
+    {
+        OMPL_ERROR("%s: Unknown type of goal", getName().c_str());
+        return base::PlannerStatus::UNRECOGNIZED_GOAL_TYPE;
+    }
+
+    if (!goal_s->couldSample())
+    {
+        OMPL_ERROR("%s: Insufficient states in sampleable goal region", getName().c_str());
+        return base::PlannerStatus::INVALID_GOAL;
+    }
+
     std::vector<Motion *> neighbors;
 
     while (const base::State *st = pis_.nextStart())
@@ -136,7 +148,7 @@ ompl::base::PlannerStatus ompl::geometric::EST::solve(const base::PlannerTermina
         assert(existing);
 
         // Sample random state in the neighborhood (with goal biasing)
-        if ((goal_s != nullptr) && rng_.uniform01() < goalBias_ && goal_s->canSample())
+        if (rng_.uniform01() < goalBias_ && goal_s->canSample())
         {
             goal_s->sampleGoal(xstate);
 

--- a/src/ompl/geometric/planners/est/src/ProjEST.cpp
+++ b/src/ompl/geometric/planners/est/src/ProjEST.cpp
@@ -94,6 +94,18 @@ ompl::base::PlannerStatus ompl::geometric::ProjEST::solve(const base::PlannerTer
     base::Goal *goal = pdef_->getGoal().get();
     auto *goal_s = dynamic_cast<base::GoalSampleableRegion *>(goal);
 
+    if (goal_s == nullptr)
+    {
+        OMPL_ERROR("%s: Unknown type of goal", getName().c_str());
+        return base::PlannerStatus::UNRECOGNIZED_GOAL_TYPE;
+    }
+
+    if (!goal_s->couldSample())
+    {
+        OMPL_ERROR("%s: Insufficient states in sampleable goal region", getName().c_str());
+        return base::PlannerStatus::INVALID_GOAL;
+    }
+
     while (const base::State *st = pis_.nextStart())
     {
         auto *motion = new Motion(si_);
@@ -124,7 +136,7 @@ ompl::base::PlannerStatus ompl::geometric::ProjEST::solve(const base::PlannerTer
         assert(existing);
 
         /* sample random state (with goal biasing) */
-        if ((goal_s != nullptr) && rng_.uniform01() < goalBias_ && goal_s->canSample())
+        if (rng_.uniform01() < goalBias_ && goal_s->canSample())
             goal_s->sampleGoal(xstate);
         else if (!sampler_->sampleNear(xstate, existing->state, maxDistance_))
             continue;

--- a/src/ompl/geometric/planners/fmt/src/FMT.cpp
+++ b/src/ompl/geometric/planners/fmt/src/FMT.cpp
@@ -298,6 +298,12 @@ ompl::base::PlannerStatus ompl::geometric::FMT::solve(const base::PlannerTermina
         return base::PlannerStatus::UNRECOGNIZED_GOAL_TYPE;
     }
 
+    if (!goal->couldSample())
+    {
+        OMPL_ERROR("%s: Insufficient states in sampleable goal region", getName().c_str());
+        return base::PlannerStatus::INVALID_GOAL;
+    }
+
     // Add start states to V (nn_) and Open
     while (const base::State *st = pis_.nextStart())
     {

--- a/src/ompl/geometric/planners/kpiece/src/BKPIECE1.cpp
+++ b/src/ompl/geometric/planners/kpiece/src/BKPIECE1.cpp
@@ -117,6 +117,7 @@ ompl::base::PlannerStatus ompl::geometric::BKPIECE1::solve(const base::PlannerTe
     base::State *xstate = si_->allocState();
     bool startTree = true;
     bool solved = false;
+    base::PlannerStatus::StatusType status = base::PlannerStatus::TIMEOUT;
 
     while (!ptc)
     {
@@ -140,6 +141,7 @@ ompl::base::PlannerStatus ompl::geometric::BKPIECE1::solve(const base::PlannerTe
             if (dGoal_.getMotionCount() == 0)
             {
                 OMPL_ERROR("%s: Unable to sample any valid states for goal tree", getName().c_str());
+                status = base::PlannerStatus::INVALID_GOAL;
                 break;
             }
         }
@@ -229,7 +231,7 @@ ompl::base::PlannerStatus ompl::geometric::BKPIECE1::solve(const base::PlannerTe
                 dGoal_.getMotionCount(), dStart_.getCellCount() + dGoal_.getCellCount(), dStart_.getCellCount(),
                 dStart_.getGrid().countExternal(), dGoal_.getCellCount(), dGoal_.getGrid().countExternal());
 
-    return solved ? base::PlannerStatus::EXACT_SOLUTION : base::PlannerStatus::TIMEOUT;
+    return solved ? base::PlannerStatus::EXACT_SOLUTION : status;
 }
 
 void ompl::geometric::BKPIECE1::freeMotion(Motion *motion)

--- a/src/ompl/geometric/planners/kpiece/src/KPIECE1.cpp
+++ b/src/ompl/geometric/planners/kpiece/src/KPIECE1.cpp
@@ -94,6 +94,12 @@ ompl::base::PlannerStatus ompl::geometric::KPIECE1::solve(const base::PlannerTer
     base::Goal *goal = pdef_->getGoal().get();
     auto *goal_s = dynamic_cast<base::GoalSampleableRegion *>(goal);
 
+    if (goal_s == nullptr)
+    {
+        OMPL_ERROR("%s: Unknown type of goal", getName().c_str());
+        return base::PlannerStatus::UNRECOGNIZED_GOAL_TYPE;
+    }
+
     Discretization<Motion>::Coord xcoord(projectionEvaluator_->getDimension());
 
     while (const base::State *st = pis_.nextStart())
@@ -132,7 +138,7 @@ ompl::base::PlannerStatus ompl::geometric::KPIECE1::solve(const base::PlannerTer
         assert(existing);
 
         /* sample random state (with goal biasing) */
-        if ((goal_s != nullptr) && rng_.uniform01() < goalBias_ && goal_s->canSample())
+        if (rng_.uniform01() < goalBias_ && goal_s->canSample())
             goal_s->sampleGoal(xstate);
         else
             sampler_->sampleUniformNear(xstate, existing->state, maxDistance_);

--- a/src/ompl/geometric/planners/kpiece/src/LBKPIECE1.cpp
+++ b/src/ompl/geometric/planners/kpiece/src/LBKPIECE1.cpp
@@ -113,6 +113,7 @@ ompl::base::PlannerStatus ompl::geometric::LBKPIECE1::solve(const base::PlannerT
     base::State *xstate = si_->allocState();
     bool startTree = true;
     bool solved = false;
+    base::PlannerStatus::StatusType status = base::PlannerStatus::TIMEOUT;
 
     while (!ptc)
     {
@@ -137,6 +138,7 @@ ompl::base::PlannerStatus ompl::geometric::LBKPIECE1::solve(const base::PlannerT
             if (dGoal_.getMotionCount() == 0)
             {
                 OMPL_ERROR("%s: Unable to sample any valid states for goal tree", getName().c_str());
+                status = base::PlannerStatus::INVALID_GOAL;
                 break;
             }
         }
@@ -222,7 +224,7 @@ ompl::base::PlannerStatus ompl::geometric::LBKPIECE1::solve(const base::PlannerT
                 dGoal_.getMotionCount(), dStart_.getCellCount() + dGoal_.getCellCount(), dStart_.getCellCount(),
                 dStart_.getGrid().countExternal(), dGoal_.getCellCount(), dGoal_.getGrid().countExternal());
 
-    return solved ? base::PlannerStatus::EXACT_SOLUTION : base::PlannerStatus::TIMEOUT;
+    return solved ? base::PlannerStatus::EXACT_SOLUTION : status;
 }
 
 bool ompl::geometric::LBKPIECE1::isPathValid(Discretization<Motion> &disc, Motion *motion, base::State *temp)

--- a/src/ompl/geometric/planners/pdst/src/PDST.cpp
+++ b/src/ompl/geometric/planners/pdst/src/PDST.cpp
@@ -64,6 +64,18 @@ ompl::base::PlannerStatus ompl::geometric::PDST::solve(const base::PlannerTermin
     base::Goal *goal = pdef_->getGoal().get();
     goalSampler_ = dynamic_cast<ompl::base::GoalSampleableRegion *>(goal);
 
+    if (goalSampler_ == nullptr)
+    {
+        OMPL_ERROR("%s: Unknown type of goal", getName().c_str());
+        return base::PlannerStatus::UNRECOGNIZED_GOAL_TYPE;
+    }
+
+    if (!goalSampler_->couldSample())
+    {
+        OMPL_ERROR("%s: Insufficient states in sampleable goal region", getName().c_str());
+        return base::PlannerStatus::INVALID_GOAL;
+    }
+
     // Ensure that we have a state sampler
     if (!sampler_)
         sampler_ = si_->allocStateSampler();

--- a/src/ompl/geometric/planners/rlrt/src/BiRLRT.cpp
+++ b/src/ompl/geometric/planners/rlrt/src/BiRLRT.cpp
@@ -214,6 +214,7 @@ ompl::base::PlannerStatus ompl::geometric::BiRLRT::solve(const base::PlannerTerm
     tree = &tStart_;
     otherTree = &tGoal_;
     bool solved = false;
+    base::PlannerStatus::StatusType status = base::PlannerStatus::TIMEOUT;
 
     auto xmotion = new Motion(si_);
 
@@ -236,6 +237,7 @@ ompl::base::PlannerStatus ompl::geometric::BiRLRT::solve(const base::PlannerTerm
             if (tGoal_.size() == 0)
             {
                 OMPL_ERROR("%s: Unable to sample any valid states for goal tree", getName().c_str());
+                status = base::PlannerStatus::INVALID_GOAL;
                 break;
             }
         }
@@ -293,7 +295,7 @@ ompl::base::PlannerStatus ompl::geometric::BiRLRT::solve(const base::PlannerTerm
     OMPL_INFORM("%s: Created %u states (%u start + %u goal)", getName().c_str(), tStart_.size() + tGoal_.size(),
                 tStart_.size(), tGoal_.size());
 
-    return solved ? base::PlannerStatus::EXACT_SOLUTION : base::PlannerStatus::TIMEOUT;
+    return solved ? base::PlannerStatus::EXACT_SOLUTION : status;
 }
 
 void ompl::geometric::BiRLRT::getPlannerData(base::PlannerData &data) const

--- a/src/ompl/geometric/planners/rlrt/src/RLRT.cpp
+++ b/src/ompl/geometric/planners/rlrt/src/RLRT.cpp
@@ -134,7 +134,7 @@ ompl::base::PlannerStatus ompl::geometric::RLRT::solve(const base::PlannerTermin
     std::pair<ompl::base::State *, double> lastValid;
     lastValid.first = si_->allocState();
 
-    while (ptc == false)
+    while (!ptc)
     {
         // Sample a state in the tree uniformly
         Motion *random = motions_[rng_.uniformInt(0, motions_.size() - 1)];

--- a/src/ompl/geometric/planners/rlrt/src/RLRT.cpp
+++ b/src/ompl/geometric/planners/rlrt/src/RLRT.cpp
@@ -91,6 +91,18 @@ ompl::base::PlannerStatus ompl::geometric::RLRT::solve(const base::PlannerTermin
     base::Goal *goal = pdef_->getGoal().get();
     auto goal_s = dynamic_cast<base::GoalSampleableRegion *>(goal);
 
+    if (goal_s == nullptr)
+    {
+        OMPL_ERROR("%s: Unknown type of goal", getName().c_str());
+        return base::PlannerStatus::UNRECOGNIZED_GOAL_TYPE;
+    }
+
+    if (!goal_s->couldSample())
+    {
+        OMPL_ERROR("%s: Insufficient states in sampleable goal region", getName().c_str());
+        return base::PlannerStatus::INVALID_GOAL;
+    }
+
     while (const base::State *st = pis_.nextStart())
     {
         Motion *motion = new Motion(si_);
@@ -128,7 +140,7 @@ ompl::base::PlannerStatus ompl::geometric::RLRT::solve(const base::PlannerTermin
         Motion *random = motions_[rng_.uniformInt(0, motions_.size() - 1)];
 
         // Sample a random state (with goal biasing)
-        if (goal_s != nullptr && rng_.uniform01() < goalBias_ && goal_s->canSample())
+        if (rng_.uniform01() < goalBias_ && goal_s->canSample())
             goal_s->sampleGoal(rstate);
         else
             sampler_->sampleUniform(rstate);

--- a/src/ompl/geometric/planners/rrt/src/BiTRRT.cpp
+++ b/src/ompl/geometric/planners/rrt/src/BiTRRT.cpp
@@ -348,7 +348,7 @@ ompl::base::PlannerStatus ompl::geometric::BiTRRT::solve(const base::PlannerTerm
     if (gsr == nullptr)
     {
         OMPL_ERROR("%s: Goal object does not derive from GoalSampleableRegion", getName().c_str());
-        return base::PlannerStatus::INVALID_GOAL;
+        return base::PlannerStatus::UNRECOGNIZED_GOAL_TYPE;
     }
 
     // Loop through the (valid) input states and add them to the start tree

--- a/src/ompl/geometric/planners/rrt/src/LBTRRT.cpp
+++ b/src/ompl/geometric/planners/rrt/src/LBTRRT.cpp
@@ -119,6 +119,18 @@ ompl::base::PlannerStatus ompl::geometric::LBTRRT::solve(const base::PlannerTerm
     if (goal == nullptr)
     {
         OMPL_ERROR("%s: Goal undefined", getName().c_str());
+        return base::PlannerStatus::UNRECOGNIZED_GOAL_TYPE;
+    }
+
+    if (goal_s == nullptr)
+    {
+        OMPL_ERROR("%s: Unknown type of goal", getName().c_str());
+        return base::PlannerStatus::UNRECOGNIZED_GOAL_TYPE;
+    }
+
+    if (!goal_s->couldSample())
+    {
+        OMPL_ERROR("%s: Insufficient states in sampleable goal region", getName().c_str());
         return base::PlannerStatus::INVALID_GOAL;
     }
 

--- a/src/ompl/geometric/planners/rrt/src/LBTRRT.cpp
+++ b/src/ompl/geometric/planners/rrt/src/LBTRRT.cpp
@@ -175,7 +175,7 @@ ompl::base::PlannerStatus ompl::geometric::LBTRRT::solve(const base::PlannerTerm
     unsigned int statesGenerated = 0;
 
     bestCost_ = lastGoalMotion_ != nullptr ? lastGoalMotion_->costApx_ : std::numeric_limits<double>::infinity();
-    while (!ptc())
+    while (!ptc)
     {
         iterations_++;
         /* sample random state (with goal biasing) */

--- a/src/ompl/geometric/planners/rrt/src/LazyLBTRRT.cpp
+++ b/src/ompl/geometric/planners/rrt/src/LazyLBTRRT.cpp
@@ -126,9 +126,15 @@ ompl::base::PlannerStatus ompl::geometric::LazyLBTRRT::solve(const base::Planner
     base::Goal *goal = pdef_->getGoal().get();
     auto *goal_s = dynamic_cast<base::GoalSampleableRegion *>(goal);
 
-    if (goal == nullptr)
+    if (goal == nullptr || goal_s == nullptr)
     {
-        OMPL_ERROR("%s: Goal undefined", getName().c_str());
+        OMPL_ERROR("%s: Unknown type of goal", getName().c_str());
+        return base::PlannerStatus::UNRECOGNIZED_GOAL_TYPE;
+    }
+
+    if (!goal_s->couldSample())
+    {
+        OMPL_ERROR("%s: Insufficient states in sampleable goal region", getName().c_str());
         return base::PlannerStatus::INVALID_GOAL;
     }
 

--- a/src/ompl/geometric/planners/rrt/src/LazyRRT.cpp
+++ b/src/ompl/geometric/planners/rrt/src/LazyRRT.cpp
@@ -97,6 +97,18 @@ ompl::base::PlannerStatus ompl::geometric::LazyRRT::solve(const base::PlannerTer
     base::Goal *goal = pdef_->getGoal().get();
     auto *goal_s = dynamic_cast<base::GoalSampleableRegion *>(goal);
 
+    if (goal_s == nullptr)
+    {
+        OMPL_ERROR("%s: Unknown type of goal", getName().c_str());
+        return base::PlannerStatus::UNRECOGNIZED_GOAL_TYPE;
+    }
+
+    if (!goal_s->couldSample())
+    {
+        OMPL_ERROR("%s: Insufficient states in sampleable goal region", getName().c_str());
+        return base::PlannerStatus::INVALID_GOAL;
+    }
+
     while (const base::State *st = pis_.nextStart())
     {
         auto *motion = new Motion(si_);
@@ -127,7 +139,7 @@ ompl::base::PlannerStatus ompl::geometric::LazyRRT::solve(const base::PlannerTer
     while (!ptc && !solutionFound)
     {
         /* sample random state (with goal biasing) */
-        if ((goal_s != nullptr) && rng_.uniform01() < goalBias_ && goal_s->canSample())
+        if (rng_.uniform01() < goalBias_ && goal_s->canSample())
             goal_s->sampleGoal(rstate);
         else
             sampler_->sampleUniform(rstate);

--- a/src/ompl/geometric/planners/rrt/src/RRT.cpp
+++ b/src/ompl/geometric/planners/rrt/src/RRT.cpp
@@ -100,6 +100,18 @@ ompl::base::PlannerStatus ompl::geometric::RRT::solve(const base::PlannerTermina
     base::Goal *goal = pdef_->getGoal().get();
     auto *goal_s = dynamic_cast<base::GoalSampleableRegion *>(goal);
 
+    if (goal_s == nullptr)
+    {
+        OMPL_ERROR("%s: Unknown type of goal", getName().c_str());
+        return base::PlannerStatus::UNRECOGNIZED_GOAL_TYPE;
+    }
+
+    if (!goal_s->couldSample())
+    {
+        OMPL_ERROR("%s: Insufficient states in sampleable goal region", getName().c_str());
+        return base::PlannerStatus::INVALID_GOAL;
+    }
+
     while (const base::State *st = pis_.nextStart())
     {
         auto *motion = new Motion(si_);
@@ -128,7 +140,7 @@ ompl::base::PlannerStatus ompl::geometric::RRT::solve(const base::PlannerTermina
     while (!ptc)
     {
         /* sample random state (with goal biasing) */
-        if ((goal_s != nullptr) && rng_.uniform01() < goalBias_ && goal_s->canSample())
+        if (rng_.uniform01() < goalBias_ && goal_s->canSample())
             goal_s->sampleGoal(rstate);
         else
             sampler_->sampleUniform(rstate);

--- a/src/ompl/geometric/planners/rrt/src/RRTConnect.cpp
+++ b/src/ompl/geometric/planners/rrt/src/RRTConnect.cpp
@@ -240,6 +240,7 @@ ompl::base::PlannerStatus ompl::geometric::RRTConnect::solve(const base::Planner
     auto *rmotion = new Motion(si_);
     base::State *rstate = rmotion->state;
     bool solved = false;
+    base::PlannerStatus::StatusType status = base::PlannerStatus::TIMEOUT;
 
     while (!ptc)
     {
@@ -262,6 +263,7 @@ ompl::base::PlannerStatus ompl::geometric::RRTConnect::solve(const base::Planner
             if (tGoal_->size() == 0)
             {
                 OMPL_ERROR("%s: Unable to sample any valid states for goal tree", getName().c_str());
+                status = base::PlannerStatus::INVALID_GOAL;
                 break;
             }
         }
@@ -387,7 +389,7 @@ ompl::base::PlannerStatus ompl::geometric::RRTConnect::solve(const base::Planner
         return base::PlannerStatus::APPROXIMATE_SOLUTION;
     }
 
-    return solved ? base::PlannerStatus::EXACT_SOLUTION : base::PlannerStatus::TIMEOUT;
+    return solved ? base::PlannerStatus::EXACT_SOLUTION : status;
 }
 
 void ompl::geometric::RRTConnect::getPlannerData(base::PlannerData &data) const

--- a/src/ompl/geometric/planners/rrt/src/RRTXstatic.cpp
+++ b/src/ompl/geometric/planners/rrt/src/RRTXstatic.cpp
@@ -244,7 +244,7 @@ ompl::base::PlannerStatus ompl::geometric::RRTXstatic::solve(const base::Planner
             std::min(maxDistance_, r_rrt_ * std::pow(log((double)(nn_->size() + 1u)) / ((double)(nn_->size() + 1u)),
                                                      1 / (double)(si_->getStateDimension()))));
 
-    while (ptc == false)
+    while (!ptc)
     {
         iterations_++;
 

--- a/src/ompl/geometric/planners/rrt/src/RRTXstatic.cpp
+++ b/src/ompl/geometric/planners/rrt/src/RRTXstatic.cpp
@@ -157,6 +157,18 @@ ompl::base::PlannerStatus ompl::geometric::RRTXstatic::solve(const base::Planner
     base::Goal *goal = pdef_->getGoal().get();
     auto *goal_s = dynamic_cast<base::GoalSampleableRegion *>(goal);
 
+    if (goal_s == nullptr)
+    {
+        OMPL_ERROR("%s: Unknown type of goal", getName().c_str());
+        return base::PlannerStatus::UNRECOGNIZED_GOAL_TYPE;
+    }
+
+    if (!goal_s->couldSample())
+    {
+        OMPL_ERROR("%s: Insufficient states in sampleable goal region", getName().c_str());
+        return base::PlannerStatus::INVALID_GOAL;
+    }
+
     // Check if there are more starts
     if (pis_.haveMoreStartStates() == true)
     {
@@ -242,7 +254,7 @@ ompl::base::PlannerStatus ompl::geometric::RRTXstatic::solve(const base::Planner
         // sample random state (with goal biasing)
         // Goal samples are only sampled until maxSampleCount() goals are in the tree, to prohibit duplicate goal
         // states.
-        if (goal_s && goalMotions_.size() < goal_s->maxSampleCount() && rng_.uniform01() < goalBias_ &&
+        if (goalMotions_.size() < goal_s->maxSampleCount() && rng_.uniform01() < goalBias_ &&
             goal_s->canSample())
             goal_s->sampleGoal(rstate);
         else

--- a/src/ompl/geometric/planners/rrt/src/RRTstar.cpp
+++ b/src/ompl/geometric/planners/rrt/src/RRTstar.cpp
@@ -168,6 +168,18 @@ ompl::base::PlannerStatus ompl::geometric::RRTstar::solve(const base::PlannerTer
     base::Goal *goal = pdef_->getGoal().get();
     auto *goal_s = dynamic_cast<base::GoalSampleableRegion *>(goal);
 
+    if (goal_s == nullptr)
+    {
+        OMPL_ERROR("%s: Unknown type of goal", getName().c_str());
+        return base::PlannerStatus::UNRECOGNIZED_GOAL_TYPE;
+    }
+
+    if (!goal_s->couldSample())
+    {
+        OMPL_ERROR("%s: Insufficient states in sampleable goal region", getName().c_str());
+        return base::PlannerStatus::INVALID_GOAL;
+    }
+
     bool symCost = opt_->isSymmetric();
 
     // Check if there are more starts
@@ -251,7 +263,7 @@ ompl::base::PlannerStatus ompl::geometric::RRTstar::solve(const base::PlannerTer
         // sample random state (with goal biasing)
         // Goal samples are only sampled until maxSampleCount() goals are in the tree, to prohibit duplicate goal
         // states.
-        if (goal_s && goalMotions_.size() < goal_s->maxSampleCount() && rng_.uniform01() < goalBias_ &&
+        if (goalMotions_.size() < goal_s->maxSampleCount() && rng_.uniform01() < goalBias_ &&
             goal_s->canSample())
             goal_s->sampleGoal(rstate);
         else

--- a/src/ompl/geometric/planners/rrt/src/TRRT.cpp
+++ b/src/ompl/geometric/planners/rrt/src/TRRT.cpp
@@ -149,7 +149,7 @@ void ompl::geometric::TRRT::freeMemory()
 }
 
 ompl::base::PlannerStatus
-ompl::geometric::TRRT::solve(const base::PlannerTerminationCondition &plannerTerminationCondition)
+ompl::geometric::TRRT::solve(const base::PlannerTerminationCondition &ptc)
 {
     // Basic error checking
     checkValidity();
@@ -231,7 +231,7 @@ ompl::geometric::TRRT::solve(const base::PlannerTerminationCondition &plannerTer
     base::State *newState;
 
     // Begin sampling --------------------------------------------------------------------------------------
-    while (plannerTerminationCondition() == false)
+    while (!ptc)
     {
         // I.
 

--- a/src/ompl/geometric/planners/rrt/src/TRRT.cpp
+++ b/src/ompl/geometric/planners/rrt/src/TRRT.cpp
@@ -158,6 +158,18 @@ ompl::geometric::TRRT::solve(const base::PlannerTerminationCondition &plannerTer
     base::Goal *goal = pdef_->getGoal().get();
     auto *goalRegion = dynamic_cast<base::GoalSampleableRegion *>(goal);
 
+    if (goalRegion == nullptr)
+    {
+        OMPL_ERROR("%s: Unknown type of goal", getName().c_str());
+        return base::PlannerStatus::UNRECOGNIZED_GOAL_TYPE;
+    }
+
+    if (!goalRegion->couldSample())
+    {
+        OMPL_ERROR("%s: Insufficient states in sampleable goal region", getName().c_str());
+        return base::PlannerStatus::INVALID_GOAL;
+    }
+
     // Input States ---------------------------------------------------------------------------------
 
     // Loop through valid input states and add to tree
@@ -224,7 +236,7 @@ ompl::geometric::TRRT::solve(const base::PlannerTerminationCondition &plannerTer
         // I.
 
         // Sample random state (with goal biasing probability)
-        if (goalRegion && rng_.uniform01() < goalBias_ && goalRegion->canSample())
+        if (rng_.uniform01() < goalBias_ && goalRegion->canSample())
         {
             // Bias sample towards goal
             goalRegion->sampleGoal(randState);

--- a/src/ompl/geometric/planners/rrt/src/TSRRT.cpp
+++ b/src/ompl/geometric/planners/rrt/src/TSRRT.cpp
@@ -95,6 +95,18 @@ ompl::base::PlannerStatus ompl::geometric::TSRRT::solve(const base::PlannerTermi
     base::Goal *goal = pdef_->getGoal().get();
     auto *goal_s = dynamic_cast<base::GoalSampleableRegion *>(goal);
 
+    if (goal_s == nullptr)
+    {
+        OMPL_ERROR("%s: Unknown type of goal", getName().c_str());
+        return base::PlannerStatus::UNRECOGNIZED_GOAL_TYPE;
+    }
+
+    if (!goal_s->couldSample())
+    {
+        OMPL_ERROR("%s: Insufficient states in sampleable goal region", getName().c_str());
+        return base::PlannerStatus::INVALID_GOAL;
+    }
+
     if (!task_space_)
         throw ompl::Exception("Task Space info is not set.  Cannot solve");
 
@@ -132,7 +144,7 @@ ompl::base::PlannerStatus ompl::geometric::TSRRT::solve(const base::PlannerTermi
         Motion *nmotion = nullptr;
 
         // Sample state (with goal biasing)
-        if (goal_s != nullptr && rng_.uniform01() < goalBias_ && goal_s->canSample())
+        if (rng_.uniform01() < goalBias_ && goal_s->canSample())
         {
             // Sample the goal in configuration space, then project to the task-space.
             goal_s->sampleGoal(rstate);

--- a/src/ompl/geometric/planners/rrt/src/TSRRT.cpp
+++ b/src/ompl/geometric/planners/rrt/src/TSRRT.cpp
@@ -138,7 +138,7 @@ ompl::base::PlannerStatus ompl::geometric::TSRRT::solve(const base::PlannerTermi
     auto &r_proj = rmotion->proj;
     r_proj.resize(task_space_->getDimension());
 
-    while (ptc == false)
+    while (!ptc)
     {
         // Nearest state in the tree to the configuration we're about to sample.
         Motion *nmotion = nullptr;

--- a/src/ompl/geometric/planners/rrt/src/VFRRT.cpp
+++ b/src/ompl/geometric/planners/rrt/src/VFRRT.cpp
@@ -197,6 +197,18 @@ ompl::base::PlannerStatus ompl::geometric::VFRRT::solve(const base::PlannerTermi
     base::Goal *goal = pdef_->getGoal().get();
     auto *goal_s = dynamic_cast<base::GoalSampleableRegion *>(goal);
 
+    if (goal_s == nullptr)
+    {
+        OMPL_ERROR("%s: Unknown type of goal", getName().c_str());
+        return base::PlannerStatus::UNRECOGNIZED_GOAL_TYPE;
+    }
+
+    if (!goal_s->couldSample())
+    {
+        OMPL_ERROR("%s: Insufficient states in sampleable goal region", getName().c_str());
+        return base::PlannerStatus::INVALID_GOAL;
+    }
+
     if (!sampler_)
         sampler_ = si_->allocStateSampler();
 
@@ -227,7 +239,7 @@ ompl::base::PlannerStatus ompl::geometric::VFRRT::solve(const base::PlannerTermi
     while (ptc == false)
     {
         // Sample random state (with goal biasing)
-        if (goal_s && rng_.uniform01() < goalBias_ && goal_s->canSample())
+        if (rng_.uniform01() < goalBias_ && goal_s->canSample())
             goal_s->sampleGoal(rstate);
         else
             sampler_->sampleUniform(rstate);

--- a/src/ompl/geometric/planners/rrt/src/VFRRT.cpp
+++ b/src/ompl/geometric/planners/rrt/src/VFRRT.cpp
@@ -236,7 +236,7 @@ ompl::base::PlannerStatus ompl::geometric::VFRRT::solve(const base::PlannerTermi
     base::State *rstate = rmotion->state;
     base::State *xstate = si_->allocState();
 
-    while (ptc == false)
+    while (!ptc)
     {
         // Sample random state (with goal biasing)
         if (rng_.uniform01() < goalBias_ && goal_s->canSample())

--- a/src/ompl/geometric/planners/rrt/src/pRRT.cpp
+++ b/src/ompl/geometric/planners/rrt/src/pRRT.cpp
@@ -175,7 +175,7 @@ ompl::base::PlannerStatus ompl::geometric::pRRT::solve(const base::PlannerTermin
 
     auto *goal = dynamic_cast<base::GoalRegion *>(pdef_->getGoal().get());
 
-    if (!goal)
+    if (goal == nullptr)
     {
         OMPL_ERROR("%s: Unknown type of goal", getName().c_str());
         return base::PlannerStatus::UNRECOGNIZED_GOAL_TYPE;

--- a/src/ompl/geometric/planners/sbl/src/SBL.cpp
+++ b/src/ompl/geometric/planners/sbl/src/SBL.cpp
@@ -119,6 +119,7 @@ ompl::base::PlannerStatus ompl::geometric::SBL::solve(const base::PlannerTermina
 
     bool startTree = true;
     bool solved = false;
+    base::PlannerStatus::StatusType status = base::PlannerStatus::TIMEOUT;
 
     while (ptc == false)
     {
@@ -141,6 +142,7 @@ ompl::base::PlannerStatus ompl::geometric::SBL::solve(const base::PlannerTermina
             if (tGoal_.size == 0)
             {
                 OMPL_ERROR("%s: Unable to sample any valid states for goal tree", getName().c_str());
+                status = base::PlannerStatus::INVALID_GOAL;
                 break;
             }
         }
@@ -177,7 +179,7 @@ ompl::base::PlannerStatus ompl::geometric::SBL::solve(const base::PlannerTermina
                 tStart_.size + tGoal_.size, tStart_.size, tGoal_.size, tStart_.grid.size() + tGoal_.grid.size(),
                 tStart_.grid.size(), tGoal_.grid.size());
 
-    return solved ? base::PlannerStatus::EXACT_SOLUTION : base::PlannerStatus::TIMEOUT;
+    return solved ? base::PlannerStatus::EXACT_SOLUTION : status;
 }
 
 bool ompl::geometric::SBL::checkSolution(bool start, TreeData &tree, TreeData &otherTree, Motion *motion,

--- a/src/ompl/geometric/planners/sbl/src/SBL.cpp
+++ b/src/ompl/geometric/planners/sbl/src/SBL.cpp
@@ -81,7 +81,7 @@ ompl::base::PlannerStatus ompl::geometric::SBL::solve(const base::PlannerTermina
     checkValidity();
     auto *goal = dynamic_cast<base::GoalSampleableRegion *>(pdef_->getGoal().get());
 
-    if (!goal)
+    if (goal == nullptr)
     {
         OMPL_ERROR("%s: Unknown type of goal", getName().c_str());
         return base::PlannerStatus::UNRECOGNIZED_GOAL_TYPE;

--- a/src/ompl/geometric/planners/sbl/src/pSBL.cpp
+++ b/src/ompl/geometric/planners/sbl/src/pSBL.cpp
@@ -191,7 +191,7 @@ ompl::base::PlannerStatus ompl::geometric::pSBL::solve(const base::PlannerTermin
 
     auto *goal = dynamic_cast<base::GoalState *>(pdef_->getGoal().get());
 
-    if (!goal)
+    if (goal == nullptr)
     {
         OMPL_ERROR("%s: Unknown type of goal", getName().c_str());
         return base::PlannerStatus::UNRECOGNIZED_GOAL_TYPE;

--- a/src/ompl/geometric/planners/sbl/src/pSBL.cpp
+++ b/src/ompl/geometric/planners/sbl/src/pSBL.cpp
@@ -217,7 +217,10 @@ ompl::base::PlannerStatus ompl::geometric::pSBL::solve(const base::PlannerTermin
             addMotion(tGoal_, motion);
         }
         else
-            OMPL_ERROR("%s: Goal state is invalid!", getName().c_str());
+            {
+                OMPL_ERROR("%s: Goal state is invalid!", getName().c_str());
+                return base::PlannerStatus::INVALID_GOAL;
+            }
     }
 
     if (tStart_.size == 0)

--- a/src/ompl/geometric/planners/sst/src/SST.cpp
+++ b/src/ompl/geometric/planners/sst/src/SST.cpp
@@ -227,6 +227,18 @@ ompl::base::PlannerStatus ompl::geometric::SST::solve(const base::PlannerTermina
     base::Goal *goal = pdef_->getGoal().get();
     auto *goal_s = dynamic_cast<base::GoalSampleableRegion *>(goal);
 
+    if (goal_s == nullptr)
+    {
+        OMPL_ERROR("%s: Unknown type of goal", getName().c_str());
+        return base::PlannerStatus::UNRECOGNIZED_GOAL_TYPE;
+    }
+
+    if (!goal_s->couldSample())
+    {
+        OMPL_ERROR("%s: Insufficient states in sampleable goal region", getName().c_str());
+        return base::PlannerStatus::INVALID_GOAL;
+    }
+
     while (const base::State *st = pis_.nextStart())
     {
         auto *motion = new Motion(si_);
@@ -262,7 +274,7 @@ ompl::base::PlannerStatus ompl::geometric::SST::solve(const base::PlannerTermina
     while (ptc == false)
     {
         /* sample random state (with goal biasing) */
-        bool attemptToReachGoal = (goal_s && rng_.uniform01() < goalBias_ && goal_s->canSample());
+        bool attemptToReachGoal = (rng_.uniform01() < goalBias_ && goal_s->canSample());
         if (attemptToReachGoal)
             goal_s->sampleGoal(rstate);
         else

--- a/src/ompl/geometric/planners/stride/src/STRIDE.cpp
+++ b/src/ompl/geometric/planners/stride/src/STRIDE.cpp
@@ -134,6 +134,18 @@ ompl::base::PlannerStatus ompl::geometric::STRIDE::solve(const base::PlannerTerm
     base::Goal *goal = pdef_->getGoal().get();
     auto *goal_s = dynamic_cast<base::GoalSampleableRegion *>(goal);
 
+    if (goal_s == nullptr)
+    {
+        OMPL_ERROR("%s: Unknown type of goal", getName().c_str());
+        return base::PlannerStatus::UNRECOGNIZED_GOAL_TYPE;
+    }
+
+    if (!goal_s->couldSample())
+    {
+        OMPL_ERROR("%s: Insufficient states in sampleable goal region", getName().c_str());
+        return base::PlannerStatus::INVALID_GOAL;
+    }
+
     while (const base::State *st = pis_.nextStart())
     {
         auto *motion = new Motion(si_);
@@ -164,7 +176,7 @@ ompl::base::PlannerStatus ompl::geometric::STRIDE::solve(const base::PlannerTerm
         assert(existing);
 
         /* sample random state (with goal biasing) */
-        if (goal_s && rng_.uniform01() < goalBias_ && goal_s->canSample())
+        if (rng_.uniform01() < goalBias_ && goal_s->canSample())
             goal_s->sampleGoal(xstate);
         else if (!sampler_->sampleNear(xstate, existing->state, maxDistance_))
             continue;

--- a/src/ompl/tools/lightning/src/Lightning.cpp
+++ b/src/ompl/tools/lightning/src/Lightning.cpp
@@ -159,6 +159,19 @@ ompl::base::PlannerStatus ompl::tools::Lightning::solve(const base::PlannerTermi
         log.result = "timedout";
         log.is_saved = "not_saved";
     }
+    else if ((lastStatus_ == ompl::base::PlannerStatus::INVALID_START)
+            || (lastStatus_ == ompl::base::PlannerStatus::INVALID_GOAL)
+            || (lastStatus_ == ompl::base::PlannerStatus::UNRECOGNIZED_GOAL_TYPE))
+    {
+        // Skip further processing if absolutely no path is available
+        OMPL_ERROR("Lightning Solve: invalid start or goal, planner status: %s", lastStatus_.asString().c_str());
+        stats_.numSolutionsFailed_++;
+
+        // Logging
+        log.planner = "neither_planner";
+        log.result = "failed";
+        log.is_saved = "not_saved";
+    }
     else if (!lastStatus_)
     {
         // Skip further processing if absolutely no path is available

--- a/src/ompl/tools/thunder/src/Thunder.cpp
+++ b/src/ompl/tools/thunder/src/Thunder.cpp
@@ -243,10 +243,23 @@ ompl::base::PlannerStatus ompl::tools::Thunder::solve(const base::PlannerTermina
         log.result = "timedout";
         log.is_saved = "not_saved";
     }
+    else if ((lastStatus_ == ompl::base::PlannerStatus::INVALID_START)
+            || (lastStatus_ == ompl::base::PlannerStatus::INVALID_GOAL)
+            || (lastStatus_ == ompl::base::PlannerStatus::UNRECOGNIZED_GOAL_TYPE))
+    {
+        // Skip further processing if absolutely no path is available
+        OMPL_ERROR("Lightning Solve: invalid start or goal, planner status: %s", lastStatus_.asString().c_str());
+        stats_.numSolutionsFailed_++;
+
+        // Logging
+        log.planner = "neither_planner";
+        log.result = "failed";
+        log.is_saved = "not_saved";
+    }
     else if (!lastStatus_)
     {
         // Skip further processing if absolutely no path is available
-        OMPL_ERROR("Thunder Solve: Unknown failure");
+        OMPL_ERROR("Thunder Solve: Unknown failure, planner status: %s", lastStatus_.asString().c_str());
         stats_.numSolutionsFailed_++;
 
         // Logging


### PR DESCRIPTION
Some algorithms didn't make use of other return code than `SUCCESS` and `TIMEOUT` but we can return earlier if the start or the goal are invalid because this won't change.

I added some early-return code to some algorithms but have the impression that catching the `INVALID_GOAL` condition is more complicated than what I did.