### PR TITLE
Fix various Python wheel generation issues

### DIFF
--- a/.github/workflows/before_all.sh
+++ b/.github/workflows/before_all.sh
@@ -22,5 +22,5 @@ elif [ "${build_os}" == "Darwin" ]; then
         eigen \
         pypy3 \
         castxml \
-        llvm@16
+        llvm@18
 fi

--- a/.github/workflows/before_build.sh
+++ b/.github/workflows/before_build.sh
@@ -3,7 +3,7 @@
 set -eux
 
 # Dependency versions.
-castxml_version="0.6.2" # version specifier for Linux only
+castxml_version="0.6.8" # version specifier for Linux only
 boost_version="1.86.0"
 
 # Collect some information about the build target.

--- a/.github/workflows/before_build.sh
+++ b/.github/workflows/before_build.sh
@@ -36,9 +36,11 @@ install_boost() {
 install_castxml() {
     curl -L "https://github.com/CastXML/CastXML/archive/refs/tags/v${castxml_version}.tar.gz" | tar xz
 
+    clang_resource_dir=$(clang -print-resource-dir)
+
     pushd "CastXML-${castxml_version}"
     mkdir -p build && cd build
-    cmake -DCMAKE_BUILD_TYPE=Release ..
+    cmake -DCMAKE_BUILD_TYPE=Release -DCLANG_RESOURCE_DIR="${clang_resource_dir}" ..
     cmake --build .
     make install
     popd

--- a/.github/workflows/before_build.sh
+++ b/.github/workflows/before_build.sh
@@ -4,7 +4,7 @@ set -eux
 
 # Dependency versions.
 castxml_version="0.6.2" # version specifier for Linux only
-boost_version="1.83.0"
+boost_version="1.86.0"
 
 # Collect some information about the build target.
 build_os="$(uname)"
@@ -20,7 +20,11 @@ install_boost() {
     # multiple on the host system.
     python_include_path=$(python3 -c "from sysconfig import get_paths as gp; print(gp()['include'])")
     echo "using python : ${python_version} : : ${python_include_path} ;" > "$HOME/user-config.jam"
-    pip3 install numpy
+
+    # TODO: As of boost-1.86.0, numpy>=2.0 is not supported.
+    # See: https://github.com/boostorg/python/issues/431
+    pip3 install "numpy<2.0"
+
     ./bootstrap.sh
     sudo ./b2 "${b2_args[@]}" \
         --with-serialization \

--- a/.github/workflows/wheels.yaml
+++ b/.github/workflows/wheels.yaml
@@ -14,7 +14,7 @@ jobs:
         os: [ubuntu-22.04, macos-13]
         arch: [x86_64]
         include:
-          - os: macos-13
+          - os: macos-14
             arch: arm64
     steps:
       - name: Check out repository code

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,6 +2,12 @@ cmake_minimum_required(VERSION 3.12)
 project(ompl VERSION 1.6.0 LANGUAGES CXX)
 set(OMPL_ABI_VERSION 17)
 
+# Use the FindBoost provided by CMake, rather than the one provided by Boost
+# (for CMake >=3.30).
+if (${CMAKE_VERSION} VERSION_GREATER_EQUAL "3.30")
+    cmake_policy(SET CMP0167 OLD)
+endif()
+
 # set the default build type
 if (NOT CMAKE_BUILD_TYPE)
     # By default, use Release mode

--- a/CMakeModules/Findcastxml.cmake
+++ b/CMakeModules/Findcastxml.cmake
@@ -7,24 +7,8 @@ endif()
 if (CASTXML)
     set(CASTXMLCFLAGS "-std=c++17 -fsized-deallocation $ENV{CASTXMLCFLAGS}")
 
-    if (CMAKE_CXX_COMPILER_ID STREQUAL "GNU")
-        set(CASTXMLCOMPILER "g++")
-    else()
-        if(CMAKE_CXX_COMPILER_ID MATCHES "^(Apple)?Clang$")
-            set(CASTXMLCOMPILER "clang++")
-        else()
-            if (MSVC)
-                set(CASTXMLCOMPILER "msvc8")
-            endif()
-        endif()
-    endif()
-
-    # workaround for problem between Xcode and castxml on Mojave
-    # if (APPLE AND CMAKE_CXX_COMPILER MATCHES "/Applications/Xcode.app/Contents/Developer/Toolchains/.*")
-    #     set(CASTXMLCOMPILER_PATH "/usr/bin/clang++")
-    # else()
+    set(CASTXMLCOMPILER "${CMAKE_CXX_COMPILER_ID}")
     set(CASTXMLCOMPILER_PATH "${CMAKE_CXX_COMPILER}")
-        # endif()
 
     set(CASTXMLCONFIG "[xml_generator]
 xml_generator=castxml
@@ -36,8 +20,6 @@ compiler_path=${CASTXMLCOMPILER_PATH}
     set(_candidate_include_path
         "${CMAKE_SOURCE_DIR}/src"
         "${CMAKE_SOURCE_DIR}/ompl/src"
-        "${OMPL_INCLUDE_DIRS}"
-        "${OMPLAPP_INCLUDE_DIRS}"
         "${PYTHON_INCLUDE_DIRS}"
         "${Boost_INCLUDE_DIR}"
         "${ASSIMP_INCLUDE_DIRS}"

--- a/CMakeModules/Findcastxml.cmake
+++ b/CMakeModules/Findcastxml.cmake
@@ -34,6 +34,8 @@ compiler_path=${CASTXMLCOMPILER_PATH}
 ")
 
     set(_candidate_include_path
+        "${CMAKE_SOURCE_DIR}/src"
+        "${CMAKE_SOURCE_DIR}/ompl/src"
         "${OMPL_INCLUDE_DIRS}"
         "${OMPLAPP_INCLUDE_DIRS}"
         "${PYTHON_INCLUDE_DIRS}"

--- a/py-bindings/pyproject.toml
+++ b/py-bindings/pyproject.toml
@@ -3,7 +3,7 @@ requires = [
     "setuptools>=42",
     "cmake>=3.18",
     "ninja",
-    "pygccxml==2.2.1",
+    "pygccxml",
     "numpy",
     # Need latest commit for this PR with Mac fixes:
     # https://github.com/ompl/pyplusplus/pull/1

--- a/py-bindings/setup.py
+++ b/py-bindings/setup.py
@@ -49,6 +49,7 @@ class CMakeBuild(build_ext):
         # EXAMPLE_VERSION_INFO shows you how to pass a value into the C++ code
         # from Python.
         cmake_args = [
+            "-DCMAKE_CXX_COMPILER=/usr/bin/clang++",  # Force Clang for castxml
             f"-DCMAKE_LIBRARY_OUTPUT_DIRECTORY={extdir}{os.sep}",
             f"-DPYTHON_EXEC={sys.executable}",
             f"-DPYTHON_INCLUDE_DIRS={get_paths()['include']}",

--- a/py-bindings/setup.py
+++ b/py-bindings/setup.py
@@ -108,8 +108,8 @@ class CMakeBuild(build_ext):
         if sys.platform.startswith("darwin"):
             # Search these paths to try to find the clang++ binary.
             potential_clang_paths = [
-                "/usr/local/opt/llvm@16/bin/clang++",
-                "/opt/homebrew/opt/llvm@16/bin/clang++",
+                "/usr/local/opt/llvm@18/bin/clang++",
+                "/opt/homebrew/opt/llvm@18/bin/clang++",
             ]
             clang_bin_path = next(
                 filter(lambda p: Path(p).exists(), potential_clang_paths), None

--- a/py-bindings/setup.py
+++ b/py-bindings/setup.py
@@ -105,8 +105,24 @@ class CMakeBuild(build_ext):
                 build_args += ["--config", cfg]
 
         if sys.platform.startswith("darwin"):
+            # Search these paths to try to find the clang++ binary.
+            potential_clang_paths = [
+                "/usr/local/opt/llvm@16/bin/clang++",
+                "/opt/homebrew/opt/llvm@16/bin/clang++",
+            ]
+            clang_bin_path = next(
+                filter(lambda p: Path(p).exists(), potential_clang_paths), None
+            )
+
+            if clang_bin_path is None:
+                print(
+                    "Could not find clang++ binary. Search paths:",
+                    potential_clang_paths,
+                )
+                sys.exit(1)
+
             # TODO: Move these out to configuration
-            cmake_args += ["-DCMAKE_CXX_COMPILER=/usr/local/opt/llvm@16/bin/clang++"]
+            cmake_args += [f"-DCMAKE_CXX_COMPILER={clang_bin_path}"]
             cmake_args += ["-DCMAKE_OSX_DEPLOYMENT_TARGET=13.0"]
 
             # Cross-compile support for macOS - respect ARCHFLAGS if set

--- a/py-bindings/setup.py
+++ b/py-bindings/setup.py
@@ -5,6 +5,7 @@ import re
 import subprocess
 import sys
 import site
+import shutil
 from pathlib import Path
 from sysconfig import get_paths
 
@@ -49,7 +50,7 @@ class CMakeBuild(build_ext):
         # EXAMPLE_VERSION_INFO shows you how to pass a value into the C++ code
         # from Python.
         cmake_args = [
-            "-DCMAKE_CXX_COMPILER=/usr/bin/clang++",  # Force Clang for castxml
+            f"-DCMAKE_CXX_COMPILER={shutil.which('clang++')}",  # Force Clang for castxml
             f"-DCMAKE_LIBRARY_OUTPUT_DIRECTORY={extdir}{os.sep}",
             f"-DPYTHON_EXEC={sys.executable}",
             f"-DPYTHON_INCLUDE_DIRS={get_paths()['include']}",

--- a/py-bindings/setup.py
+++ b/py-bindings/setup.py
@@ -106,24 +106,7 @@ class CMakeBuild(build_ext):
                 build_args += ["--config", cfg]
 
         if sys.platform.startswith("darwin"):
-            # Search these paths to try to find the clang++ binary.
-            potential_clang_paths = [
-                "/usr/local/opt/llvm@18/bin/clang++",
-                "/opt/homebrew/opt/llvm@18/bin/clang++",
-            ]
-            clang_bin_path = next(
-                filter(lambda p: Path(p).exists(), potential_clang_paths), None
-            )
-
-            if clang_bin_path is None:
-                print(
-                    "Could not find clang++ binary. Search paths:",
-                    potential_clang_paths,
-                )
-                sys.exit(1)
-
-            # TODO: Move these out to configuration
-            cmake_args += [f"-DCMAKE_CXX_COMPILER={clang_bin_path}"]
+            # TODO: Move this out to configuration
             cmake_args += ["-DCMAKE_OSX_DEPLOYMENT_TARGET=13.0"]
 
             # Cross-compile support for macOS - respect ARCHFLAGS if set

--- a/src/ompl/tools/config/SelfConfig.h
+++ b/src/ompl/tools/config/SelfConfig.h
@@ -37,7 +37,6 @@
 #ifndef OMPL_TOOLS_SELF_CONFIG_
 #define OMPL_TOOLS_SELF_CONFIG_
 
-#include "ompl/config.h"
 #include "ompl/base/Goal.h"
 #include "ompl/base/Planner.h"
 #include "ompl/base/SpaceInformation.h"


### PR DESCRIPTION
- Fix numpy at <2.0 because Boost-Python does not support numpy>=2.0 as of Boost-1.86. See this issue; the fix will likely be included in 1.87: https://github.com/boostorg/python/issues/431
- Use the new Github Mac M1 runner when building the arm64 wheel. This makes that target a native build instead of a cross-compile.
  - This requires some additional logic to find the system clang++ executable. I don't have a Mac so I can't test a better solution, but it could probably be cleaned up.
- Work around a `error: no member named 'piecewise_construct' in namespace 'std';` error on MacOS by bumping Boost dependency version. See: https://github.com/NREL/OpenStudio/issues/5229
- Fix a CastXML build error complaining about missing the clang resource directory.
- Silence a CMake warning when using CMake>=3.30 caused by the removal of `FindBoost` (https://cmake.org/cmake/help/latest/policy/CMP0167.html)

@zkingston I also pulled in your changes to fix an error in the Python binding generation due to the recent changes in include paths. These affected the CI wheel generation too, but I can wait and rebase if you want to merge those separately.

Follow here to see a successful CI build: https://github.com/kylc/ompl/actions/runs/10998657273