### PR TITLE
Enable Python bindings for Dubins path segments 

### DIFF
--- a/py-bindings/bindings_generator.py.in
+++ b/py-bindings/bindings_generator.py.in
@@ -218,3 +218,6 @@ class code_generator_t(object):
 
     def add_function_wrapper(self, FT, func_name, func_doc):
         self.mb.add_registration_code('PYREGISTER_FUNCTION(%s,%s,"%s")' % (FT, func_name, func_doc))
+
+    def add_optional_wrapper(self, T):
+        self.mb.add_registration_code('PYREGISTER_OPTIONAL(%s)' % (T))

--- a/py-bindings/generate_bindings.py
+++ b/py-bindings/generate_bindings.py
@@ -514,6 +514,11 @@ void __set%(member_function_camelize)s(%(cls)s* self, double %(member_function)s
                 arg_types=['::std::ostream &']).exclude()
         except declaration_not_found_t:
             pass
+        
+        # add wrappers for std::optional types
+        self.add_optional_wrapper('ompl::base::OwenStateSpace::PathType')
+        self.add_optional_wrapper('ompl::base::VanaStateSpace::PathType')
+        self.add_optional_wrapper('ompl::base::VanaOwenStateSpace::PathType')
 
 
 class ompl_control_generator_t(code_generator_t):

--- a/py-bindings/generate_bindings.py
+++ b/py-bindings/generate_bindings.py
@@ -305,9 +305,11 @@ void __set%(member_function_camelize)s(%(cls)s* self, double %(member_function)s
     })
 
         # I don't know how to export a C-style array of an enum type
-        for stype in ['Dubins', 'ReedsShepp']:
+        for stype in ['ReedsShepp']:
             self.ompl_ns.enumeration(stype + 'PathSegmentType').exclude()
             self.ompl_ns.class_(stype + 'Path').exclude()
