### PR TITLE
Add dependency caching for Python wheel builds to resolve #1161

### DIFF
--- a/.github/workflows/wheels.yaml
+++ b/.github/workflows/wheels.yaml
@@ -35,6 +35,15 @@ jobs:
         with:
           submodules: 'recursive'
 
+      - name: Restore dependency cache
+        id: cache-deps
+        uses: actions/cache@v4
+        with:
+          path: ${{ runner.temp }}/ompl-deps-cache
+          key: deps-${{ matrix.id }}-boost-1.87.0-yaml-0.8.0-castxml-0.6.11
+          restore-keys: |
+            deps-${{ matrix.id }}-
+
       - name: Build wheels
         uses: pypa/cibuildwheel@v2.23.2
         with:
@@ -44,7 +53,17 @@ jobs:
           OMPL_BUILD_ARCH: ${{ matrix.arch }}
           CIBW_BUILD: ${{ matrix.pybuilds }}
           CIBW_SKIP: "cp*-manylinux_i686 cp*-musllinux* cp*-win32"
-          CIBW_ENVIRONMENT_MACOS: MACOSX_DEPLOYMENT_TARGET="15.0"
+          CIBW_ENVIRONMENT_MACOS: MACOSX_DEPLOYMENT_TARGET="15.0" OMPL_DEPS_CACHE_DIR="${{ runner.temp }}/ompl-deps-cache"
+          CIBW_ENVIRONMENT_LINUX: OMPL_DEPS_CACHE_DIR=/host${{ runner.temp }}/ompl-deps-cache
+          CIBW_ENVIRONMENT_PASS_LINUX: OMPL_DEPS_CACHE_DIR
+
+      - name: Save dependency cache
+        if: steps.cache-deps.outputs.cache-hit != 'true'
+        uses: actions/cache/save@v4
+        with:
+          path: ${{ runner.temp }}/ompl-deps-cache
+          key: deps-${{ matrix.id }}-boost-1.87.0-yaml-0.8.0-castxml-0.6.11
+
       - uses: actions/upload-artifact@v4
         with:
           name: wheels-${{ matrix.os }}-${{ matrix.arch }}


### PR DESCRIPTION
## Description
This PR implements dependency caching for Python wheel builds to significantly reduce CI build times, resolving issue #1161.
## Solution
This PR adds GitHub Actions caching to store built dependencies and reuse them across builds.
### Changes Made:

1. **`.github/workflows/wheels.yaml`**:
   - Added cache restore step before building wheels
   - Added cache save step after building wheels (only when cache misses)
   - Cache is keyed by: `deps-{platform}-boost-{version}-yaml-{version}-castxml-{version}`
   - Different environment variable handling for Linux (containerized) vs macOS (native)

2. **`.github/workflows/before_build.sh`**:
   - Modified `install_boost()`, `install_yaml_cpp()`, and `install_castxml()` functions to check for cached dependencies
   - If cached dependencies exist, they are restored instead of being rebuilt
   - After building, dependencies are saved to cache for future use
   - Cache directory passed via `OMPL_DEPS_CACHE_DIR` environment variable
   
 ### Benefits:

- **Dramatic build time reduction**: First build for each configuration still builds from source, but subsequent builds reuse cached dependencies
- **Cross-Python version efficiency**: Each Python version (3.10-3.13) can share the same cached Boost build specific to that version
- **Platform-specific caching**: Separate caches for each OS/architecture combination
- **Backward compatible**: If caching fails or cache is unavailable, builds fall back to building from source
