### PR TITLE
cibuildwheel 2.23.0

### DIFF
--- a/.github/workflows/wheels.yaml
+++ b/.github/workflows/wheels.yaml
@@ -36,7 +36,7 @@ jobs:
           submodules: 'recursive'
 
       - name: Build wheels
-        uses: pypa/cibuildwheel@v2.22.0
+        uses: pypa/cibuildwheel@v2.23.0
         with:
           package-dir: py-bindings
         env:


### PR DESCRIPTION
This pull request includes an update to the `.github/workflows/wheels.yaml` file to use the latest version of the `cibuildwheel` action.

* [`.github/workflows/wheels.yaml`](diffhunk://#diff-91b9b589616af36da34e6a0314171ea68cc16b399915d9630a20ea04eb8e99f5L39-R39): Updated `cibuildwheel` action from version `v2.22.0` to `v2.23.0`.

support native arm: 
![image](https://github.com/user-attachments/assets/72e1e98d-51c7-45b3-8f67-8f7176726253)
