### PR TITLE
Fix failing macOS tests by including CompilerSettings in test target.

### DIFF
--- a/tests/cmake_export/CMakeLists.txt
+++ b/tests/cmake_export/CMakeLists.txt
@@ -1,6 +1,8 @@
 cmake_minimum_required(VERSION 3.12)
 project(ompl_cmake_export LANGUAGES CXX)
 
+include("${CMAKE_CURRENT_LIST_DIR}/../../CMakeModules/CompilerSettings.cmake")
+
 find_package(ompl REQUIRED)
 add_executable(main main.cpp)
 target_link_libraries(main PRIVATE ompl::ompl)


### PR DESCRIPTION
Specifically, ensures that `CXX_STANDARD=17`. Otherwise, some OMPL headers will fail to build on compilers that use an older C++ standard by default.

Fixes compile errors in test targets on MacOS in CI.