### PR TITLE
Force llvm/clang to v18 in CI to avoid compilation error

### DIFF
--- a/.github/workflows/before_all.sh
+++ b/.github/workflows/before_all.sh
@@ -10,8 +10,8 @@ if [ "${build_os}" == "Linux" ]; then
     yum -y install \
         sudo \
         eigen3-devel \
-        llvm-devel \
-        clang-devel
+        llvm-devel-18.* \
+        clang-devel-18.*
 
     if [ "${arch}" == "aarch64" ]; then
         echo "Detected AlmaLinux 8 AArch64. Applying architecture-specific fixes..."


### PR DESCRIPTION
The Python bindings fail to compile with `clang>=19`, which was recently bumped in the container image used to build OMPL wheels. I see the issue in CI and locally. My best guess is that it's related to the combination of recent compiler (`clang-19`) + old Eigen (`3.3.4`).

For now, we should just stick to `clang-18` until a better solution is found or the bindings are replaced with nanobind.

Current error: https://github.com/ompl/ompl/actions/runs/15561864951/job/43815998469#step:3:20189

```
    In file included from /project/src/ompl/base/objectives/src/ControlDurationObjective.cpp:37:
    In file included from /project/src/ompl/base/objectives/ControlDurationObjective.h:40:
    In file included from /project/src/ompl/base/OptimizationObjective.h:41:
    In file included from /project/src/ompl/base/SpaceInformation.h:43:
    In file included from /project/src/ompl/base/StateSpace.h:43:
    In file included from /project/src/ompl/base/ProjectionEvaluator.h:49:
    In file included from /usr/include/eigen3/Eigen/Core:467:
    /usr/include/eigen3/Eigen/src/Core/Transpositions.h:387:87: error: no member named 'derived' in 'Transpose<TranspositionsBase<type-parameter-0-0>>'
      387 |       return Product<OtherDerived, Transpose, AliasFreeProduct>(matrix.derived(), trt.derived());
          |                                                                                   ~~~ ^
    1 error generated.
```

Successful build with this PR: https://github.com/kylc/ompl/actions/runs/15715642142