### PR TITLE
Restore legacy CMAKE variables 

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -114,6 +114,8 @@ set_package_properties(flann PROPERTIES
 find_package(flann CONFIG 1.9.2 QUIET)
 if (FLANN_FOUND)
     set(OMPL_HAVE_FLANN 1)
+else ()
+    set(OMPL_HAVE_FLANN 0)
 endif()
 
 set_package_properties(spot PROPERTIES

--- a/doc/markdown/buildSystem.md
+++ b/doc/markdown/buildSystem.md
@@ -16,7 +16,7 @@ When developing your own code that relies on OMPL, you have several options:
       target_link_libraries(your_library PUBLIC ompl::ompl)
       ```
       
-      To support the previous CMake module behavior, the following variables are defined. These are for backwards compatability, but not recommended anymore.
+      To support the previous CMake module behavior, the following variables are defined. These are for backwards compatability, but not recommended anymore. These variables are NOT portable if these libraries exist at a different place than where ompl was built.
 
          - `OMPL_FOUND`         - `TRUE`
          - `OMPL_INCLUDE_DIRS`  - The OMPL include directory

--- a/omplConfig.cmake.in
+++ b/omplConfig.cmake.in
@@ -4,12 +4,33 @@
 # find_package(ompl @OMPL_VERSION_MAJOR@ REQUIRED)
 # add_library(your_app main.cpp)
 # target_link_libraries(your_app PRIVATE ompl::ompl)
+#
+#
 
 @PACKAGE_INIT@
 
+
+# These must be set BEFORE any call to find_package because PACKAGE_PREFIX_DIR gets overwritten by Eigen3.
+# See https://cmake.org/cmake/help/latest/module/CMakePackageConfigHelpers.html#command:configure_package_config_file.
+## Deprecated Variables ##
+set(OMPL_FOUND ${@PROJECT_NAME@_FOUND})
+set(OMPL_VERSION @PROJECT_VERSION@)
+set(OMPL_MAJOR_VERSION @PROJECT_VERSION_MAJOR@)
+set(OMPL_MINOR_VERSION @PROJECT_VERSION_MINOR@)
+set(OMPL_PATCH_VERSION @PROJECT_VERSION_PATCH@)
+set_and_check(OMPL_INCLUDE_DIRS @PACKAGE_INCLUDE_INSTALL_DIR@)
+set_and_check(OMPL_LIBRARIES @PACKAGE_LIB_INSTALL_DIR@)
+
 include ("${CMAKE_CURRENT_LIST_DIR}/omplExport.cmake" )
 include(CMakeFindDependencyMacro)
-find_dependency(Boost REQUIRED COMPONENTS serialization filesystem system)
+set(_@PROJECT_NAME@_boost_components serialization filesystem system)
+find_dependency(Boost REQUIRED COMPONENTS ${_@PROJECT_NAME@_boost_components})
+if(Boost_FOUND)
+    foreach(_comp ${_@PROJECT_NAME@_boost_components})
+        get_target_property(_includes Boost::${_comp} INTERFACE_INCLUDE_DIRECTORIES)
+        list(APPEND OMPL_INCLUDE_DIRS ${_includes})
+    endforeach()
+endif()
 find_dependency(Eigen3 REQUIRED)
 
 # Add OMPL's find modules to the search path so consumers can also find them.
@@ -38,3 +59,14 @@ endif()
 if(@OMPL_HAVE_SPOT@) # if(OMPL_HAVE_SPOT)
     find_dependency(spot MODULE QUIET)
 endif()
+
+# Add optional dependent library includes based on their non-portable variable directories (best effort).
+foreach(_dir @FLANN_INCLUDE_DIRS@;@SPOT_INCLUDE_DIRS@;@TRIANGLE_INCLUDE_DIR@;@FCL_INCLUDE_DIRS@;@PQP_INCLUDE_DIR@;@ASSIMP_INCLUDE_DIRS@;@OPENGL_INCLUDE_DIR@)
+    if(_dir)
+        list(APPEND OMPL_INCLUDE_DIRS "${_dir}")
+    endif()
+endforeach()
+list(REMOVE_DUPLICATES OMPL_INCLUDE_DIRS)
+set(OMPL_INCLUDE_DIRS "${OMPL_INCLUDE_DIRS}" CACHE STRING "Include path for OMPL and its dependencies - DEPRECATED")
+
+

--- a/omplConfig.cmake.in
+++ b/omplConfig.cmake.in
@@ -19,7 +19,6 @@ set(OMPL_MAJOR_VERSION @PROJECT_VERSION_MAJOR@)
 set(OMPL_MINOR_VERSION @PROJECT_VERSION_MINOR@)
 set(OMPL_PATCH_VERSION @PROJECT_VERSION_PATCH@)
 set_and_check(OMPL_INCLUDE_DIRS @PACKAGE_INCLUDE_INSTALL_DIR@)
-set_and_check(OMPL_LIBRARIES @PACKAGE_LIB_INSTALL_DIR@)
 
 include ("${CMAKE_CURRENT_LIST_DIR}/omplExport.cmake" )
 include(CMakeFindDependencyMacro)
@@ -32,6 +31,7 @@ if(Boost_FOUND)
     endforeach()
 endif()
 find_dependency(Eigen3 REQUIRED)
+list(APPEND OMPL_INCLUDE_DIRS @EIGEN3_INCLUDE_DIRS@)
 
 # Add OMPL's find modules to the search path so consumers can also find them.
 list(APPEND CMAKE_MODULE_PATH ${CMAKE_CURRENT_LIST_DIR})
@@ -61,7 +61,7 @@ if(@OMPL_HAVE_SPOT@) # if(OMPL_HAVE_SPOT)
 endif()
 
 # Add optional dependent library includes based on their non-portable variable directories (best effort).
-foreach(_dir @FLANN_INCLUDE_DIRS@;@SPOT_INCLUDE_DIRS@;@TRIANGLE_INCLUDE_DIR@;@FCL_INCLUDE_DIRS@;@PQP_INCLUDE_DIR@;@ASSIMP_INCLUDE_DIRS@;@OPENGL_INCLUDE_DIR@)
+foreach(_dir @FLANN_INCLUDE_DIRS@;@SPOT_INCLUDE_DIRS@;@Triangle_INCLUDE_DIR@;@FCL_INCLUDE_DIRS@;@PQP_INCLUDE_DIR@;@ASSIMP_INCLUDE_DIRS@;@OPENGL_INCLUDE_DIR@)
     if(_dir)
         list(APPEND OMPL_INCLUDE_DIRS "${_dir}")
     endif()
@@ -69,4 +69,25 @@ endforeach()
 list(REMOVE_DUPLICATES OMPL_INCLUDE_DIRS)
 set(OMPL_INCLUDE_DIRS "${OMPL_INCLUDE_DIRS}" CACHE STRING "Include path for OMPL and its dependencies - DEPRECATED")
 
+# Add optional dependent libraries based on their non-portable library absolute paths (best effort).
+find_library(OMPL_LIBRARIES NAMES ompl
+    PATHS "${PACKAGE_PREFIX_DIR}/lib" NO_DEFAULT_PATH)
+foreach(_lib @Boost_SERIALIZATION_LIBRARY@;@Boost_FILESYSTEM_LIBRARY@;@Boost_SYSTEM_LIBRARY@;@SPOT_LIBRARIES@)
+    if(_lib)
+        list(APPEND OMPL_LIBRARIES "${_lib}")
+    endif()
+endforeach()
+
+# Set OMPL_LIBRARY_DIRS for backward compatibility
+set_and_check(OMPL_LIBRARY_DIRS "@PACKAGE_LIB_INSTALL_DIR@")
+foreach(_dir @FLANN_LIBRARY_DIRS@;@SPOT_LIBRARY_DIRS@;@FCL_LIBRARY_DIRS@;@ASSIMP_LIBRARY_DIRS@)
+    if(_dir)
+        list(APPEND OMPL_LIBRARY_DIRS "${_dir}")
+    endif()
+endforeach()
+list(REMOVE_DUPLICATES OMPL_LIBRARY_DIRS)
+set(OMPL_LIBRARY_DIRS "${OMPL_LIBRARY_DIRS}" CACHE STRING "Library path for OMPL and its dependencies - DEPRECATED")
+
+include(FindPackageHandleStandardArgs)
+find_package_handle_standard_args(ompl DEFAULT_MSG OMPL_INCLUDE_DIRS OMPL_LIBRARY_DIRS OMPL_LIBRARIES)
 

--- a/tests/cmake_export/CMakeLists.txt
+++ b/tests/cmake_export/CMakeLists.txt
@@ -1,7 +1,9 @@
 cmake_minimum_required(VERSION 3.12)
 project(ompl_cmake_export LANGUAGES CXX)
 
-find_package(ompl REQUIRED)
+# Use NO_SYSTEM_ENVIRONMENT_PATH to avoid finding /opt/ros/humble/include/ompl-1.6
+# We only want ompl from the prefix path.
+find_package(ompl REQUIRED NO_SYSTEM_ENVIRONMENT_PATH)
 
 message(STATUS "Legacy Variables:")
 message("* OMPL_FOUND: ${OMPL_FOUND}")

--- a/tests/cmake_export/CMakeLists.txt
+++ b/tests/cmake_export/CMakeLists.txt
@@ -2,5 +2,22 @@ cmake_minimum_required(VERSION 3.12)
 project(ompl_cmake_export LANGUAGES CXX)
 
 find_package(ompl REQUIRED)
+
+message(STATUS "Legacy Variables:")
+message("* OMPL_FOUND: ${OMPL_FOUND}")
+message("* ompl_FOUND: ${ompl_FOUND}")
+message("* OMPL_INCLUDE_DIRS: ${OMPL_INCLUDE_DIRS}")
+message("* OMPL_LIBRARIES: ${OMPL_LIBRARIES}")
+message("* OMPLAPP_LIBRARIES: ${OMPLAPP_LIBRARIES}")
+message("* OMPL_VERSION: ${OMPL_VERSION}")
+message("* OMPL_MAJOR_VERSION: ${OMPL_MAJOR_VERSION}")
+message("* OMPL_MINOR_VERSION: ${OMPL_MINOR_VERSION}")
+message("* OMPL_PATCH_VERSION: ${OMPL_PATCH_VERSION}")
+
+include(CMakePrintHelpers)
+cmake_print_properties(
+    TARGETS ompl::ompl PROPERTIES
+    LOCATION INTERFACE_INCLUDE_DIRECTORIES INCLUDE_DIRECTORIES)
+
 add_executable(main main.cpp)
 target_link_libraries(main PRIVATE ompl::ompl)

--- a/tests/cmake_export/README.md
+++ b/tests/cmake_export/README.md
@@ -11,14 +11,3 @@ cd tests/cmake_export
 cmake -B build -DCMAKE_INSTALL_PREFIX=../../install
 cmake --build build
 ```
-
-
-add_subdirectory(ompl)
-target_include_directories(ompl
-  PUBLIC
-    "$<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}>"
-    "$<BUILD_INTERFACE:${CMAKE_CURRENT_BINARY_DIR}>"
-    $<${BUILD_INTERFACE}:${CMAKE_INSTALL_INCLUDEDIR}/foobar)
-  # The install include directory will be set during install().
--- Configuring done
-gmake: *** [Makefile:948: cmake_check_build_system] Segmentation fault (core dumped)

--- a/tests/cmake_export/README.md
+++ b/tests/cmake_export/README.md
@@ -11,3 +11,14 @@ cd tests/cmake_export
 cmake -B build -DCMAKE_INSTALL_PREFIX=../../install
 cmake --build build
 ```
+
+
+add_subdirectory(ompl)
+target_include_directories(ompl
+  PUBLIC
+    "$<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}>"
+    "$<BUILD_INTERFACE:${CMAKE_CURRENT_BINARY_DIR}>"
+    $<${BUILD_INTERFACE}:${CMAKE_INSTALL_INCLUDEDIR}/foobar)
+  # The install include directory will be set during install().
+-- Configuring done
+gmake: *** [Makefile:948: cmake_check_build_system] Segmentation fault (core dumped)


### PR DESCRIPTION
# Purpose

The legacy variables that historically used with ompl have been broken on `main` for a few months as a result of #1067. 
These variables were not tested for validity in CI, so there was nothing to enforce regressions.
These should not be broken because OMPL did not bump its major version.
This has caused projects such as MoveIt that are consuming the `main` branch of `ompl` to be forced to linking `ompl::ompl`. We want to recommend the new targets, but do our best not to break older workflows.

This PR does a best-effort attempt to bring them back. 

# Details

The legacy variables have some known issues which is why we want to recommend target-based linkage to OMPL consumers. 
One concern is the installation is not portable to systems with dependencies installed in other locations, as seen [here](https://github.com/ompl/ompl/pull/1067#discussion_r1753001282). The PR does not attempt to solve those pre-existing problems. 

# Behavior

Here's what the old OMPL would set up for the "legacy" variables.
```
--  OMPL_FOUND: TRUE
--  OMPL_INCLUDE_DIRS: /home/ryan/Dev/moveit_ws/install/ompl/include/ompl-1.6;/usr/include;/usr/include/eigen3
--  OMPL_LIBRARY_DIRS: /home/ryan/Dev/moveit_ws/install/ompl/lib;/usr/lib/x86_64-linux-gnu;/usr/lib
--  OMPL_LIBRARIES: /home/ryan/Dev/moveit_ws/install/ompl/lib/libompl.so;optimized;/usr/lib/x86_64-linux-gnu/libboost_serialization.so.1.74.0;debug;/usr/lib/x86_64-linux-gnu/libboost_serialization.so;optimized;/usr/lib/x86_64-linux-gnu/libboost_filesystem.so.1.74.0;debug;/usr/lib/x86_64-linux-gnu/libboost_filesystem.so;optimized;/usr/lib/x86_64-linux-gnu/libboost_system.so.1.74.0;debug;/usr/lib/x86_64-linux-gnu/libboost_system.so
--  ompl_FOUND: TRUE
```
Here's what you get on ompl `main`:
```
-- OMPL_FOUND: 
--  OMPL_INCLUDE_DIRS: /home/ryan/Dev/moveit_ws/install/ompl/include/ompl-1.6;/usr/include
--  OMPL_LIBRARY_DIRS: /home/ryan/Dev/moveit_ws/install/ompl/lib
--  OMPL_LIBRARIES: /home/ryan/Dev/moveit_ws/install/ompl/lib/libompl.so
-- ompl_FOUND: 1
```

And, here's what you get on this branch, which restores the same behavior as ompl, aside from missing `OMPL_LIBRARY_DIRS` of `usr/lib/x86_64-linux-gnu;/usr/lib` and the switch to exported namespace targets which should work the same. Given those are standard paths and target names, I think this should work for everyone!
```
--  OMPL_FOUND: TRUE
--  OMPL_INCLUDE_DIRS: /home/ryan/Dev/moveit_ws/install/ompl/include/ompl-1.6;/usr/include;/usr/include/eigen3
--  OMPL_LIBRARY_DIRS: /home/ryan/Dev/moveit_ws/install/ompl/lib
--  OMPL_LIBRARIES: /home/ryan/Dev/moveit_ws/install/ompl/lib/libompl.so;Boost::serialization;Boost::filesystem;Boost::system
--  ompl_FOUND: TRUE
```

# Expectations

Users should be able to build and link to ompl, follow the instructions here, and compile code against OMPL, assuming the build and install environment have the same paths to includes and libraries. 

We should be able to take a version of moveit from a year ago and build it against this PR with no issues before merging. I welcome other users try it out and share your results. I tested `moveit` on `humble` branch at hash 8d89f73df33a0ca1460132b272b7ea367b23ca53 and it works for me! 

# Considerations

We could add another CMake task in CI to check you can link to ompl and compile a minimal example using the deprecated variables.


