### PR TITLE
Bump MacOS target version + modernize Python targets

### DIFF
--- a/.github/workflows/wheels.yaml
+++ b/.github/workflows/wheels.yaml
@@ -33,6 +33,7 @@ jobs:
           # depending on your patience. For example:
           CIBW_BUILD: cp3{10,11,12}-macosx_{x86_64,arm64} cp3{7,8,9,10,11,12}-manylinux_x86_64
           CIBW_BUILD_VERBOSITY: 1
+          CIBW_ENVIRONMENT_MACOS: MACOSX_DEPLOYMENT_TARGET="14.0"
 
       - uses: actions/upload-artifact@v4
         with:

--- a/.github/workflows/wheels.yaml
+++ b/.github/workflows/wheels.yaml
@@ -31,7 +31,7 @@ jobs:
           OMPL_BUILD_ARCH: ${{ matrix.arch }}
           # NOTE: Many combinations of OS, arch, and Python version can be built
           # depending on your patience. For example:
-          CIBW_BUILD: cp3{10,11,12}-macosx_{x86_64,arm64} cp3{7,8,9,10,11,12}-manylinux_x86_64
+          CIBW_BUILD: cp3{10,11,12,13}-macosx_{x86_64,arm64} cp3{9,10,11,12,13}-manylinux_x86_64
           CIBW_BUILD_VERBOSITY: 1
           CIBW_ENVIRONMENT_MACOS: MACOSX_DEPLOYMENT_TARGET="14.0"
 

--- a/py-bindings/setup.py
+++ b/py-bindings/setup.py
@@ -108,7 +108,7 @@ class CMakeBuild(build_ext):
 
         if sys.platform.startswith("darwin"):
             # TODO: Move this out to configuration
-            cmake_args += ["-DCMAKE_OSX_DEPLOYMENT_TARGET=13.0"]
+            cmake_args += ["-DCMAKE_OSX_DEPLOYMENT_TARGET=14.0"]
 
             # Cross-compile support for macOS - respect ARCHFLAGS if set
             archs = re.findall(r"-arch (\S+)", os.environ.get("ARCHFLAGS", ""))


### PR DESCRIPTION
- Bump `DCMAKE_OSX_DEPLOYMENT_TARGET` to avoid build failure of `Set the environment variable 'MACOSX_DEPLOYMENT_TARGET=14.0' to update minimum supported macOS for this wheel`, introduced in https://github.com/ompl/ompl/commit/fca3d5f70bec3a15f100f40ebe088506360ed25f.
- Remove wheel builds for EOL Python versions and add Python 13.

Successful CI run here: https://github.com/kylc/ompl/actions/runs/13128098253