### PR TITLE
Fix AIT*/EIT* not respecting termination condition when there are no valid samples

### DIFF
--- a/src/ompl/geometric/planners/informedtrees/aitstar/src/ImplicitGraph.cpp
+++ b/src/ompl/geometric/planners/informedtrees/aitstar/src/ImplicitGraph.cpp
@@ -267,8 +267,7 @@ namespace ompl
                     // Allocate a state sampler if we have at least one start and one goal.
                     if (!startVertices_.empty() && !goalVertices_.empty())
                     {
-                        sampler_ = objective_->allocInformedStateSampler(problemDefinition_,
-                                                                         std::numeric_limits<unsigned int>::max());
+                        sampler_ = objective_->allocInformedStateSampler(problemDefinition_, 100u);
                     }
                 }
 

--- a/src/ompl/geometric/planners/informedtrees/aitstar/src/ImplicitGraph.cpp
+++ b/src/ompl/geometric/planners/informedtrees/aitstar/src/ImplicitGraph.cpp
@@ -338,7 +338,8 @@ namespace ompl
                         ++numSampledStates_;
 
                         // Check if the sample is valid.
-                        foundValidSample = spaceInformation_->getStateValidityChecker()->isValid(newSamples_.back()->getState());
+                        foundValidSample =
+                            spaceInformation_->getStateValidityChecker()->isValid(newSamples_.back()->getState());
                     } while (!foundValidSample && !terminationCondition);
 
                     // The sample can be invalid if the termination condition is met.

--- a/src/ompl/geometric/planners/informedtrees/eitstar/src/RandomGeometricGraph.cpp
+++ b/src/ompl/geometric/planners/informedtrees/eitstar/src/RandomGeometricGraph.cpp
@@ -208,8 +208,7 @@ namespace ompl
                     do
                     {
                         // Get a new goal. If there are none, or the underlying state is invalid this will be a nullptr.
-                        const auto newGoalState =
-                            inputStates->nextGoal(terminationCondition);
+                        const auto newGoalState = inputStates->nextGoal(terminationCondition);
 
                         // If there was a new valid goal, register it as such and remember that a goal has been added.
                         if (static_cast<bool>(newGoalState))
@@ -313,8 +312,7 @@ namespace ompl
                     // Allocate a state sampler if we have at least one start and one goal.
                     if (!startStates_.empty() && !goalStates_.empty())
                     {
-                        sampler_ =
-                            objective_->allocInformedStateSampler(problem_, 100u);
+                        sampler_ = objective_->allocInformedStateSampler(problem_, 100u);
                     }
                 }
 
@@ -494,7 +492,8 @@ namespace ompl
                 whitelistedStates_.push_back(state);
             }
 
-            std::shared_ptr<State> RandomGeometricGraph::getNewSample(const ompl::base::PlannerTerminationCondition& terminationCondition)
+            std::shared_ptr<State>
+            RandomGeometricGraph::getNewSample(const ompl::base::PlannerTerminationCondition &terminationCondition)
             {
                 // Allocate a new state.
                 auto state = std::make_shared<State>(spaceInfo_, objective_);

--- a/src/ompl/geometric/planners/informedtrees/eitstar/src/RandomGeometricGraph.cpp
+++ b/src/ompl/geometric/planners/informedtrees/eitstar/src/RandomGeometricGraph.cpp
@@ -314,7 +314,7 @@ namespace ompl
                     if (!startStates_.empty() && !goalStates_.empty())
                     {
                         sampler_ =
-                            objective_->allocInformedStateSampler(problem_, std::numeric_limits<unsigned int>::max());
+                            objective_->allocInformedStateSampler(problem_, 100u);
                     }
                 }
 


### PR DESCRIPTION
Currently, both the AIT* and EIT* are initializing their Informed State Samplers' maxNumberCalls with `std::numeric_limits<unsigned int>::max()`. The maxNumberCalls will [determine the maximum number of tries the sampler will do to find a valid sample](https://github.com/ompl/ompl/blob/main/src/ompl/base/samplers/informed/src/RejectionInfSampler.cpp#L77-L96). So currently, if for some reason the sampler cannot find a valid sample (maybe because a PHS is way smaller than the full sampling space), it will try at most `std::numeric_limits<unsigned int>::max()` (~4.3 billion) times before returning to the planner. (In my experiments, I had a moveit plan taking 1000s when the maximum planning time was set to 50s)

As this value was already hard coded, I simply changed the value to 100, mainly because this is the default value used by [RRT*](https://github.com/ompl/ompl/blob/main/src/ompl/geometric/planners/rrt/RRTstar.h#L491). (Should this be exposed with a getter and a setter like RRT*?)

It would be better if the samplers also respected the termination conditions, but this change would require changing the ABI in a lot of places.