### PR TITLE
Fix static initialisation / destruction issue for Dubins path types

### DIFF
--- a/src/ompl/base/spaces/DubinsStateSpace.h
+++ b/src/ompl/base/spaces/DubinsStateSpace.h
@@ -77,9 +77,9 @@ namespace ompl
             class DubinsPath
             {
             public:
-              DubinsPath(const std::vector<DubinsPathSegmentType> *type = &dubinsPathType()[0],
+              DubinsPath(const std::vector<DubinsPathSegmentType>& type = dubinsPathType()[0],
                   double t = 0., double p = std::numeric_limits<double>::max(), double q = 0.)
-                   : type_(type)
+                   : type_(&type)
                 {
                     length_[0] = t;
                     length_[1] = p;

--- a/src/ompl/base/spaces/DubinsStateSpace.h
+++ b/src/ompl/base/spaces/DubinsStateSpace.h
@@ -71,12 +71,13 @@ namespace ompl
             };
 
             /** \brief Dubins path types */
-            static const std::vector<std::vector<DubinsPathSegmentType>> dubinsPathType;
+            static const std::vector<std::vector<DubinsPathSegmentType>>& dubinsPathType();
+
             /** \brief Complete description of a Dubins path */
             class DubinsPath
             {
             public:
-              DubinsPath(const std::vector<DubinsPathSegmentType> *type = &dubinsPathType[0],
+              DubinsPath(const std::vector<DubinsPathSegmentType> *type = &dubinsPathType()[0],
                   double t = 0., double p = std::numeric_limits<double>::max(), double q = 0.)
                    : type_(type)
                 {

--- a/src/ompl/base/spaces/src/DubinsStateSpace.cpp
+++ b/src/ompl/base/spaces/src/DubinsStateSpace.cpp
@@ -260,7 +260,7 @@ namespace
             assert(fabs(p * cos(alpha + t) - sa + sb - d) < (1 + p) * DUBINS_EPS);
             assert(fabs(p * sin(alpha + t) + ca - cb) < (1 + p) * DUBINS_EPS);
             assert(mod2pi(alpha + t + q - beta + .5 * DUBINS_EPS) < DUBINS_EPS);
-            return DubinsStateSpace::DubinsPath(&DubinsStateSpace::dubinsPathType()[0], t, p, q);
+            return DubinsStateSpace::DubinsPath(DubinsStateSpace::dubinsPathType()[0], t, p, q);
         }
         return {};
     }
@@ -278,7 +278,7 @@ namespace
             assert(fabs(p * cos(alpha - t) + sa - sb - d) < (1 + p) * DUBINS_EPS);
             assert(fabs(p * sin(alpha - t) - ca + cb) < (1 + p) * DUBINS_EPS);
             assert(mod2pi(alpha - t - q - beta + .5 * DUBINS_EPS) < DUBINS_EPS);
-            return DubinsStateSpace::DubinsPath(&DubinsStateSpace::dubinsPathType()[1], t, p, q);
+            return DubinsStateSpace::DubinsPath(DubinsStateSpace::dubinsPathType()[1], t, p, q);
         }
         return {};
     }
@@ -296,7 +296,7 @@ namespace
             assert(fabs(p * cos(alpha - t) - 2. * sin(alpha - t) + sa + sb - d) < 2 * DUBINS_EPS);
             assert(fabs(p * sin(alpha - t) + 2. * cos(alpha - t) - ca - cb) < 2 * DUBINS_EPS);
             assert(mod2pi(alpha - t + q - beta + .5 * DUBINS_EPS) < DUBINS_EPS);
-            return DubinsStateSpace::DubinsPath(&DubinsStateSpace::dubinsPathType()[2], t, p, q);
+            return DubinsStateSpace::DubinsPath(DubinsStateSpace::dubinsPathType()[2], t, p, q);
         }
         return {};
     }
@@ -314,7 +314,7 @@ namespace
             assert(fabs(p * cos(alpha + t) + 2. * sin(alpha + t) - sa - sb - d) < 2 * DUBINS_EPS);
             assert(fabs(p * sin(alpha + t) - 2. * cos(alpha + t) + ca + cb) < 2 * DUBINS_EPS);
             assert(mod2pi(alpha + t - q - beta + .5 * DUBINS_EPS) < DUBINS_EPS);
