### PR TITLE
chore: Add Ubuntu 24.04 to the list of OS versions tested in CI

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -12,7 +12,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-22.04, ubuntu-20.04, macos-12, windows-2022]
+        os: [ubuntu-24.04, ubuntu-22.04, ubuntu-20.04, macos-12, windows-2022]
 
     steps:
     - uses: actions/checkout@v4


### PR DESCRIPTION
Ubuntu 24.04 is now offered as a runner in beta (see https://docs.github.com/en/actions/using-github-hosted-runners/about-github-hosted-runners/about-github-hosted-runners#supported-runners-and-hardware-resources). As such, we should test the OMPL build against it. Once it's out of beta, there's another chore to update the wheel building workflow to use Ubuntu 24 instead of 22.
