### PR TITLE
Fix Python wheels missing constrained planning components

### DIFF
--- a/.github/workflows/before_build.sh
+++ b/.github/workflows/before_build.sh
@@ -20,7 +20,7 @@ install_boost() {
     # multiple on the host system.
     python_include_path=$(python3 -c "from sysconfig import get_paths as gp; print(gp()['include'])")
     echo "using python : ${python_version} : : ${python_include_path} ;" > "$HOME/user-config.jam"
-
+    pip3 install numpy
     ./bootstrap.sh
     sudo ./b2 "${b2_args[@]}" \
         --with-serialization \

--- a/.github/workflows/wheels.yaml
+++ b/.github/workflows/wheels.yaml
@@ -22,7 +22,7 @@ jobs:
           submodules: 'recursive'
 
       - name: Build wheels
-        uses: pypa/cibuildwheel@v2.16.1
+        uses: pypa/cibuildwheel@v2.17.0
         with:
           package-dir: py-bindings
         env:
@@ -33,7 +33,7 @@ jobs:
           CIBW_BUILD: cp3{10,11,12}-macosx_{x86_64,arm64} cp3{7,8,9,10,11,12}-manylinux_x86_64
           CIBW_BUILD_VERBOSITY: 1
 
-      - uses: actions/upload-artifact@v3
+      - uses: actions/upload-artifact@v4
         with:
           name: wheels
           path: wheelhouse

--- a/py-bindings/generate_bindings.py
+++ b/py-bindings/generate_bindings.py
@@ -245,8 +245,9 @@ class ompl_base_generator_t(code_generator_t):
             try:
                 # create a python type for each of their corresponding state types
                 state = self.ompl_ns.class_('ScopedState< ompl::base::%sStateSpace >' % stype)
-            except:
+            except Exception as e:
                 # ignore errors because of missing Boost.Numpy
+                print(f"Ignoring error due to missing Boost.Numpy: {e}")
                 continue
             state.rename(stype+'State')
             state.operator('=', arg_types=['::ompl::base::State const &']).exclude()
@@ -355,6 +356,7 @@ class ompl_base_generator_t(code_generator_t):
                         try:
                             cls.member_function(method, arg_types=[signature, None]).add_transformation(FT.input(0))
                         except Exception as e:
+                            print(f"Ignoring constraint signature rewrite exception: {e}")
                             pass
 
             cls = self.ompl_ns.class_('Constraint')
@@ -364,9 +366,11 @@ class ompl_base_generator_t(code_generator_t):
                     try:
                         cls.member_function(method, arg_types=[signature]).add_transformation(FT.input(0))
                     except Exception as e:
+                        print(f"Ignoring constraint signature rewrite exception: {e}")
                         pass
 
         except Exception as e:
+            print(f"Ignoring generation exception: {e}")
             pass
 
         # Exclude PlannerData::getEdges function that returns a map of PlannerDataEdge* for now


### PR DESCRIPTION
I found a bug wherein, due to `numpy` not being installed correctly before building Boost in the Python wheel CI, `libboost_numpy` would not be built, and so part of the binding generator would silently fail, leading to some components - notably, the constrained planning modules - being missing from the pre-built wheels.

Note that the pip install seems to be necessary; the system-package install (for Linux, at least) places `numpy` in a location that Boost's build does not find.

This PR also adds some output to prevent silent failures like this from going unnoticed in the future and updates the versions of other CI actions used in building Python wheels, in compliance with the warning output visible on the last few runs of the wheel action.

- **Install numpy before building Boost in CI**
- **Make binding generation exceptions less silent**
- **Update versions of actions for Python wheel CI**