-            return DubinsStateSpace::DubinsPath(&DubinsStateSpace::dubinsPathType()[3], t, p, q);
+            return DubinsStateSpace::DubinsPath(DubinsStateSpace::dubinsPathType()[3], t, p, q);
         }
         return {};
     }
@@ -332,7 +332,7 @@ namespace
             assert(fabs(2. * sin(alpha - t + p) - 2. * sin(alpha - t) - d + sa - sb) < 2 * DUBINS_EPS);
             assert(fabs(-2. * cos(alpha - t + p) + 2. * cos(alpha - t) - ca + cb) < 2 * DUBINS_EPS);
             assert(mod2pi(alpha - t + p - q - beta + .5 * DUBINS_EPS) < DUBINS_EPS);
-            return DubinsStateSpace::DubinsPath(&DubinsStateSpace::dubinsPathType()[4], t, p, q);
+            return DubinsStateSpace::DubinsPath(DubinsStateSpace::dubinsPathType()[4], t, p, q);
         }
         return {};
     }
@@ -350,7 +350,7 @@ namespace
             assert(fabs(-2. * sin(alpha + t - p) + 2. * sin(alpha + t) - d - sa + sb) < 2 * DUBINS_EPS);
             assert(fabs(2. * cos(alpha + t - p) - 2. * cos(alpha + t) + ca - cb) < 2 * DUBINS_EPS);
             assert(mod2pi(alpha + t - p + q - beta + .5 * DUBINS_EPS) < DUBINS_EPS);
-            return DubinsStateSpace::DubinsPath(&DubinsStateSpace::dubinsPathType()[5], t, p, q);
+            return DubinsStateSpace::DubinsPath(DubinsStateSpace::dubinsPathType()[5], t, p, q);
         }
         return {};
     }
@@ -364,7 +364,7 @@ namespace
     DubinsStateSpace::DubinsPath dubinsExhaustive(const double d, const double alpha, const double beta)
     {
         if (d < DUBINS_EPS && fabs(alpha - beta) < DUBINS_EPS)
-            return {&DubinsStateSpace::dubinsPathType()[0], 0, d, 0};
+            return {DubinsStateSpace::dubinsPathType()[0], 0, d, 0};
 
         DubinsStateSpace::DubinsPath path(dubinsLSL(d, alpha, beta)), tmp(dubinsRSR(d, alpha, beta));
         double len, minLength = path.length();
@@ -447,7 +447,7 @@ namespace
     DubinsStateSpace::DubinsPath dubinsClassification(const double d, const double alpha, const double beta)
     {
         if (d < DUBINS_EPS && fabs(alpha - beta) < DUBINS_EPS)
-            return {&DubinsStateSpace::dubinsPathType()[0], 0, d, 0};
+            return {DubinsStateSpace::dubinsPathType()[0], 0, d, 0};
         // Dubins set classification scheme
         // Shkel, Andrei M., and Vladimir Lumelsky. "Classification of the Dubins set."
         //   Robotics and Autonomous Systems 34.4 (2001): 179-202.
@@ -712,7 +712,7 @@ namespace ompl::base
 DubinsStateSpace::DubinsPath dubins(double d, double alpha, double beta)
 {
     if (d < DUBINS_EPS && fabs(alpha - beta) < DUBINS_EPS)
-        return {&DubinsStateSpace::dubinsPathType()[0], 0, d, 0};
+        return {DubinsStateSpace::dubinsPathType()[0], 0, d, 0};
     alpha = mod2pi(alpha);
     beta = mod2pi(beta);
     return isLongPath(d, alpha, beta) ? ::dubinsClassification(d, alpha, beta) : ::dubinsExhaustive(d, alpha, beta);

--- a/src/ompl/base/spaces/src/DubinsStateSpace.cpp
+++ b/src/ompl/base/spaces/src/DubinsStateSpace.cpp
@@ -260,7 +260,7 @@ namespace
             assert(fabs(p * cos(alpha + t) - sa + sb - d) < (1 + p) * DUBINS_EPS);
             assert(fabs(p * sin(alpha + t) + ca - cb) < (1 + p) * DUBINS_EPS);
             assert(mod2pi(alpha + t + q - beta + .5 * DUBINS_EPS) < DUBINS_EPS);
-            return DubinsStateSpace::DubinsPath(&DubinsStateSpace::dubinsPathType[0], t, p, q);
+            return DubinsStateSpace::DubinsPath(&DubinsStateSpace::dubinsPathType()[0], t, p, q);
         }
         return {};
     }
@@ -278,7 +278,7 @@ namespace
             assert(fabs(p * cos(alpha - t) + sa - sb - d) < (1 + p) * DUBINS_EPS);
             assert(fabs(p * sin(alpha - t) - ca + cb) < (1 + p) * DUBINS_EPS);
             assert(mod2pi(alpha - t - q - beta + .5 * DUBINS_EPS) < DUBINS_EPS);
-            return DubinsStateSpace::DubinsPath(&DubinsStateSpace::dubinsPathType[1], t, p, q);
+            return DubinsStateSpace::DubinsPath(&DubinsStateSpace::dubinsPathType()[1], t, p, q);
         }
         return {};
     }
