### PR TITLE
BITstar: use atomic variable instead of lock in IdGenerator

### DIFF
--- a/src/ompl/geometric/planners/informedtrees/bitstar/IdGenerator.h
+++ b/src/ompl/geometric/planners/informedtrees/bitstar/IdGenerator.h
@@ -42,7 +42,7 @@
 #include "ompl/geometric/planners/informedtrees/BITstar.h"
 
 #include <thread>
-#include <mutex>
+#include <atomic>
 // For boost::scoped_ptr
 #include <boost/scoped_ptr.hpp>
 
@@ -63,9 +63,6 @@ namespace ompl
             /** \brief Generator a new id and increment the global/static counter of IDs. */
             BITstar::VertexId getNewId()
             {
-                // Create a scoped mutex copy of idMutex that unlocks when it goes out of scope:
-                std::lock_guard<std::mutex> lockGuard(idMutex_);
-
                 // Return the next id, purposefully post-decrementing:
                 return nextId_++;
             }
@@ -73,9 +70,7 @@ namespace ompl
         private:
             // Variables:
             // The next ID to be returned. We never use 0.
-            BITstar::VertexId nextId_{1u};
-            // The mutex
-            std::mutex idMutex_;
+            std::atomic<BITstar::VertexId> nextId_{1u};
         };
     }  // geometric
 }  // ompl

--- a/src/ompl/geometric/planners/informedtrees/bitstar/src/Vertex.cpp
+++ b/src/ompl/geometric/planners/informedtrees/bitstar/src/Vertex.cpp
@@ -40,6 +40,9 @@
 // For std::move
 #include <utility>
 
+// For std::once_flag
+#include <mutex>
+
 // For exceptions:
 #include "ompl/util/Exception.h"
 


### PR DESCRIPTION
 In the current implementation of `BITstar`, the `IdGenerator` class uses a lock to prevent data races. The same task can be accomplished more effectively with atomic variables, leading to cleaner code and a slight performance boost.

Please review my changes and provide any feedback. I am willing to make further adjustments or conduct additional testing if required.

Thank you for your time and consideration.

reference: https://en.cppreference.com/w/cpp/atomic/atomic/operator_arith