### PR TITLE
Fix CI artifact upload naming, take 2

### DIFF
--- a/.github/workflows/wheels.yaml
+++ b/.github/workflows/wheels.yaml
@@ -1,5 +1,6 @@
 name: Build Wheels
 on:
+  workflow_dispatch:
   push:
     branches:
       - main

--- a/.github/workflows/wheels.yaml
+++ b/.github/workflows/wheels.yaml
@@ -35,7 +35,7 @@ jobs:
 
       - uses: actions/upload-artifact@v4
         with:
-          name: wheels-${{ matrix.runs-on }}
+          name: wheels-${{ matrix.os }}-${{ matrix.arch }}
           path: wheelhouse
 
   prerelease:


### PR DESCRIPTION
Unfortunately, the docs I followed in #1160 didn't align with the OMPL Github Actions setup - specifically, the `matrix.runs_on` variable, intended to give each platform's artifact a unique name, was unset. This PR does what #1160 was supposed to do, using the correct platform variables, as well as enabling manual triggering of the wheel build action. I've tested it on my fork, and all builds succeed.

- **fix(CI): Used wrong variable to set unique name for upload artifacts in #1160**
- **feat(CI): Allow manual dispatch of wheel build action**
