### PR TITLE
fix signedness compare warning (for -Werror build)

### DIFF
--- a/demos/multilevel/MultiLevelPlanningKinematicChain.cpp
+++ b/demos/multilevel/MultiLevelPlanningKinematicChain.cpp
@@ -65,7 +65,7 @@ PlannerPtr GetQRRT(std::vector<int> sequenceLinks, SpaceInformationPtr si)
     for (unsigned int k = 0; k < sequenceLinks.size(); k++)
     {
         auto links = sequenceLinks.at(k);
-        assert(links < numLinks);
+        assert(static_cast<unsigned int>(links) < numLinks);
 
         OMPL_INFORM("Create MultiLevel Chain with %d links.", links);
         auto spaceK(std::make_shared<KinematicChainSpace>(links, linkLength, &envs.at(links)));

--- a/src/ompl/geometric/planners/xxl/src/XXL.cpp
+++ b/src/ompl/geometric/planners/xxl/src/XXL.cpp
@@ -353,7 +353,7 @@ int ompl::geometric::XXL::addThisState(base::State *state)
 
     // Inserting motion into the list
     motions_.push_back(motion);
-    assert(motion->index == motions_.size() - 1);
+    assert(static_cast<size_t>(motion->index) == motions_.size() - 1);
 
     // Updating sublayer storage with this motion
     Layer *layer = topLayer_;


### PR DESCRIPTION
Fixes these clang warnings:

```
ompl/geometric/planners/xxl/src/XXL.cpp:356:26: error: comparison of integers of different signs: 'int' and 'size_type' (aka 'unsigned long') [-Werror,-Wsign-compare]

ompl/demos/multilevel/MultiLevelPlanningKinematicChain.cpp:68:22: error: comparison of integers of different signs: 'value_type' (aka 'int') and 'const unsigned int' [-Werror,-Wsign-compare]
```