### PR TITLE
[fix clang -Werror build] do not name unused parameter

### DIFF
--- a/src/ompl/base/spaces/src/TrochoidStateSpace.cpp
+++ b/src/ompl/base/spaces/src/TrochoidStateSpace.cpp
@@ -583,7 +583,7 @@ namespace
         }  
     }
 
-    bool isLongPathCase(double x0, double y0, double phi0, double xf, double yf, double phif, double radius, double wind_ratio)
+    bool isLongPathCase(double x0, double y0, double phi0, double xf, double yf, double phif, double radius, double /* wind_ratio */)
     {   
         double dx = (xf - x0)/radius, dy = (yf - y0)/radius;
         double d = sqrt(dx*dx + dy*dy), theta = atan2(dy, dx);


### PR DESCRIPTION
to resolve -Werror with clang:

```
ompl/src/ompl/base/spaces/src/TrochoidStateSpace.cpp:586:117: error: unused parameter 'wind_ratio' [-Werror,-Wunused-parameter]
  586 |     bool isLongPathCase(double x0, double y0, double phi0, double xf, double yf, double phif, double radius, double wind_ratio)
```