### PR TITLE
Add windows Build

### DIFF
--- a/.github/workflows/before_all.ps1
+++ b/.github/workflows/before_all.ps1
@@ -1,0 +1,38 @@
+# OMPL Windows vcpkg setup script for cibuildwheel
+Write-Host "Running before_all.ps1 for Windows"
+
+# Check if vcpkg already exists
+if (Test-Path "$PWD\vcpkg\vcpkg.exe") {
+    Write-Host "vcpkg already exists"
+    $env:VCPKG_ROOT = "$PWD\vcpkg"
+} else {
+    Write-Host "Downloading and bootstrapping vcpkg..."
+    
+    # Download vcpkg
+    git clone https://github.com/Microsoft/vcpkg.git
+    Set-Location vcpkg
+    
+    # Bootstrap vcpkg
+    .\bootstrap-vcpkg.bat
+    
+    # Set VCPKG_ROOT environment variable
+    Set-Location ..
+    $env:VCPKG_ROOT = "$PWD\vcpkg"
+}
+
+# Set CMAKE_TOOLCHAIN_FILE environment variable
+$env:CMAKE_TOOLCHAIN_FILE = "$env:VCPKG_ROOT\scripts\buildsystems\vcpkg.cmake"
+Write-Host "VCPKG_ROOT=$env:VCPKG_ROOT"
+Write-Host "CMAKE_TOOLCHAIN_FILE=$env:CMAKE_TOOLCHAIN_FILE"
+
+# Export environment variables to parent process
+[Environment]::SetEnvironmentVariable("VCPKG_ROOT", $env:VCPKG_ROOT, "Process")
+[Environment]::SetEnvironmentVariable("CMAKE_TOOLCHAIN_FILE", $env:CMAKE_TOOLCHAIN_FILE, "Process")
+
+Write-Host "Installing dependencies with vcpkg..."
+Set-Location $env:VCPKG_ROOT
+# Use full path to call vcpkg executable
+& .\vcpkg install --triplet=x64-windows
+
+Set-Location ..
+Write-Host "Finished vcpkg setup and dependency installation"

--- a/.github/workflows/wheels.yaml
+++ b/.github/workflows/wheels.yaml
@@ -25,6 +25,9 @@ jobs:
           - os: macos-15
             arch: arm64
             suffix: macosx_arm64
+          - os: windows-latest
+            arch: AMD64
+            suffix: win_amd64
         python-version: [310, 311, 312, 313]
     steps:
       - name: Check out repository code

--- a/.gitignore
+++ b/.gitignore
@@ -17,3 +17,6 @@ log/
 py-bindings/ompl/app/
 py-bindings/ompl/bindings_generator.py
 !py-bindings/ompl/bindings_generator.py.in
+vcpkg_installed/
+dist/
+wheelhouse/

--- a/bindings/CMakeLists.txt
+++ b/bindings/CMakeLists.txt
@@ -20,7 +20,10 @@ else()
 endif()
 
 target_link_libraries(_ompl PRIVATE ompl::ompl)
-target_compile_options(_ompl PRIVATE -Wno-unused-parameter)
+# Only use -Wno-unused-parameter for non-MSVC compilers since MSVC doesn't recognize this flag
+if (NOT MSVC)
+    target_compile_options(_ompl PRIVATE -Wno-unused-parameter)
+endif()
 
 file(COPY ompl DESTINATION ${CMAKE_CURRENT_BINARY_DIR})
 

--- a/bindings/pyproject.toml
+++ b/bindings/pyproject.toml
@@ -34,7 +34,13 @@ archs = "auto64"
 build-verbosity = 1
 skip = ""
 
+[tool.cibuildwheel.linux]
 before-all = ".github/workflows/before_all.sh"
-
 manylinux-x86_64-image = "quay.io/pypa/manylinux_2_28_x86_64"
 manylinux-aarch64-image = "quay.io/pypa/manylinux_2_28_aarch64"
+
+[tool.cibuildwheel.macos]
+before-all = ".github/workflows/before_all.sh"
+
+[tool.cibuildwheel.windows]
+before-all = "powershell .github/workflows/before_all.ps1"

--- a/bindings/setup.py
+++ b/bindings/setup.py
@@ -72,6 +72,27 @@ class CMakeBuild(build_ext):
         if "CMAKE_ARGS" in os.environ:
             cmake_args += [item for item in os.environ["CMAKE_ARGS"].split(" ") if item]
 
