### PR TITLE
Override isMetricSpace to check if CompoundStateSpace's components are a metric spaces

### DIFF
--- a/src/ompl/base/StateSpace.h
+++ b/src/ompl/base/StateSpace.h
@@ -609,6 +609,8 @@ namespace ompl
 
             bool isHybrid() const override;
 
+            bool isMetricSpace() const override;
+
             /** @name Management of contained subspaces
                 @{ */
 

--- a/src/ompl/base/src/StateSpace.cpp
+++ b/src/ompl/base/src/StateSpace.cpp
@@ -901,6 +901,12 @@ bool ompl::base::CompoundStateSpace::isHybrid() const
     return c && d;
 }
 
+bool ompl::base::CompoundStateSpace::isMetricSpace() const
+{
+    return std::all_of(components_.begin(), components_.end(),
+                       [](const StateSpacePtr &component) { return component->isMetricSpace(); });
+}
+
 unsigned int ompl::base::CompoundStateSpace::getSubspaceCount() const
 {
     return componentCount_;

--- a/tests/base/state_spaces.cpp
+++ b/tests/base/state_spaces.cpp
@@ -419,6 +419,30 @@ BOOST_AUTO_TEST_CASE(Compound_Simple)
     BOOST_CHECK(t->includes(t));
 }
 
+BOOST_AUTO_TEST_CASE(Compound_IsMetric)
+{
+    auto d = std::make_shared<base::DubinsStateSpace>();
+
+    auto real_state_space_1 = std::make_shared<base::RealVectorStateSpace>(2);
+    real_state_space_1->setBounds(-3, 3);
+
+    auto real_state_space_2 = std::make_shared<base::RealVectorStateSpace>(4);
+    real_state_space_2->setBounds(-3, 3);
+
+    base::RealVectorBounds bounds2(2);
+    bounds2.setLow(-3);
+    bounds2.setHigh(3);
+    d->setBounds(bounds2);
+
+    auto rs = real_state_space_1 + real_state_space_2;
+    rs->setup();
+    BOOST_CHECK(rs->isMetricSpace());
+
+    auto n = d + real_state_space_1 + real_state_space_2;
+    n->setup();
+    BOOST_CHECK(!n->isMetricSpace());
+}
+
 BOOST_AUTO_TEST_CASE(Torus_Simple)
 {
     auto m(std::make_shared<base::TorusStateSpace>());


### PR DESCRIPTION
Not sure if I'm missing something, but shouldn't isMetricSpace() simply check if all components are metric spaces? The current implementation always return true.