### PR TITLE
bump version number to make it immediately obvious this is not the same version as an official release

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,6 @@
 cmake_minimum_required(VERSION 3.12)
-project(ompl VERSION 1.7.0 LANGUAGES CXX)
-set(OMPL_ABI_VERSION 18)
+project(ompl VERSION 1.8.0 LANGUAGES CXX)
+set(OMPL_ABI_VERSION 19)
 
 # Use the FindBoost provided by CMake, rather than the one provided by Boost
 # (for CMake >=3.30).

--- a/package.xml
+++ b/package.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <package format="2">
   <name>ompl</name>
-  <version>1.7.0</version>
+  <version>1.8.0</version>
   <description>OMPL is a free sampling-based motion planning library.</description>
   <maintainer email="mmoll@rice.edu">Mark Moll</maintainer>
   <maintainer email="marq.razz@gmail.com">Marq Rasumessen</maintainer>


### PR DESCRIPTION
closes #1283.