### PR TITLE
Expose best cost progress property in control::SST

### DIFF
--- a/src/ompl/control/planners/sst/src/SST.cpp
+++ b/src/ompl/control/planners/sst/src/SST.cpp
@@ -55,6 +55,8 @@ ompl::control::SST::SST(const SpaceInformationPtr &si) : base::Planner(si, "SST"
     Planner::declareParam<double>("selection_radius", this, &SST::setSelectionRadius, &SST::getSelectionRadius, "0.:.1:"
                                                                                                                 "100");
     Planner::declareParam<double>("pruning_radius", this, &SST::setPruningRadius, &SST::getPruningRadius, "0.:.1:100");
+
+    addPlannerProgressProperty("best cost REAL", [this] { return std::to_string(this->prevSolutionCost_.value()); });
 }
 
 ompl::control::SST::~SST()


### PR DESCRIPTION
This adds the following to the control::SST constructor:

`addPlannerProgressProperty("best cost REAL", [this] { return std::to_string(this->prevSolutionCost_.value()); });`

This exposes the current best solution cost to the benchmarking framework. Other optimal planners - such as RRT*, LBTRRT, and kBIT*, as well as the geometric variant of SST - already register this property.

This allows Planner Arena or tools like [aorthey/ompl_benchmark_plotter](https://github.com/aorthey/ompl_benchmark_plotter) to plot best cost over time and evaluate planners or different samplers with SST.

This should make the behavior consistent with the rest of the optimal planners in OMPL.