### PR TITLE
fix strrt distance function: return inf when t1 > t2, and change the order of the arguments in distance function for goal tree.

### DIFF
--- a/src/ompl/base/spaces/src/SpaceTimeStateSpace.cpp
+++ b/src/ompl/base/spaces/src/SpaceTimeStateSpace.cpp
@@ -53,7 +53,7 @@ double ompl::base::SpaceTimeStateSpace::distance(const ompl::base::State *state1
     double deltaSpace = distanceSpace(state1, state2);
     double deltaTime = distanceTime(state1, state2);
 
-    if (deltaSpace / vMax_ > deltaTime + eps_) return std::numeric_limits<double>::infinity();
+    if (std::isinf(deltaTime) || (deltaSpace / vMax_ > deltaTime + eps_)) return std::numeric_limits<double>::infinity();
 
     return weights_[0] * deltaSpace + weights_[1] * deltaTime;
 
@@ -77,6 +77,8 @@ double ompl::base::SpaceTimeStateSpace::distanceSpace(const ompl::base::State *s
 double ompl::base::SpaceTimeStateSpace::distanceTime(const ompl::base::State *state1,
                                                      const ompl::base::State *state2) const
 {
+    if(getStateTime(state1)>getStateTime(state2)) return std::numeric_limits<double>::infinity();
+    
     const auto *cstate1 = static_cast<const CompoundState *>(state1);
     const auto *cstate2 = static_cast<const CompoundState *>(state2);
 

--- a/src/ompl/geometric/planners/rrt/src/STRRTstar.cpp
+++ b/src/ompl/geometric/planners/rrt/src/STRRTstar.cpp
@@ -67,7 +67,7 @@ void ompl::geometric::STRRTstar::setup()
     if (!tGoal_)
         tGoal_.reset(new ompl::NearestNeighborsLinear<Motion *>());
     tStart_->setDistanceFunction([this](const Motion *a, const Motion *b) { return distanceFunction(a, b); });
-    tGoal_->setDistanceFunction([this](const Motion *a, const Motion *b) { return distanceFunction(a, b); });
+    tGoal_->setDistanceFunction([this](const Motion *a, const Motion *b) { return distanceFunction(b, a); });
 
     if (si_->getStateSpace()->as<ompl::base::SpaceTimeStateSpace>()->getTimeComponent()->isBounded())
     {


### PR DESCRIPTION
in original paper of STRRT* distance function is defined as
![image](https://github.com/user-attachments/assets/be089179-cb68-4f43-b838-bda108c6d863)

As we see, if t1 > t2, than distance function returns infinity, but in SpaceTimeStateSpace if t1>t2, it just returns the absolute value of |t1-t2|. This leads to incorrect work of nearest neighbours, that returns invalid states. In this pull request i add a check of (t1>t2) in SpaceTimeStateSpace, so it can be identical to  the original distance function, that is defined in paper. 

Also, i changed order of arguments in distanceFunction for goal tree, because it grows backwards.