### PR TITLE
Add getters for OwenStateSpace

### DIFF
--- a/src/ompl/base/spaces/OwenStateSpace.h
+++ b/src/ompl/base/spaces/OwenStateSpace.h
@@ -196,6 +196,14 @@ namespace ompl::base
          */
         std::optional<PathType> getPath(const State *state1, const State *state2) const;
 
+        double getMinTurnRadius() const {
+            return rho_;
+        };
+
+        double getMaxPitch() const {
+            return atan(tanMaxPitch_);
+        };
+
     protected:
         /**
          * \brief Compute the SE(2) state after making a turn


### PR DESCRIPTION
**Problem Description**
This PR adds getters to conveniently get properties of OwenStateSpace


**Additional Context**
- @mamoll This was needed for porting `terrain-navigation` for the new OwenStateSpace implementation (https://github.com/ethz-asl/terrain-navigation2/pull/3)