### PR TITLE
Use reusable interpolation for Dubins3DMotionValidator

### DIFF
--- a/src/ompl/base/spaces/Dubins3DMotionValidator.h
+++ b/src/ompl/base/spaces/Dubins3DMotionValidator.h
@@ -75,6 +75,7 @@ namespace ompl::base
                 return false;
 
             bool result = true;
+            bool firstTime = true;
             int nd = stateSpace_->validSegmentCount(s1, s2);
 
             /* initialize the queue of test positions */
@@ -92,7 +93,7 @@ namespace ompl::base
                     std::pair<int, int> x = pos.front();
 
                     int mid = (x.first + x.second) / 2;
-                    stateSpace_->interpolate(s1, s2, (double)mid / (double)nd, *path, test);
+                    stateSpace_->interpolate(s1, s2, (double)mid / (double)nd, firstTime, *path, test);
 
                     if (!si_->isValid(test))
                     {

--- a/src/ompl/base/spaces/OwenStateSpace.h
+++ b/src/ompl/base/spaces/OwenStateSpace.h
@@ -185,7 +185,8 @@ namespace ompl::base
          * \param state the state that lies on the segment at fraction @e t of the distance between
          * @e from and @e to.
          */
-        virtual void interpolate(const State *from, const State *to, double t, PathType &path, State *state) const;
+         virtual void interpolate(const State *from, const State *to, double t, bool &firstTime, PathType &path, State *state) const;
+         virtual void interpolate(const State *from, const State *to, double t, PathType &path, State *state) const;
 
         /**
          * \brief Compute a 3D Dubins path using the model and algorithm proposed by Owen et al.

--- a/src/ompl/base/spaces/VanaOwenStateSpace.h
+++ b/src/ompl/base/spaces/VanaOwenStateSpace.h
@@ -197,7 +197,8 @@ namespace ompl::base
          * \param state the state that lies on the segment at fraction @e t of the distance between
          * @e from and @e to.
          */
-        virtual void interpolate(const State *from, const State *to, double t, PathType &path, State *state) const;
+         virtual void interpolate(const State *from, const State *to, double t, bool &firstTime, PathType &path, State *state) const;
+         virtual void interpolate(const State *from, const State *to, double t, PathType &path, State *state) const;
 
         /**
          * \brief Compute a 3D Dubins path using the model and algorithm proposed by VanaOwen et al.

--- a/src/ompl/base/spaces/VanaStateSpace.h
+++ b/src/ompl/base/spaces/VanaStateSpace.h
@@ -187,7 +187,8 @@ namespace ompl::base
          * \param state the state that lies on the segment at fraction @e t of the distance between
          * @e from and @e to.
          */
-        virtual void interpolate(const State *from, const State *to, double t, PathType &path, State *state) const;
+         virtual void interpolate(const State *from, const State *to, double t, bool &firstTime, PathType &path, State *state) const;
+         virtual void interpolate(const State *from, const State *to, double t, PathType &path, State *state) const;
         /**
          * \brief Compute the state that lies at time @e t in [0,1] on the segment @e path starting from state @e from.
          *

--- a/src/ompl/base/spaces/src/OwenStateSpace.cpp
+++ b/src/ompl/base/spaces/src/OwenStateSpace.cpp
@@ -196,10 +196,43 @@ unsigned int OwenStateSpace::validSegmentCount(const State *state1, const State 
 
 void OwenStateSpace::interpolate(const State *from, const State *to, double t, State *state) const
 {
-    if (auto path = getPath(from, to))
-        interpolate(from, to, t, *path, state);
-    else if (from != state)
-        copyState(state, from);
+    bool firstTime = true;
+    std::optional<PathType> path;
+    interpolate(from, to, t, firstTime, *path, state);
+}
+
+void OwenStateSpace::interpolate(const State *from, const State *to, double t, bool &firstTime, PathType &path, State *state) const
+{
+    if (firstTime)
+    {
+        if (t >= 1.)
+        {
+            if (to != state)
+                copyState(state, to);
+            return;
+        }
+        if (t <= 0.)
+        {
+            if (from != state)
+                copyState(state, from);
+            return;
+        }
+    
+        auto computed_path = getPath(from, to);
+        if (!computed_path)
+        {
+            if (from != state)
+            {
+                copyState(state, from);
+            }
+        }
+        else
+        {
+            path = *computed_path;
+        }
+        firstTime = false;
+    }
+    interpolate(from, to, t, path, state);
 }
 
 void OwenStateSpace::interpolate(const State *from, const State *to, double t, PathType &path, State *state) const

--- a/src/ompl/base/spaces/src/VanaOwenStateSpace.cpp
+++ b/src/ompl/base/spaces/src/VanaOwenStateSpace.cpp
@@ -341,11 +341,44 @@ unsigned int VanaOwenStateSpace::validSegmentCount(const State *state1, const St
 
 void VanaOwenStateSpace::interpolate(const State *from, const State *to, const double t, State *state) const
 {
-    if (auto path = getPath(from, to))
-        interpolate(from, to, t, *path, state);
-    else
-        if (from != state)
-            copyState(state, from);
+    bool firstTime = true;
+    std::optional<PathType> path;
+    interpolate(from, to, t, firstTime, *path, state);
+}
+
+void VanaOwenStateSpace::interpolate(const State *from, const State *to, const double t, bool &firstTime, PathType &path,
+    State *state) const
+{
+    if (firstTime)
+    {
+        if (t >= 1.)
+        {
+            if (to != state)
+                copyState(state, to);
+            return;
+        }
+        if (t <= 0.)
+        {
+            if (from != state)
+                copyState(state, from);
+            return;
+        }
+    
+        auto computed_path = getPath(from, to);
+        if (!computed_path)
+        {
+            if (from != state)
+            {
+                copyState(state, from);
+            }
+        }
+        else
+        {
+            path = *computed_path;
+        }
+        firstTime = false;
+    }
+    interpolate(from, to, t, path, state);
 }
 
 void VanaOwenStateSpace::interpolate(const State *from, const State *to, const double t, PathType &path,

--- a/src/ompl/base/spaces/src/VanaStateSpace.cpp
+++ b/src/ompl/base/spaces/src/VanaStateSpace.cpp
@@ -206,12 +206,45 @@ unsigned int VanaStateSpace::validSegmentCount(const State *state1, const State 
 
 void VanaStateSpace::interpolate(const State *from, const State *to, const double t, State *state) const
 {
-    if (auto path = getPath(from, to))
-        interpolate(from, to, t, *path, state);
-    else
-        if (from != state)
-            copyState(state, from);
+    bool firstTime = true;
+    std::optional<PathType> path;
+    interpolate(from, to, t, firstTime, *path, state);
 }
+
+void VanaStateSpace::interpolate(const State *from, const State *to, double t, bool &firstTime, PathType &path, State *state) const
+{
+    if (firstTime)
+    {
+        if (t >= 1.)
+        {
+            if (to != state)
+                copyState(state, to);
+            return;
+        }
+        if (t <= 0.)
+        {
+            if (from != state)
+                copyState(state, from);
+            return;
+        }
+    
+        auto computed_path = getPath(from, to);
+        if (!computed_path)
+        {
+            if (from != state)
+            {
+                copyState(state, from);
+            }
+        }
+        else
+        {
+            path = *computed_path;
+        }
+        firstTime = false;
+    }
+    interpolate(from, to, t, path, state);
+}
+
 
 void VanaStateSpace::interpolate(const State *from, const State *to, const double t, PathType &path,
                                  State *state) const


### PR DESCRIPTION
**Problem Description**
This commit makes the path computation reusable for the interpolation inside the Dubins3DMotionValidator.