### PR TITLE
Hotfix: Cmake installation with version folder

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -55,7 +55,12 @@ jobs:
         run-test: true
         ctest-options: --output-on-failure
         install-build: true
-
+    - name: Test CMake target linkage to ompl::ompl
+      if: runner.os != 'Windows'
+      run: |
+        cd tests/cmake_export
+        cmake -B build -DCMAKE_INSTALL_PREFIX=${{ runner.workspace }}/install
+        cmake --build build
     - name: Build & Test (Windows)
       if: runner.os == 'Windows'
       uses: ashutoshvarma/action-cmake-build@master

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -3,7 +3,9 @@ target_include_directories(ompl
   PUBLIC
     "$<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}>"
     "$<BUILD_INTERFACE:${CMAKE_CURRENT_BINARY_DIR}>"
-    "$<INSTALL_INTERFACE:include/ompl>")
+    "$<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}>"
+)
+
 get_target_property(_include_dirs ompl INCLUDE_DIRECTORIES)
 set(OMPL_INCLUDE_DIRS _include_dirs)
 get_target_property(_include_dirs ompl INTERFACE_INCLUDE_DIRECTORIES)


### PR DESCRIPTION
* The installation path was incorrectly changed and broke users who link to ompl::ompl after find_package. It was changed to support FetchContent.
* This was caused by the accidental change from https://github.com/ompl/ompl/pull/1182/files#diff-148715d6ea0c0ea0a346af3f6bd610d010d490eca35ac6a9b408748f7ca9e3f4L15  to https://github.com/ompl/ompl/pull/1182/files#diff-148715d6ea0c0ea0a346af3f6bd610d010d490eca35ac6a9b408748f7ca9e3f4R6
* Add CI to enforce the existing export test because the dockerfile is not build in CI