### PR TITLE
Use target include directories for FetchContent support

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -25,11 +25,8 @@ include(OMPLUtils)
 
 set(OMPL_CMAKE_UTIL_DIR "${CMAKE_CURRENT_SOURCE_DIR}/CMakeModules"
     CACHE FILEPATH "Path to directory with auxiliary CMake scripts for OMPL")
-set(OMPL_INCLUDE_DIRS "${CMAKE_CURRENT_SOURCE_DIR}/src;${CMAKE_CURRENT_BINARY_DIR}/src")
 set(OMPL_DEMO_INSTALL_DIR "${CMAKE_INSTALL_DATAROOTDIR}/ompl/demos"
     CACHE STRING "Relative path to directory where demos will be installed")
-
-include_directories("${OMPL_INCLUDE_DIRS}")
 
 if(MSVC)
     add_definitions(-DBOOST_ALL_NO_LIB)

--- a/doc/markdown/installation.md
+++ b/doc/markdown/installation.md
@@ -10,6 +10,7 @@
     <li class="nav-item"><a class="nav-link" id="linux-tab" data-toggle="pill" href="#linux" role="tab" aria-controls="linux" aria-selected="false">Linux (generic)</a></li>
     <li class="nav-item"><a class="nav-link" id="osx-tab" data-toggle="pill" href="#osx" role="tab" aria-controls="macos" aria-selected="false">macOS</a></li>
     <li class="nav-item"><a class="nav-link" id="windows-tab" data-toggle="pill" href="#windows" role="tab" aria-controls="windows" aria-selected="false">MS Windows</a></li>
+    <li class="nav-item"><a class="nav-link" id="cmake-fetch-tab" data-toggle="pill" href="#cmakefetch" role="tab" aria-controls="cmakefetch" aria-selected="false">CMake Fetchcontent</a></li>
   </ul>
 </div>
 
@@ -111,6 +112,22 @@ cmake ../..</pre></li>
     It is recommended to use <a href="https://vcpkg.readthedocs.io/en/latest/">vcpkg</a>, a Microsoft-supported package manager for open source software. Once you have vcpkg installed, you can install OMPL like so:
     <pre class="fragment">vcpkg install ompl</pre>
     Note that the vcpkg installation does not include Python bindings.
+  </div>
+  <!-- CMake Fetchcontent -->
+  <div class="tab-pane fade" id="cmakefetch" role="tabpanel" aria-labelledby="cmake-fetch-tab">
+    <h2>CMake Fetchcontent</h2>
+    If you want to build ompl from source as part of another repository, FetchContent is one approach. In CMake, you can fetch and link like so:
+    <pre class="fragment">
+include(FetchContent)
+FetchContent_Declare(
+  ompl
+  GIT_REPOSITORY https://github.com/ompl/ompl.git
+)
+FetchContent_MakeAvailable(ompl)
+
+add_executable(main main.cpp)
+target_link_libraries(main PRIVATE ompl::ompl)
+    </pre>
   </div>
 </div>
 \endhtmlonly

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -1,4 +1,14 @@
 add_subdirectory(ompl)
+target_include_directories(ompl
+  PUBLIC
+    "$<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}>"
+    "$<BUILD_INTERFACE:${CMAKE_CURRENT_BINARY_DIR}>"
+    "$<INSTALL_INTERFACE:include/ompl>")
+get_target_property(_include_dirs ompl INCLUDE_DIRECTORIES)
+set(OMPL_INCLUDE_DIRS _include_dirs)
+get_target_property(_include_dirs ompl INTERFACE_INCLUDE_DIRECTORIES)
+list(APPEND OMPL_INCLUDE_DIRS _include_dirs)
+
 install(DIRECTORY ompl/ DESTINATION "${CMAKE_INSTALL_INCLUDEDIR}/ompl"
     COMPONENT ompl
     FILES_MATCHING 
@@ -9,8 +19,3 @@ install(DIRECTORY ompl/ DESTINATION "${CMAKE_INSTALL_INCLUDEDIR}/ompl"
     REGEX "/doc$" EXCLUDE
     REGEX "/tests$" EXCLUDE)
 
-target_include_directories(ompl
-    PUBLIC
-    $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}>
-    $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}>
-)


### PR DESCRIPTION
# Purpose

* Carry includes through target properties
* Attempt to preserve backwards compatability with OMPL_INCLUDE_DIRS
* Document how to use the library through FetchContent (platform-portable)
* Ensure the build interface can include ompl/config.h

This should also make it work in the same way with `add_subdirectory` for those who use git submodules and similar.

# TIcket

* Solves #1174

# Risks

I'm haven't tested if I handled `OMPL_INCLUDE_DIRS`. Can we set up a test for this somehow? Make sure `config.h` is found!  Of note, the docs say this: `      To support the previous CMake module behavior, the following variables are defined. These are for backwards compatability, but not recommended anymore.` I don't think this is actually true when we install the package. Let's discuss whether we should fix it. 

```bash
$ grep OMPL_INCLUDE_DIRS -rn install
install/share/ompl/cmake/Findcastxml.cmake:37:        "${OMPL_INCLUDE_DIRS}"
$ grep OMPL_LIBRARIES -rn install
$ grep OMPL_VERSION -rn install
```

# Testing

Use this code example in another folder. Place it outside of your ompl folder. 

```cmake
cmake_minimum_required(VERSION 3.22)
project(ompl_consumer)

include(FetchContent)
FetchContent_Declare(
  ompl
)

FetchContent_MakeAvailable(ompl)
add_executable(main main.cpp)
target_link_libraries(main PRIVATE ompl::ompl)
```

Build it like so. Make sure to check out this branch of ompl, and set the path to it correctly so FetchContent uses the local version.
`cmake -B build -DFETCHCONTENT_SOURCE_DIR_OMPL=/your/path/to/omplapp/ompl`

**main.cpp**
```
#include <ompl/base/ScopedState.h>

int main() {
    return 0;
}
```
