### PR TITLE
correct maxextent in sphere statespace

### DIFF
--- a/src/ompl/base/spaces/special/SphereStateSpace.h
+++ b/src/ompl/base/spaces/special/SphereStateSpace.h
@@ -105,6 +105,8 @@ namespace ompl
 
             virtual State *allocState() const override;
 
+            double getMaximumExtent() const override;
+
             /* \brief Convert a state to a 3D vector to visualize the state
              * space. */
             Eigen::Vector3f toVector(const State *state) const;

--- a/src/ompl/base/spaces/special/src/SphereStateSpace.cpp
+++ b/src/ompl/base/spaces/special/src/SphereStateSpace.cpp
@@ -124,6 +124,11 @@ double SphereStateSpace::distance(const State *state1, const State *state2) cons
     return 2 * radius_ * asin(d);
 }
 
+double SphereStateSpace::getMaximumExtent() const
+{
+    return pi * radius_;
+}
+
 double SphereStateSpace::getMeasure() const
 {
     return 4 * pi * radius_ * radius_;


### PR DESCRIPTION
basic bug where default max distance implementation is not correct for a sphere.