+            
+        for stype in ['Dubins', 'ReedsShepp']:
             self.ompl_ns.class_(stype + "StateSpace").member_function(
                 stype[0].lower() + stype[1:],
                 arg_types=[
@@ -315,6 +317,11 @@ void __set%(member_function_camelize)s(%(cls)s* self, double %(member_function)s
                     "::ompl::base::State const *",
                 ],
             ).exclude()
+
+        # access to public member variables
+        self.ompl_ns.class_('DubinsPath').variable("type_").include()
+        self.ompl_ns.class_('DubinsPath').variable("length_").include()
+        self.ompl_ns.class_('DubinsPath').variable("reverse_").include()
 
         # Disable the other dubins overload
         self.ompl_ns.class_("DubinsStateSpace").member_function(
@@ -519,7 +526,6 @@ void __set%(member_function_camelize)s(%(cls)s* self, double %(member_function)s
         self.add_optional_wrapper('ompl::base::OwenStateSpace::PathType')
         self.add_optional_wrapper('ompl::base::VanaStateSpace::PathType')
         self.add_optional_wrapper('ompl::base::VanaOwenStateSpace::PathType')
-
 
 class ompl_control_generator_t(code_generator_t):
     def __init__(self):

--- a/py-bindings/ompl_py_base.h
+++ b/py-bindings/ompl_py_base.h
@@ -56,6 +56,7 @@
 #include "ompl/base/Goal.h"
 #include "ompl/base/PlannerData.h"
 #include "py_std_function.hpp"
+#include "py_std_optional.hpp"
 
 #define DeclareStateType(T) \
     inline int __dummy##T() \

--- a/py-bindings/py_std_optional.hpp
+++ b/py-bindings/py_std_optional.hpp
@@ -1,0 +1,78 @@
+/*********************************************************************
+ * Software License Agreement (BSD License)
+ *
+ *  Copyright (c) 2024,  
+ *  All rights reserved.
+ *
+ *  Redistribution and use in source and binary forms, with or without
+ *  modification, are permitted provided that the following conditions
+ *  are met:
+ *
+ *   * Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *   * Redistributions in binary form must reproduce the above
+ *     copyright notice, this list of conditions and the following
+ *     disclaimer in the documentation and/or other materials provided
+ *     with the distribution.
+ *   * Neither the name of the Rice University nor the names of its
+ *     contributors may be used to endorse or promote products derived
+ *     from this software without specific prior written permission.
+ *
+ *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ *  "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ *  LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ *  FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ *  COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ *  INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ *  BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ *  LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ *  CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ *  LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ *  ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ *  POSSIBILITY OF SUCH DAMAGE.
+ *********************************************************************/
+
+/*********************************************************************
+ * How to wrap std::optional objects with boost.python and use them both from
+ * C++ and Python.
+ *
+ * https://stackoverflow.com/questions/36485840/wrap-boostoptional-using-boostpython
+ *
+ *********************************************************************/
+
+
+#ifndef PY_BINDINGS_PY_STD_OPTIONAL_
+#define PY_BINDINGS_PY_STD_OPTIONAL_
+
+#include <exception>
+#include <optional>
+#include <type_traits>
+
+#include <boost/python.hpp>
+#include <boost/python/errors.hpp>
+
+namespace detail
+{
+    template <typename T>
+    struct to_python_optional
+    {
+        static PyObject* convert(const std::optional<T>& obj)
+        {
+            if(obj) {
+              return boost::python::incref(boost::python::object(*obj).ptr());
+            }
+            else {
+              // return None if the value is not set
+              return boost::python::incref(boost::python::object().ptr());
+            }
+        }
+    };
+
+}  // namespace detail
+
+#define PYREGISTER_OPTIONAL(T)            \
+    boost::python::to_python_converter<   \
+    std::optional<T>,                     \
+    detail::to_python_optional<T> >();
+
+#endif  // PY_BINDINGS_PY_STD_OPTIONAL_

--- a/src/ompl/base/spaces/DubinsStateSpace.h
+++ b/src/ompl/base/spaces/DubinsStateSpace.h
@@ -37,6 +37,7 @@
 #ifndef OMPL_BASE_SPACES_DUBINS_STATE_SPACE_
 #define OMPL_BASE_SPACES_DUBINS_STATE_SPACE_
 
+#include <vector>
 #include "ompl/base/spaces/SE2StateSpace.h"
 #include "ompl/base/MotionValidator.h"
 #include <boost/math/constants/constants.hpp>
@@ -70,14 +71,14 @@ namespace ompl
             };
 
             /** \brief Dubins path types */
-            static const DubinsPathSegmentType dubinsPathType[6][3];
+            static const std::vector<std::vector<DubinsPathSegmentType>> dubinsPathType;
             /** \brief Complete description of a Dubins path */
             class DubinsPath
             {
             public:
-                DubinsPath(const DubinsPathSegmentType *type = dubinsPathType[0], double t = 0.,
-                           double p = std::numeric_limits<double>::max(), double q = 0.)
-                  : type_(type)
+              DubinsPath(const std::vector<DubinsPathSegmentType> *type = &dubinsPathType[0],
+                  double t = 0., double p = std::numeric_limits<double>::max(), double q = 0.)
+                   : type_(type)
                 {
                     length_[0] = t;
                     length_[1] = p;
@@ -93,7 +94,7 @@ namespace ompl
 
                 friend std::ostream& operator<<(std::ostream& os, const DubinsPath& path);
                 /** Path segment types */
-                const DubinsPathSegmentType *type_;
+                const std::vector<DubinsPathSegmentType> *type_;
                 /** Path segment lengths */
                 double length_[3];
                 /** Whether the path should be followed "in reverse" */

--- a/src/ompl/base/spaces/src/DubinsStateSpace.cpp
+++ b/src/ompl/base/spaces/src/DubinsStateSpace.cpp
@@ -260,7 +260,7 @@ namespace
             assert(fabs(p * cos(alpha + t) - sa + sb - d) < (1 + p) * DUBINS_EPS);
             assert(fabs(p * sin(alpha + t) + ca - cb) < (1 + p) * DUBINS_EPS);
             assert(mod2pi(alpha + t + q - beta + .5 * DUBINS_EPS) < DUBINS_EPS);
-            return DubinsStateSpace::DubinsPath(DubinsStateSpace::dubinsPathType[0], t, p, q);
+            return DubinsStateSpace::DubinsPath(&DubinsStateSpace::dubinsPathType[0], t, p, q);
         }
         return {};
     }
@@ -278,7 +278,7 @@ namespace
             assert(fabs(p * cos(alpha - t) + sa - sb - d) < (1 + p) * DUBINS_EPS);
             assert(fabs(p * sin(alpha - t) - ca + cb) < (1 + p) * DUBINS_EPS);
             assert(mod2pi(alpha - t - q - beta + .5 * DUBINS_EPS) < DUBINS_EPS);
-            return DubinsStateSpace::DubinsPath(DubinsStateSpace::dubinsPathType[1], t, p, q);
+            return DubinsStateSpace::DubinsPath(&DubinsStateSpace::dubinsPathType[1], t, p, q);
         }
         return {};
     }