+        # Check for VCPKG_ROOT environment variable and set CMAKE_TOOLCHAIN_FILE accordingly
+        vcpkg_root = os.environ.get("VCPKG_ROOT")
+        if vcpkg_root:
+            cmake_toolchain_file = os.path.join(vcpkg_root, "scripts", "buildsystems", "vcpkg.cmake")
+            cmake_args += [f"-DCMAKE_TOOLCHAIN_FILE={cmake_toolchain_file}"]
+            # For vcpkg, we also need to specify the target triplet on Windows
+            if sys.platform.startswith("win"):
+                cmake_args += ["-DVCPKG_TARGET_TRIPLET=x64-windows"]
+        elif "CMAKE_TOOLCHAIN_FILE" in os.environ:
+            # If VCPKG_ROOT is not set but CMAKE_TOOLCHAIN_FILE is, use it directly
+            cmake_args += [f"-DCMAKE_TOOLCHAIN_FILE={os.environ['CMAKE_TOOLCHAIN_FILE']}"]
+        else:
+            # Fallback: try to find vcpkg in the project root directory
+            project_root = Path(__file__).parent.parent
+            vcpkg_dir = project_root / "vcpkg"
+            cmake_toolchain_file = vcpkg_dir / "scripts" / "buildsystems" / "vcpkg.cmake"
+            if cmake_toolchain_file.exists():
+                cmake_args += [f"-DCMAKE_TOOLCHAIN_FILE={cmake_toolchain_file}"]
+                if sys.platform.startswith("win"):
+                    cmake_args += ["-DVCPKG_TARGET_TRIPLET=x64-windows"]
+
         if self.compiler.compiler_type != "msvc":
             # Using Ninja-build since it a) is available as a wheel and b)
             # multithreads automatically. MSVC would require all variables be

--- a/bindings/setup.py
+++ b/bindings/setup.py
@@ -44,6 +44,11 @@ class CMakeBuild(build_ext):
         # Can be set with Conda-Build, for example.
         cmake_generator = os.environ.get("CMAKE_GENERATOR", "")
 
+        # For Windows, we need to ensure the binary is placed in the ompl subdirectory
+        # to match the Python package structure
+        if sys.platform.startswith("win"):
+            extdir = extdir / "ompl"
+
         # - Hint the desired Python target for CMake to find, per [1].
         # - Set CMAKE_LIBRARY_OUTPUT_DIRECTORY to a location expected by the
         #   wheel builder so that libraries are included in the output artifact.


### PR DESCRIPTION
Add the vcpkg cmake toolchain to automatically install dependencies on windows. Currently, it still has issues with environment variable detection, using relative paths to find locally installed vcpkg.

Build log:
https://github.com/Puiching-Memory/ompl/actions/runs/17008018101

Only this kind of import can work:
```python
from ompl import base as ob
from ompl import geometric as og
```

This will result in an error:
```python
import ompl.base
```

At present, I am still unable to verify whether the build on windows is working properly.The generated binary file is much smaller than that of other platforms. This makes me worried.

```powershell
$env:CIBW_BUILD = "cp311-*"; cibuildwheel .\bindings\
```

<details> <summary>Run pytest:</summary>

