### PR TITLE
Fix dll_loader in py-bindings

### DIFF
--- a/py-bindings/ompl/__init__.py
+++ b/py-bindings/ompl/__init__.py
@@ -3,6 +3,7 @@ def dll_loader(lib, path):
     from os.path import isfile
     import ctypes
     from ctypes.util import find_library
+    import os
     import site
 
     # First, try the user-specified path
@@ -19,6 +20,8 @@ def dll_loader(lib, path):
     # Fallback to site-packages
     if not isfile(fpath):
         for sitepackagedir in site.getsitepackages():
+            if not os.path.exists(sitepackagedir):
+                continue
             for _fname in os.listdir(sitepackagedir):
                 _fpath = os.path.join(sitepackagedir, _fname)
                 if isfile(_fpath):


### PR DESCRIPTION
Fix library import issue when using virtual environments

- Add missing import.
- Add check site package dir exists.

Fixes: https://github.com/ompl/ompl/issues/1253