@@ -296,7 +296,7 @@ namespace
             assert(fabs(p * cos(alpha - t) - 2. * sin(alpha - t) + sa + sb - d) < 2 * DUBINS_EPS);
             assert(fabs(p * sin(alpha - t) + 2. * cos(alpha - t) - ca - cb) < 2 * DUBINS_EPS);
             assert(mod2pi(alpha - t + q - beta + .5 * DUBINS_EPS) < DUBINS_EPS);
-            return DubinsStateSpace::DubinsPath(&DubinsStateSpace::dubinsPathType[2], t, p, q);
+            return DubinsStateSpace::DubinsPath(&DubinsStateSpace::dubinsPathType()[2], t, p, q);
         }
         return {};
     }
@@ -314,7 +314,7 @@ namespace
             assert(fabs(p * cos(alpha + t) + 2. * sin(alpha + t) - sa - sb - d) < 2 * DUBINS_EPS);
             assert(fabs(p * sin(alpha + t) - 2. * cos(alpha + t) + ca + cb) < 2 * DUBINS_EPS);
             assert(mod2pi(alpha + t - q - beta + .5 * DUBINS_EPS) < DUBINS_EPS);
-            return DubinsStateSpace::DubinsPath(&DubinsStateSpace::dubinsPathType[3], t, p, q);
+            return DubinsStateSpace::DubinsPath(&DubinsStateSpace::dubinsPathType()[3], t, p, q);
         }
         return {};
     }
@@ -332,7 +332,7 @@ namespace
             assert(fabs(2. * sin(alpha - t + p) - 2. * sin(alpha - t) - d + sa - sb) < 2 * DUBINS_EPS);
             assert(fabs(-2. * cos(alpha - t + p) + 2. * cos(alpha - t) - ca + cb) < 2 * DUBINS_EPS);
             assert(mod2pi(alpha - t + p - q - beta + .5 * DUBINS_EPS) < DUBINS_EPS);
-            return DubinsStateSpace::DubinsPath(&DubinsStateSpace::dubinsPathType[4], t, p, q);
+            return DubinsStateSpace::DubinsPath(&DubinsStateSpace::dubinsPathType()[4], t, p, q);
         }
         return {};
     }
@@ -350,7 +350,7 @@ namespace
             assert(fabs(-2. * sin(alpha + t - p) + 2. * sin(alpha + t) - d - sa + sb) < 2 * DUBINS_EPS);
             assert(fabs(2. * cos(alpha + t - p) - 2. * cos(alpha + t) + ca - cb) < 2 * DUBINS_EPS);
             assert(mod2pi(alpha + t - p + q - beta + .5 * DUBINS_EPS) < DUBINS_EPS);
-            return DubinsStateSpace::DubinsPath(&DubinsStateSpace::dubinsPathType[5], t, p, q);
+            return DubinsStateSpace::DubinsPath(&DubinsStateSpace::dubinsPathType()[5], t, p, q);
         }
         return {};
     }