```bash
================================================ test session starts =================================================
platform win32 -- Python 3.11.13, pytest-8.4.1, pluggy-1.6.0
rootdir: C:\workspace\github\ompl
collected 21 items / 6 errors                                                                                         

======================================================= ERRORS =======================================================
______________________________________ ERROR collecting tests/base/test_base.py ______________________________________ 
ImportError while importing test module 'C:\workspace\github\ompl\tests\base\test_base.py'.
Hint: make sure your test modules/packages have valid Python names.
Traceback:
C:\Users\11386\.conda\envs\ompl\Lib\importlib\__init__.py:126: in import_module
    return _bootstrap._gcd_import(name[level:], package, level)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
tests\base\test_base.py:44: in <module>
    from ompl.base import *
E   ModuleNotFoundError: No module named 'ompl.base'
___________________________________ ERROR collecting tests/control/test_control.py ___________________________________ 
ImportError while importing test module 'C:\workspace\github\ompl\tests\control\test_control.py'.
Hint: make sure your test modules/packages have valid Python names.
Traceback:
C:\Users\11386\.conda\envs\ompl\Lib\importlib\__init__.py:126: in import_module
    return _bootstrap._gcd_import(name[level:], package, level)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
tests\control\test_control.py:47: in <module>
    import ompl.util as ou
E   ModuleNotFoundError: No module named 'ompl.util'
_________________________________ ERROR collecting tests/geometric/test_geometric.py _________________________________ 
ImportError while importing test module 'C:\workspace\github\ompl\tests\geometric\test_geometric.py'.
Hint: make sure your test modules/packages have valid Python names.
Traceback:
C:\Users\11386\.conda\envs\ompl\Lib\importlib\__init__.py:126: in import_module
    return _bootstrap._gcd_import(name[level:], package, level)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
tests\geometric\test_geometric.py:47: in <module>
    import ompl.util as ou
E   ModuleNotFoundError: No module named 'ompl.util'
__________________________ ERROR collecting tests/geometric/test_geometric_compoundstate.py __________________________ 
ImportError while importing test module 'C:\workspace\github\ompl\tests\geometric\test_geometric_compoundstate.py'.    
Hint: make sure your test modules/packages have valid Python names.
Traceback:
C:\Users\11386\.conda\envs\ompl\Lib\importlib\__init__.py:126: in import_module
    return _bootstrap._gcd_import(name[level:], package, level)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
tests\geometric\test_geometric_compoundstate.py:47: in <module>
    import ompl.base as ob
E   ModuleNotFoundError: No module named 'ompl.base'
________________________________ ERROR collecting tests/util/test_py_std_function.py _________________________________ 
ImportError while importing test module 'C:\workspace\github\ompl\tests\util\test_py_std_function.py'.
Hint: make sure your test modules/packages have valid Python names.
Traceback:
C:\Users\11386\.conda\envs\ompl\Lib\importlib\__init__.py:126: in import_module
    return _bootstrap._gcd_import(name[level:], package, level)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
tests\util\test_py_std_function.py:40: in <module>
    from py_std_function import *
E   ModuleNotFoundError: No module named 'py_std_function'
______________________________________ ERROR collecting tests/util/test_util.py ______________________________________ 
ImportError while importing test module 'C:\workspace\github\ompl\tests\util\test_util.py'.
Hint: make sure your test modules/packages have valid Python names.
Traceback:
C:\Users\11386\.conda\envs\ompl\Lib\importlib\__init__.py:126: in import_module
    return _bootstrap._gcd_import(name[level:], package, level)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
tests\util\test_util.py:43: in <module>
    from ompl.util import *
E   ModuleNotFoundError: No module named 'ompl.util'
============================================== short test summary info =============================================== 
ERROR tests/base/test_base.py
ERROR tests/control/test_control.py
ERROR tests/geometric/test_geometric.py
ERROR tests/geometric/test_geometric_compoundstate.py
ERROR tests/util/test_py_std_function.py
ERROR tests/util/test_util.py
!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!! Interrupted: 6 errors during collection !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!! 
================================================= 6 errors in 21.00s ================================================= 
```

</details> 

<details> <summary>Run print(dir(base)):</summary>