@@ -296,7 +296,7 @@ namespace
             assert(fabs(p * cos(alpha - t) - 2. * sin(alpha - t) + sa + sb - d) < 2 * DUBINS_EPS);
             assert(fabs(p * sin(alpha - t) + 2. * cos(alpha - t) - ca - cb) < 2 * DUBINS_EPS);
             assert(mod2pi(alpha - t + q - beta + .5 * DUBINS_EPS) < DUBINS_EPS);
-            return DubinsStateSpace::DubinsPath(DubinsStateSpace::dubinsPathType[2], t, p, q);
+            return DubinsStateSpace::DubinsPath(&DubinsStateSpace::dubinsPathType[2], t, p, q);
         }
         return {};
     }
@@ -314,7 +314,7 @@ namespace
             assert(fabs(p * cos(alpha + t) + 2. * sin(alpha + t) - sa - sb - d) < 2 * DUBINS_EPS);
             assert(fabs(p * sin(alpha + t) - 2. * cos(alpha + t) + ca + cb) < 2 * DUBINS_EPS);
             assert(mod2pi(alpha + t - q - beta + .5 * DUBINS_EPS) < DUBINS_EPS);
-            return DubinsStateSpace::DubinsPath(DubinsStateSpace::dubinsPathType[3], t, p, q);
+            return DubinsStateSpace::DubinsPath(&DubinsStateSpace::dubinsPathType[3], t, p, q);
         }
         return {};
     }
@@ -332,7 +332,7 @@ namespace
             assert(fabs(2. * sin(alpha - t + p) - 2. * sin(alpha - t) - d + sa - sb) < 2 * DUBINS_EPS);
             assert(fabs(-2. * cos(alpha - t + p) + 2. * cos(alpha - t) - ca + cb) < 2 * DUBINS_EPS);
             assert(mod2pi(alpha - t + p - q - beta + .5 * DUBINS_EPS) < DUBINS_EPS);
-            return DubinsStateSpace::DubinsPath(DubinsStateSpace::dubinsPathType[4], t, p, q);
+            return DubinsStateSpace::DubinsPath(&DubinsStateSpace::dubinsPathType[4], t, p, q);
         }
         return {};
     }
@@ -350,7 +350,7 @@ namespace
             assert(fabs(-2. * sin(alpha + t - p) + 2. * sin(alpha + t) - d - sa + sb) < 2 * DUBINS_EPS);
             assert(fabs(2. * cos(alpha + t - p) - 2. * cos(alpha + t) + ca - cb) < 2 * DUBINS_EPS);
             assert(mod2pi(alpha + t - p + q - beta + .5 * DUBINS_EPS) < DUBINS_EPS);
-            return DubinsStateSpace::DubinsPath(DubinsStateSpace::dubinsPathType[5], t, p, q);
+            return DubinsStateSpace::DubinsPath(&DubinsStateSpace::dubinsPathType[5], t, p, q);
         }
         return {};
     }
