### PR TITLE
Fix off-by-one error and deprecated call in python path visualization tutorial

### DIFF
--- a/doc/markdown/pathVisualization.md
+++ b/doc/markdown/pathVisualization.md
@@ -53,8 +53,8 @@ import numpy
 import matplotlib.pyplot as plt
 data = numpy.loadtxt('path.txt')
 fig = plt.figure()
-ax = fig.gca(projection='3d')
-ax.plot(data[:,1],data[:,2],data[:,3],'.-')
+ax = plt.axes(projection='3d')
+ax.plot(data[:,0],data[:,1],data[:,2],'.-')
 plt.show()
 ~~~
 


### PR DESCRIPTION
# Purpose

There was an off-by-one error in the sample matplotlib script for path vizualization that caused this error:
```
$ python3 plot.py 
/home/ryan/Dev/ompl_ws/tutorials/plot.py:6: MatplotlibDeprecationWarning: Calling gca() with keyword arguments was deprecated in Matplotlib 3.4. Starting two minor releases later, gca() will take no keyword arguments. The gca() function should only be used to get the current axes, or if no axes exist, create new axes with default keyword arguments. To create a new axes with non-default arguments, use plt.axes() or plt.subplot().
  ax = fig.gca(projection='3d')
Traceback (most recent call last):
  File "/home/ryan/Dev/ompl_ws/tutorials/plot.py", line 7, in <module>
    ax.plot(data[:,1],data[:,2],data[:,3],'.-')
IndexError: index 3 is out of bounds for axis 1 with size 3
```

You can also see a depcrecation warning. Both are fixed.

Result with GeometricCarPlanning.cpp:
![image](https://github.com/user-attachments/assets/ea27a49b-8b1a-4e9e-a511-cc1ad3f8c1ae)

I've attached the generated path you can reproduce this plot with. Just update the filename.

[geo_car_plan.txt](https://github.com/user-attachments/files/16903411/geo_car_plan.txt)
