### PR TITLE
Fix syntax error to avoid unnecessary error message in bash script

### DIFF
--- a/install-ompl-ubuntu.sh.in
+++ b/install-ompl-ubuntu.sh.in
@@ -71,7 +71,7 @@ install_ompl()
         OMPL="omplapp"
     fi
     if [ -z $GITHUB ]; then
-        if [ -z $APP]; then
+        if [ -z $APP ]; then
             wget -O - https://github.com/ompl/${OMPL}/archive/@PROJECT_VERSION@.tar.gz | tar zxf -
             cd ${OMPL}-@PROJECT_VERSION@
         else


### PR DESCRIPTION
### Background
Noticed a minor typo in the bash script that triggers an unnecessary error message when installing OMPL.app due to missing space in the if statement.

### Changes Made
``` diff
- if [ -z $APP]; then
+ if [ -z $APP ]; then
```

### Impact Assessment
This change is minimal and does not affect the logic of the script. It purely enhances the script cleanliness and prevents misleading error messages during execution.
