### PR TITLE
add build option to control shared/static build

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -153,6 +153,12 @@ endif()
 # R is needed for running Planner Arena locally
 find_program(R_EXEC R)
 
+# default to building shared libs except Windows
+if (MSVC)
+    option(OMPL_BUILD_SHARED "Build OMPL as a shared library" OFF)
+else()
+    option(OMPL_BUILD_SHARED "Build OMPL as a shared library" ON)
+endif()
 add_subdirectory(src)
 add_subdirectory(py-bindings)
 

--- a/doc/markdown/buildOptions.md
+++ b/doc/markdown/buildOptions.md
@@ -7,6 +7,7 @@ If you are building OMPL from source, there are several options that you can use
 | OMPL_BUILD_DEMOS              | ON            | Compile the OMPL demo programs. (The binaries are never installed.) |
 | OMPL_BUILD_PYBINDINGS         | ON            | Whether to compile the Python bindings (requires Py++). |
 | OMPL_BUILD_PYTESTS            | ON            | Whether the Python tests should be added to the `test` target. |
+| OMPL_BUILD_SHARED             | ON            | Whether the OMPL library should be a static or dynamic library (the default on Windows is to build a static library)
 | OMPL_BUILD_TESTS              | ON            | Wether to compile the C++ unit tests |
 | OMPL_BUILD_VAMP               | ON            | Build VAMP (Vector-Accelerated Motion Planning) submodule for enhanced collision checking performance. |
 | OMPL_REGISTRATION             | ON            | Whether the registration page is shown. (Disabling it might be useful for build bots.) |

--- a/src/ompl/CMakeLists.txt
+++ b/src/ompl/CMakeLists.txt
@@ -50,18 +50,24 @@ target_link_libraries(ompl
     PRIVATE
         "$<$<BOOL:${OMPL_HAVE_SPOT}>:Spot::Spot>")
 
-if (MSVC)
-    set_target_properties(ompl PROPERTIES VERSION "${PROJECT_VERSION}" STATIC_LIBRARY_FLAGS "psapi.lib ws2_32.lib")
-else (MSVC)
+set_target_properties(ompl PROPERTIES VERSION "${PROJECT_VERSION}")
+
+if (OMPL_BUILD_SHARED)
+    set_target_properties(ompl PROPERTIES SOVERSION "${OMPL_ABI_VERSION}")
     if (MINGW)
         target_link_libraries(ompl psapi ws2_32)
         set_target_properties(ompl PROPERTIES LINK_FLAGS "-Wl,--export-all-symbols")
-    endif (MINGW)
-    set_target_properties(ompl PROPERTIES VERSION "${PROJECT_VERSION}" SOVERSION "${OMPL_ABI_VERSION}")
-endif (MSVC)
+    endif()
+else()
+    if (MSVC)
+        set_target_properties(ompl PROPERTIES STATIC_LIBRARY_FLAGS "psapi.lib ws2_32.lib")
+    elseif (MINGW)
+        target_link_libraries(ompl psapi ws2_32)
+    endif()
+endif()
 
-if (NOT MSVC)
+if (OMPL_BUILD_SHARED)
     add_custom_command(TARGET ompl POST_BUILD
         COMMAND "${CMAKE_COMMAND}" -E copy "$<TARGET_FILE:ompl>"
         "${CMAKE_CURRENT_SOURCE_DIR}/../../py-bindings/ompl/util/libompl${CMAKE_SHARED_LIBRARY_SUFFIX}")
-endif (NOT MSVC)
+endif (OMPL_BUILD_SHARED)

--- a/src/ompl/CMakeLists.txt
+++ b/src/ompl/CMakeLists.txt
@@ -34,10 +34,10 @@ source_group("OMPL Source" FILES "${OMPL_SOURCE_CODE}")
 source_group("OMPL Headers" FILES "${OMPL_HEADERS}")
 
 # build the library
-if(MSVC)
-    add_library(ompl STATIC ${OMPL_SOURCE_CODE})
-else()
+if(OMPL_BUILD_SHARED)
     add_library(ompl SHARED ${OMPL_SOURCE_CODE})
+else()
+    add_library(ompl STATIC ${OMPL_SOURCE_CODE})
 endif()
 add_library(ompl::ompl ALIAS ompl)
 target_link_libraries(ompl


### PR DESCRIPTION
this doesn't change any of the defaults, but makes it possible to create a static build of libompl with a cmake option.