@@ -364,7 +364,7 @@ namespace
     DubinsStateSpace::DubinsPath dubinsExhaustive(const double d, const double alpha, const double beta)
     {
         if (d < DUBINS_EPS && fabs(alpha - beta) < DUBINS_EPS)
-            return {&DubinsStateSpace::dubinsPathType[0], 0, d, 0};
+            return {&DubinsStateSpace::dubinsPathType()[0], 0, d, 0};
 
         DubinsStateSpace::DubinsPath path(dubinsLSL(d, alpha, beta)), tmp(dubinsRSR(d, alpha, beta));
         double len, minLength = path.length();
@@ -447,7 +447,7 @@ namespace
     DubinsStateSpace::DubinsPath dubinsClassification(const double d, const double alpha, const double beta)
     {
         if (d < DUBINS_EPS && fabs(alpha - beta) < DUBINS_EPS)
-            return {&DubinsStateSpace::dubinsPathType[0], 0, d, 0};
+            return {&DubinsStateSpace::dubinsPathType()[0], 0, d, 0};
         // Dubins set classification scheme
         // Shkel, Andrei M., and Vladimir Lumelsky. "Classification of the Dubins set."
         //   Robotics and Autonomous Systems 34.4 (2001): 179-202.
@@ -712,21 +712,26 @@ namespace ompl::base
 DubinsStateSpace::DubinsPath dubins(double d, double alpha, double beta)
 {
     if (d < DUBINS_EPS && fabs(alpha - beta) < DUBINS_EPS)
-        return {&DubinsStateSpace::dubinsPathType[0], 0, d, 0};
+        return {&DubinsStateSpace::dubinsPathType()[0], 0, d, 0};
     alpha = mod2pi(alpha);
     beta = mod2pi(beta);
     return isLongPath(d, alpha, beta) ? ::dubinsClassification(d, alpha, beta) : ::dubinsExhaustive(d, alpha, beta);
 }
 
-// const DubinsStateSpace::DubinsPathSegmentType DubinsStateSpace::dubinsPathType[6][3] = {
-const std::vector<std::vector<DubinsStateSpace::DubinsPathSegmentType> > DubinsStateSpace::dubinsPathType {{
-    {{DUBINS_LEFT, DUBINS_STRAIGHT, DUBINS_LEFT}},
-    {{DUBINS_RIGHT, DUBINS_STRAIGHT, DUBINS_RIGHT}},
-    {{DUBINS_RIGHT, DUBINS_STRAIGHT, DUBINS_LEFT}},
-    {{DUBINS_LEFT, DUBINS_STRAIGHT, DUBINS_RIGHT}},
-    {{DUBINS_RIGHT, DUBINS_LEFT, DUBINS_RIGHT}},
-    {{DUBINS_LEFT, DUBINS_RIGHT, DUBINS_LEFT}}
-  }};
+const std::vector<std::vector<DubinsStateSpace::DubinsPathSegmentType> >& DubinsStateSpace::dubinsPathType() {
+  static std::vector<std::vector<DubinsStateSpace::DubinsPathSegmentType> >* pathType
+    = new std::vector<std::vector<DubinsStateSpace::DubinsPathSegmentType> >(
+      {{
+        {{DUBINS_LEFT, DUBINS_STRAIGHT, DUBINS_LEFT}},
+        {{DUBINS_RIGHT, DUBINS_STRAIGHT, DUBINS_RIGHT}},
+        {{DUBINS_RIGHT, DUBINS_STRAIGHT, DUBINS_LEFT}},
+        {{DUBINS_LEFT, DUBINS_STRAIGHT, DUBINS_RIGHT}},
+        {{DUBINS_RIGHT, DUBINS_LEFT, DUBINS_RIGHT}},
+        {{DUBINS_LEFT, DUBINS_RIGHT, DUBINS_LEFT}}
+      }}
+    );
+    return *pathType;
+}
 
 double DubinsStateSpace::distance(const State *state1, const State *state2) const
 {

--- a/src/ompl/base/spaces/src/VanaOwenStateSpace.cpp
+++ b/src/ompl/base/spaces/src/VanaOwenStateSpace.cpp
@@ -166,7 +166,7 @@ bool VanaOwenStateSpace::decoupled(const StateType *from, const StateType *to, d
     {
         if (std::abs(result.deltaZ_) < 1e-8 && std::abs(to->pitch() - from->pitch()) < 1e-8)
         {
-            result.pathSZ_.type_ = &DubinsStateSpace::dubinsPathType[0]; // LSL type
+            result.pathSZ_.type_ = &DubinsStateSpace::dubinsPathType()[0]; // LSL type
             result.pathSZ_.length_[0] = result.pathSZ_.length_[2] = 0.;
             result.pathSZ_.length_[1] = result.deltaZ_;
             return true;


### PR DESCRIPTION
Provide safe initialisation and no-destruct for `dubinsPath` object with static storage.

- Closes: https://github.com/ompl/ompl/issues/1270

**Edit** Convert to draft as getting a seg fault on release build on Ubuntu 22.04 in docker. No issue on macOS. 
