### PR TITLE
Update macOs version

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -12,7 +12,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-24.04, ubuntu-22.04, ubuntu-20.04, macos-12, windows-2022]
+        os: [ubuntu-24.04, ubuntu-22.04, ubuntu-20.04, macos-13, windows-2022]
 
     steps:
     - uses: actions/checkout@v4


### PR DESCRIPTION
the version of macos-12 has exceeded the support period on 16 Sep 2024. We proceed by changing the version to the oldest supported version "13 macos Ventura".