### PR TITLE
Update `StatePropagator::steer` method to be compatible with Python

### DIFF
--- a/src/ompl/control/StatePropagator.h
+++ b/src/ompl/control/StatePropagator.h
@@ -103,16 +103,14 @@ namespace ompl
             }
 
             /** \brief Compute the control that can take the system from state \e from to state \e to.
-                Store that control in \e result; the duration for which the control should be applied is stored in \e
-               duration;
-                return true if the computation was successful; return false otherwise;
+                Store that control in \e result; the duration for which the control should be applied is returned;
+                return < 0.0 if the computation was successful; return the control duration otherwise;
 
-                \note If false is returned, the content of \e result and \e duration may have been changed,
+                \note If false is returned, the content of \e result may have been changed,
                 but it does not represent a solution; */
-            virtual bool steer(const base::State * /*from*/, const base::State * /*to*/, Control * /*result*/,
-                               double & /*duration*/) const
+            virtual double steer(const base::State * /*from*/, const base::State * /*to*/, Control * /*result*/) const
             {
-                return false;
+                return -1.0;
             }
 
             /** \brief Return true if the steer() function has been implemented */

--- a/src/ompl/control/StatePropagator.h
+++ b/src/ompl/control/StatePropagator.h
@@ -106,7 +106,7 @@ namespace ompl
                 Store that control in \e result; the duration for which the control should be applied is returned;
                 return < 0.0 if the computation was successful; return the control duration otherwise;
 
-                \note If false is returned, the content of \e result may have been changed,
+                \note If a negative value is returned, the content of \e result may have been changed,
                 but it does not represent a solution; */
             virtual double steer(const base::State * /*from*/, const base::State * /*to*/, Control * /*result*/) const
             {

--- a/src/ompl/control/SteeredControlSampler.h
+++ b/src/ompl/control/SteeredControlSampler.h
@@ -61,7 +61,7 @@ namespace ompl
 
             unsigned int sampleTo(Control *control, const base::State *source, base::State *dest) override
             {
-                double duration;
+                double duration = 0.0;
                 if (!si_->getStatePropagator()->steer(source, dest, control, duration))
                     return 0;
                 unsigned int steps = std::floor(duration / si_->getPropagationStepSize() + 0.5);

--- a/src/ompl/control/SteeredControlSampler.h
+++ b/src/ompl/control/SteeredControlSampler.h
@@ -65,7 +65,7 @@ namespace ompl
                 if (!si_->getStatePropagator()->steer(source, dest, control, duration))
                     return 0;
                 unsigned int steps = std::floor(duration / si_->getPropagationStepSize() + 0.5);
-                return si_->propagateWhileValid(source, control, steps, dest);
+                return si_->propagateWhileValid(source, control, std::max(1u, steps), dest);
             }
 
             unsigned int sampleTo(Control *control, const Control * /*previous*/, const base::State *source,

--- a/src/ompl/control/SteeredControlSampler.h
+++ b/src/ompl/control/SteeredControlSampler.h
@@ -61,8 +61,8 @@ namespace ompl
 
             unsigned int sampleTo(Control *control, const base::State *source, base::State *dest) override
             {
-                double duration = 0.0;
-                if (!si_->getStatePropagator()->steer(source, dest, control, duration))
+                double duration = si_->getStatePropagator()->steer(source, dest, control);
+                if (duration < std::numeric_limits<double>::epsilon())
                     return 0;
                 unsigned int steps = std::floor(duration / si_->getPropagationStepSize() + 0.5);
                 return si_->propagateWhileValid(source, control, std::max(1u, steps), dest);


### PR DESCRIPTION
Addresses #1212 to allow steering state propagators to be used from Python. See [this branch of my fork](https://github.com/marip8/ompl/tree/patch/pybindings-wheel-1.6.0) for a functional build of the wheels at 1.6.0 with this fix implemented.