@@ -364,7 +364,7 @@ namespace
     DubinsStateSpace::DubinsPath dubinsExhaustive(const double d, const double alpha, const double beta)
     {
         if (d < DUBINS_EPS && fabs(alpha - beta) < DUBINS_EPS)
-            return {DubinsStateSpace::dubinsPathType[0], 0, d, 0};
+            return {&DubinsStateSpace::dubinsPathType[0], 0, d, 0};
 
         DubinsStateSpace::DubinsPath path(dubinsLSL(d, alpha, beta)), tmp(dubinsRSR(d, alpha, beta));
         double len, minLength = path.length();
@@ -447,7 +447,7 @@ namespace
     DubinsStateSpace::DubinsPath dubinsClassification(const double d, const double alpha, const double beta)
     {
         if (d < DUBINS_EPS && fabs(alpha - beta) < DUBINS_EPS)
-            return {DubinsStateSpace::dubinsPathType[0], 0, d, 0};
+            return {&DubinsStateSpace::dubinsPathType[0], 0, d, 0};
         // Dubins set classification scheme
         // Shkel, Andrei M., and Vladimir Lumelsky. "Classification of the Dubins set."
         //   Robotics and Autonomous Systems 34.4 (2001): 179-202.
@@ -697,9 +697,9 @@ namespace ompl::base
     {
         os << "DubinsPath[ type=";
         for (unsigned i = 0; i < 3; ++i)
-            if (path.type_[i] == DubinsStateSpace::DUBINS_LEFT)
+            if (path.type_->at(i) == DubinsStateSpace::DUBINS_LEFT)
                 os << "L";
-            else if (path.type_[i] == DubinsStateSpace::DUBINS_STRAIGHT)
+            else if (path.type_->at(i) == DubinsStateSpace::DUBINS_STRAIGHT)
                 os << "S";
             else
                 os << "R";
@@ -712,16 +712,21 @@ namespace ompl::base
 DubinsStateSpace::DubinsPath dubins(double d, double alpha, double beta)
 {
     if (d < DUBINS_EPS && fabs(alpha - beta) < DUBINS_EPS)
-        return {DubinsStateSpace::dubinsPathType[0], 0, d, 0};
+        return {&DubinsStateSpace::dubinsPathType[0], 0, d, 0};
     alpha = mod2pi(alpha);
     beta = mod2pi(beta);
     return isLongPath(d, alpha, beta) ? ::dubinsClassification(d, alpha, beta) : ::dubinsExhaustive(d, alpha, beta);
 }
 
-const DubinsStateSpace::DubinsPathSegmentType DubinsStateSpace::dubinsPathType[6][3] = {
-    {DUBINS_LEFT, DUBINS_STRAIGHT, DUBINS_LEFT},  {DUBINS_RIGHT, DUBINS_STRAIGHT, DUBINS_RIGHT},
-    {DUBINS_RIGHT, DUBINS_STRAIGHT, DUBINS_LEFT}, {DUBINS_LEFT, DUBINS_STRAIGHT, DUBINS_RIGHT},
-    {DUBINS_RIGHT, DUBINS_LEFT, DUBINS_RIGHT},    {DUBINS_LEFT, DUBINS_RIGHT, DUBINS_LEFT}};
+// const DubinsStateSpace::DubinsPathSegmentType DubinsStateSpace::dubinsPathType[6][3] = {
+const std::vector<std::vector<DubinsStateSpace::DubinsPathSegmentType> > DubinsStateSpace::dubinsPathType {{
+    {{DUBINS_LEFT, DUBINS_STRAIGHT, DUBINS_LEFT}},
+    {{DUBINS_RIGHT, DUBINS_STRAIGHT, DUBINS_RIGHT}},
+    {{DUBINS_RIGHT, DUBINS_STRAIGHT, DUBINS_LEFT}},
+    {{DUBINS_LEFT, DUBINS_STRAIGHT, DUBINS_RIGHT}},
+    {{DUBINS_RIGHT, DUBINS_LEFT, DUBINS_RIGHT}},
+    {{DUBINS_LEFT, DUBINS_RIGHT, DUBINS_LEFT}}
+  }};
 
 double DubinsStateSpace::distance(const State *state1, const State *state2) const
 {
@@ -791,7 +796,7 @@ void DubinsStateSpace::interpolate(const State *from, const DubinsPath &path, do
             v = std::min(seg, path.length_[i]);
             phi = s->getYaw();
             seg -= v;
-            switch (path.type_[i])
+            switch (path.type_->at(i))
             {
                 case DUBINS_LEFT:
                     s->setXY(s->getX() + sin(phi + v) - sin(phi), s->getY() - cos(phi + v) + cos(phi));
@@ -814,7 +819,7 @@ void DubinsStateSpace::interpolate(const State *from, const DubinsPath &path, do
             v = std::min(seg, path.length_[2 - i]);
             phi = s->getYaw();
             seg -= v;
-            switch (path.type_[2 - i])
+            switch (path.type_->at(2 - i))
             {
                 case DUBINS_LEFT:
                     s->setXY(s->getX() + sin(phi - v) - sin(phi), s->getY() - cos(phi - v) + cos(phi));

--- a/src/ompl/base/spaces/src/VanaOwenStateSpace.cpp
+++ b/src/ompl/base/spaces/src/VanaOwenStateSpace.cpp
@@ -140,9 +140,9 @@ bool VanaOwenStateSpace::isValid(DubinsStateSpace::DubinsPath const &path, State
     // 1. path of type CCC (i.e., RLR or LRL)
     // 2. pitch smaller than minPitch_
     // 3. pitch greater than maxPitch_
-    if ((path.type_[1] != DubinsStateSpace::DUBINS_STRAIGHT) ||
-        (path.type_[0] == DubinsStateSpace::DUBINS_RIGHT && state->pitch() - path.length_[0] < minPitch_) ||
-        (path.type_[0] == DubinsStateSpace::DUBINS_LEFT && state->pitch() + path.length_[0] > maxPitch_))
+    if ((path.type_->at(1) != DubinsStateSpace::DUBINS_STRAIGHT) ||
+        (path.type_->at(0) == DubinsStateSpace::DUBINS_RIGHT && state->pitch() - path.length_[0] < minPitch_) ||
+        (path.type_->at(0) == DubinsStateSpace::DUBINS_LEFT && state->pitch() + path.length_[0] > maxPitch_))
     {
         return false;
     }
@@ -166,7 +166,7 @@ bool VanaOwenStateSpace::decoupled(const StateType *from, const StateType *to, d
     {
         if (std::abs(result.deltaZ_) < 1e-8 && std::abs(to->pitch() - from->pitch()) < 1e-8)
         {
-            result.pathSZ_.type_ = DubinsStateSpace::dubinsPathType[0]; // LSL type
+            result.pathSZ_.type_ = &DubinsStateSpace::dubinsPathType[0]; // LSL type
             result.pathSZ_.length_[0] = result.pathSZ_.length_[2] = 0.;
             result.pathSZ_.length_[1] = result.deltaZ_;
             return true;

--- a/src/ompl/base/spaces/src/VanaStateSpace.cpp
+++ b/src/ompl/base/spaces/src/VanaStateSpace.cpp
@@ -142,10 +142,10 @@ bool VanaStateSpace::decoupled(const State *state1, const State *state2, double 
     // 1. path of type CCC (i.e., RLR or LRL)
     // 2. pitch smaller than minPitch_
     // 3. pitch greater than maxPitch_
-    if ((result.pathSZ_.type_[1] != DubinsStateSpace::DUBINS_STRAIGHT) ||
-        (result.pathSZ_.type_[0] == DubinsStateSpace::DUBINS_RIGHT &&
+    if ((result.pathSZ_.type_->at(1) != DubinsStateSpace::DUBINS_STRAIGHT) ||
+        (result.pathSZ_.type_->at(0) == DubinsStateSpace::DUBINS_RIGHT &&
          s1->pitch() - result.pathSZ_.length_[0] < minPitch_) ||
-        (result.pathSZ_.type_[0] == DubinsStateSpace::DUBINS_LEFT &&
+        (result.pathSZ_.type_->at(0) == DubinsStateSpace::DUBINS_LEFT &&
          s1->pitch() + result.pathSZ_.length_[0] > maxPitch_))
     {
         return false;


### PR DESCRIPTION
Provide a binding generator for `std::optional<T>` and change the storage type of the static array of `DubinsPathSegmentType` from c-style arrays to `std::vector`. This is to allow the Python binding generator to generate interfaces for the `DubinsPath` returned by the `getPath` function in the `DubinsStateSpace`.

- Fixes #1259

This change is more intrusive than I would have liked (ideally the C++ code would not need to change to provide bindings). The preferred solution would be to add a generator for c-style arrays of fixed size, however attempts at this were not successful (see below).

## Alternatives

Looked into providing bindings for the c-array types directly and also using `std::array<T, N>`. For some reason neither of these approaches was successful. The bindings appear to have been generated by the compiler but the following errors are reported at runtime when loading the module (i.e. `>>> from ompl import base as ob`):

```bash
TypeError: No to_python (by-value) converter found for C++ type: ompl::base::DubinsStateSpace::DubinsPathSegmentType [3]
```

or in the case of `std::array`:

```bash
TypeError: No Python class registered for C++ class std::__1::array<std::__1::array<ompl::base::DubinsStateSpace::DubinsPathSegmentType, 3ul>, 6ul>
```

This branch (https://github.com/srmainwaring/ompl/tree/prs/pr-fix-path-segment-array-binding) contains a version of the `DubinsStateSpace` using `std::array`.

## Testing

The `DubinsAirplane.py` demo is updated to display details of the Dubins curve segments from the generated path.

```bash
Debug:   RRTstar: Planner range detected to be 7.242362
Warning: RRTstar requires a state space with symmetric distance and symmetric interpolation.
         at line 101 in /Users/rhys/Code/ompl/ompl/src/ompl/geometric/planners/rrt/src/RRTstar.cpp
...
Info:    RRTstar: Started planning with 1 states. Seeking a solution better than 0.00000.
Info:    RRTstar: Initial k-nearest value of 83
Info:    RRTstar: Found an initial solution with a cost of 18.60 in 115 iterations (23 vertices in the graph)
Info:    RRTstar: Created 669 new states. Checked 224115 rewire options. 1 goal states in tree. Final solution cost 15.544
Info:    Solution found in 10.113416 seconds
-3.25318 6.34438 -2.35268 -0.225403 
-3.22259 6.33686 -2.36956 -0.256906 
-3.19225 6.32838 -2.38643 -0.288409 
-3.16219 6.31894 -2.40331 -0.319912 
-3.13245 6.30857 -2.42018 -0.351416 
-3.10305 6.29726 -2.43706 -0.382919 
-3.07402 6.28503 -2.45393 -0.414422 
...
Path length is  15.543926579752133
from_state: -3.3, 6.3, -2.4, -0.2
to_state:   -3.2, 6.3, -2.4, -0.3
path_type.phi: 0.00
path_type.deltaZ: -0.0169
path_type.numTurns: 0
path_type.path: DubinsPath[ type=RSL, length=0.0315032+0+0=0.0315032, reverse=0 ]
path_type.path.type: DUBINS_RIGHT, DUBINS_STRAIGHT. DUBINS_LEFT
path_type.path.length: 0.0315, 0.0000, 0.0000
path_type.path.reverse: False
from_state: -3.2, 6.3, -2.4, -0.3
to_state:   -3.2, 6.3, -2.4, -0.3
path_type.phi: 0.00
path_type.deltaZ: -0.0169
path_type.numTurns: 0
path_type.path: DubinsPath[ type=LSR, length=0+0+0.0315032=0.0315032, reverse=0 ]
path_type.path.type: DUBINS_LEFT, DUBINS_STRAIGHT. DUBINS_RIGHT
path_type.path.length: 0.0000, 0.0000, 0.0315
path_type.path.reverse: False
...

```