### PR TITLE
Save test planner data to different files

### DIFF
--- a/tests/base/planner_data.cpp
+++ b/tests/base/planner_data.cpp
@@ -523,8 +523,8 @@ BOOST_AUTO_TEST_CASE(Serialization)
 
     base::PlannerData data2(si);
     base::PlannerDataStorage storage;
-    storage.store(data, "testdata");
-    storage.load("testdata", data2);
+    storage.store(data, "testdata-base");
+    storage.load("testdata-base", data2);
 
     // Verify that data == data2
     BOOST_CHECK_EQUAL ( data2.numVertices(), states.size() );

--- a/tests/control/planner_data.cpp
+++ b/tests/control/planner_data.cpp
@@ -542,8 +542,8 @@ BOOST_AUTO_TEST_CASE(Serialization)
 
     control::PlannerData data2(si);
     control::PlannerDataStorage storage;
-    storage.store(data, "testdata");
-    storage.load("testdata", data2);
+    storage.store(data, "testdata-control");
+    storage.load("testdata-control", data2);
 
     // Verify that data == data2
     BOOST_CHECK_EQUAL ( data2.numVertices(), states.size() );


### PR DESCRIPTION
Fix: https://github.com/conda-forge/ompl-feedstock/issues/43#issuecomment-2502656357

I ran into this issue as well while debugging https://github.com/conda-forge/ompl-feedstock/issues/43, these two tests are storing/loading from the same file when ran in parallel.