```bash
['ATLAS_STATE_SPACE_ALPHA', 'ATLAS_STATE_SPACE_BACKOFF', 'ATLAS_STATE_SPACE_EPSILON', 'ATLAS_STATE_SPACE_EXPLORATION', 'ATLAS_STATE_SPACE_MAX_CHARTS_PER_EXTENSION', 'ATLAS_STATE_SPACE_RHO_MULTIPLIER', 'ATLAS_STATE_SPACE_SAMPLES', 'AllValidStateValidityChecker', 'AtlasChart', 'AtlasStateSampler', 'AtlasStateSpace', 'AtlasStateType', 'BridgeTestValidStateSampler', 'CONSTRAINED_STATE_SPACE_DELTA', 'CONSTRAINED_STATE_SPACE_LAMBDA', 'CONSTRAINT_PROJECTION_MAX_ITERATIONS', 'CONSTRAINT_PROJECTION_TOLERANCE', 'CompoundState', 'CompoundStateSampler', 'CompoundStateSpace', 'ConditionalStateSampler', 'ConstrainedMotionValidator', 'ConstrainedSpaceInformation', 'ConstrainedStateSpace', 'ConstrainedStateSpaceStateType', 'ConstrainedValidStateSampler', 'Constraint', 'ConstraintIntersection', 'ControlDurationObjective', 'Cost', 'CostConvergenceTerminationCondition', 'DeterministicSequence', 'DeterministicStateSampler', 'DiscreteMotionValidator', 'DiscreteState', 'DiscreteStateSampler', 'DiscreteStateSpace', 'DubinsMotionValidator', 'DubinsPath', 'DubinsPathSegmentType', 'DubinsStateSpace', 'EmptyStateSpace', 'GOAL_ANY', 'GOAL_LAZY_SAMPLES', 'GOAL_REGION', 'GOAL_SAMPLEABLE_REGION', 'GOAL_STATE', 'GOAL_STATES', 'GaussianValidStateSampler', 'GenericParam', 'Goal', 'GoalLazySamples', 'GoalRegion', 'GoalSampleableRegion', 'GoalSpace', 'GoalState', 'GoalStates', 'GoalType', 'HaltonSequence', 'InformedSampler', 'InformedStateSampler', 'IterationTerminationCondition', 'KleinBottleStateSampler', 'KleinBottleStateSpace', 'MaximizeClearanceValidStateSampler', 'MaximizeMinClearanceObjective', 'MechanicalWorkOptimizationObjective', 'MinimaxObjective', 'MinimizeArrivalTime', 'MinimumClearanceValidStateSampler', 'MobiusStateSpace', 'MotionValidator', 'MultiOptimizationObjective', 'ObstacleBasedValidStateSampler', 'OptimizationObjective', 'OrderedInfSampler', 'ParamSet', 'Path', 'PathLengthDirectInfSampler', 'PathLengthOptimizationObjective', 'Planner', 'PlannerData', 'PlannerDataEdge', 'PlannerDataStorage', 'PlannerDataVertex', 'PlannerInputStates', 'PlannerStatus', 'PlannerTerminationCondition', 'PrecomputedSequence', 'PrecomputedStateSampler', 'ProblemDefinition', 'ProjectedStateSampler', 'ProjectedStateSpace', 'ProjectionEvaluator', 'ProjectionMatrix', 'RealVectorBounds', 'RealVectorIdentityProjectionEvaluator', 'RealVectorLinearProjectionEvaluator', 'RealVectorOrthogonalProjectionEvaluator', 'RealVectorRandomLinearProjectionEvaluator', 'RealVectorStateSampler', 'RealVectorStateSpace', 'RealVectorStateType', 'ReedsSheppMotionValidator', 'ReedsSheppPath', 'ReedsSheppStateSpace', 'RejectionInfSampler', 'SE2StateSpace', 'SE2StateType', 'SE3State', 'SE3StateSpace', 'SO2State', 'SO2StateSampler', 'SO2StateSpace', 'SO3State', 'SO3StateSampler', 'SO3StateSpace', 'SolutionNonExistenceProof', 'SpaceInformation', 'SpaceTimeStateSpace', 'SphereStateSampler', 'SphereStateSpace', 'SphereStateSpaceStateType', 'State', 'StateCostIntegralObjective', 'StateSampler', 'StateSpace', 'StateStorage', 'StateValidityChecker', 'SubspaceProjectionEvaluator', 'SubspaceStateSampler', 'TangentBundleSpaceInformation', 'TangentBundleStateSpace', 'TimeState', 'TimeStateSampler', 'TimeStateSpace', 'TorusStateSampler', 'TorusStateSpace', 'TorusStateSpaceStateType', 'UniformValidStateSampler', 'VFMechanicalWorkOptimizationObjective', 'VFUpstreamCriterionOptimizationObjective', 'ValidStateSampler', 'WrapperProjectionEvaluator', 'WrapperStateSampler', 'WrapperStateSpace', 'WrapperStateType', '__doc__', '__loader__', '__name__', '__package__', '__spec__', 'exactSolnPlannerTerminationCondition', 'plannerAlwaysTerminatingCondition', 'plannerAndTerminationCondition', 'plannerNonTerminatingCondition', 'plannerOrTerminationCondition', 'timedPlannerTerminationCondition']
```
</details> 

<details> <summary>Run pytest/test_Base.py:</summary>

```bash
Geometric path with 3 states
RealVectorState [0.25 0.25]
RealVectorState [0.948511 0.106417]
RealVectorState [0.124105 0.0833464]

Initial path:
 None
Path length before interpolation: 1.537843652513164
Path length after interpolation: 1.5378436525131638
Geometric path with 19 states
RealVectorState [0.124105 0.0833464]
RealVectorState [0.227156 0.0862303]
RealVectorState [0.330206 0.0891142]
RealVectorState [0.433257 0.0919981]
RealVectorState [0.536308 0.0948819]
RealVectorState [0.639359 0.0977658]
RealVectorState [0.742409 0.10065]
RealVectorState [0.84546 0.103534]
RealVectorState [0.948511 0.106417]
RealVectorState [0.87866 0.120776]
RealVectorState [0.808809 0.135134]
RealVectorState [0.738958 0.149492]
RealVectorState [0.669106 0.16385]
RealVectorState [0.599255 0.178209]
RealVectorState [0.529404 0.192567]
RealVectorState [0.738958 0.149492]
RealVectorState [0.669106 0.16385]
RealVectorState [0.599255 0.178209]
RealVectorState [0.529404 0.192567]
RealVectorState [0.669106 0.16385]
RealVectorState [0.599255 0.178209]
RealVectorState [0.529404 0.192567]
RealVectorState [0.599255 0.178209]
RealVectorState [0.529404 0.192567]
RealVectorState [0.529404 0.192567]
RealVectorState [0.459553 0.206925]
RealVectorState [0.389702 0.221283]
RealVectorState [0.319851 0.235642]
RealVectorState [0.25 0.25]

Path after subdivide + reverse:
 None
Geometric path with 2 states
RealVectorState [0.755394 0.359394]
RealVectorState [0.948053 0.872129]

Path after randomization:
 None
Path is cleared. State count = 0
```
</details> 