### PR TITLE
Add Greedy RRT* (G-RRT*) - bidirectional anytime planner

### DIFF
--- a/demos/OptimalPlanning.cpp
+++ b/demos/OptimalPlanning.cpp
@@ -53,6 +53,7 @@
 #include <ompl/geometric/planners/fmt/FMT.h>
 #include <ompl/geometric/planners/fmt/BFMT.h>
 #include <ompl/geometric/planners/prm/PRMstar.h>
+#include <ompl/geometric/planners/rrt/GreedyRRTstar.h>
 #include <ompl/geometric/planners/rrt/InformedRRTstar.h>
 #include <ompl/geometric/planners/rrt/RRTstar.h>
 #include <ompl/geometric/planners/rrt/SORRTstar.h>
@@ -82,6 +83,7 @@ enum optimalPlanner
     PLANNER_EITSTAR,
     PLANNER_EIRMSTAR,
     PLANNER_FMTSTAR,
+    PLANNER_GREEDY_RRTSTAR,
     PLANNER_INF_RRTSTAR,
     PLANNER_PRMSTAR,
     PLANNER_RRTSTAR,
@@ -196,6 +198,11 @@ ob::PlannerPtr allocatePlanner(ob::SpaceInformationPtr si, optimalPlanner planne
         case PLANNER_FMTSTAR:
         {
             return std::make_shared<og::FMT>(si);
+            break;
+        }
+        case PLANNER_GREEDY_RRTSTAR:
+        {
+            return std::make_shared<og::GreedyRRTstar>(si);
             break;
         }
         case PLANNER_INF_RRTSTAR:
@@ -455,7 +462,7 @@ bool argParse(int argc, char **argv, double *runTimePtr, optimalPlanner *planner
         "planner,p", bpo::value<std::string>()->default_value("BLITstar"),
         "(Optional) Specify the optimal planner to use, defaults to RRTstar if not given. "
         "Valid options are AITstar, "
-        "AORRTC, BFMTstar, BITstar, BLITstar, CForest, EITstar, EIRMstar, FMTstar, InformedRRTstar, PRMstar, RRTstar, "
+        "AORRTC, BFMTstar, BITstar, BLITstar, CForest, EITstar, EIRMstar, FMTstar, GreedyRRTstar, InformedRRTstar, PRMstar, RRTstar, "
         "and SORRTstar.")  // Alphabetical order
         ("objective,o", bpo::value<std::string>()->default_value("PathLength"),
          "(Optional) Specify the optimization objective, defaults to PathLength if not given. Valid options are "
@@ -546,6 +553,10 @@ bool argParse(int argc, char **argv, double *runTimePtr, optimalPlanner *planner
     else if (boost::iequals("FMTstar", plannerStr))
     {
         *plannerPtr = PLANNER_FMTSTAR;
+    }
+    else if (boost::iequals("GreedyRRTstar", plannerStr))
+    {
+        *plannerPtr = PLANNER_GREEDY_RRTSTAR;
     }
     else if (boost::iequals("InformedRRTstar", plannerStr))
     {

--- a/demos/OptimalPlanning.py
+++ b/demos/OptimalPlanning.py
@@ -169,6 +169,8 @@ def allocatePlanner(si, plannerType):
         return og.BITstar(si)
     elif plannerType.lower() == "fmtstar":
         return og.FMT(si)
+    elif plannerType.lower() == "greedyrrtstar":
+        return og.GreedyRRTstar(si)
     elif plannerType.lower() == "informedrrtstar":
         return og.InformedRRTstar(si)
     elif plannerType.lower() == "prmstar":
@@ -290,6 +292,7 @@ if __name__ == "__main__":
             "BFMTstar",
             "BITstar",
             "FMTstar",
+            "GreedyRRTstar",
             "InformedRRTstar",
             "PRMstar",
             "RRTstar",

--- a/src/ompl/geometric/planners/rrt/GreedyRRTstar.h
+++ b/src/ompl/geometric/planners/rrt/GreedyRRTstar.h
@@ -1,0 +1,625 @@
+/*********************************************************************
+ * Software License Agreement (BSD License)
+ *
+ *  Copyright (c) 2025, University of Toronto
+ *  All rights reserved.
+ *
+ *  Redistribution and use in source and binary forms, with or without
+ *  modification, are permitted provided that the following conditions
+ *  are met:
+ *
+ *   * Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *   * Redistributions in binary form must reproduce the above
+ *     copyright notice, this list of conditions and the following
+ *     disclaimer in the documentation and/or other materials provided
+ *     with the distribution.
+ *   * Neither the name of University of Toronto nor the names of its
+ *     contributors may be used to endorse or promote products derived
+ *     from this software without specific prior written permission.
+ *
+ *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ *  "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ *  LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ *  FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ *  COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ *  INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ *  BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ *  LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ *  CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ *  LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ *  ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ *  POSSIBILITY OF SUCH DAMAGE.
+ *********************************************************************/
+
+/* Authors: Phone Thiha Kyaw */
+
+#ifndef OMPL_GEOMETRIC_PLANNERS_RRT_GREEDY_RRTSTAR_
+#define OMPL_GEOMETRIC_PLANNERS_RRT_GREEDY_RRTSTAR_
+
+#include "ompl/geometric/planners/PlannerIncludes.h"
+#include "ompl/base/OptimizationObjective.h"
+#include "ompl/datastructures/NearestNeighbors.h"
+#include "ompl/base/goals/GoalState.h"
+
+#include <limits>
+#include <vector>
+#include <queue>
+#include <deque>
+#include <utility>
+#include <list>
+
+namespace ompl
+{
+    namespace geometric
+    {
+        /**
+            @anchor gGreedyRRTstar
+
+            @par Short description
+            \ref gGreedyRRTstar "G-RRT*" is a greedy version of the anytime Rapidly-exploring Random Trees algorithm
+            (RRT*). It finds initial solutions as quickly as RRT-Connect by maintaining two balanced trees rooted at the
+            start and goal, advancing toward each other using greedy connection heuristics. The algorithm then performs
+            incremental rewiring of the growing trees to asymptotically finds better solutions, similar to RRT*. Both
+            approximation and search in G-RRT* use a greedy version of the direct informed sampling heuristic to focus
+            exploration on promising regions of the state space.
+
+            @par Associated publications:
+
+            Kyaw, P. T., Le, A. V., Elara, M. R., & Kelly, J. (2025).
+            Greedy heuristics for sampling-based motion planning in high-dimensional state spaces.
+            arXiv preprint arXiv:2405.03411.
+            DOI: <a href="https://doi.org/10.48550/arXiv.2405.03411">arXiv.2405.03411</a>.
+            arXiv: <a href="https://arxiv.org/abs/2405.03411">2405.03411 [cs.RO]</a>.
+
+            Kyaw, P. T., et al..(2022).
+            Energy-efficient path planning of reconfigurable robots in complex environments.
+            IEEE Transactions on Robotics, 38(4), 2481-2494.
+            DOI: <a href="https://doi.org/10.1109/TRO.2022.3147408">TRO.2022.3147408</a>.
+        */
+
+        /** \brief Greedy version of the anytime Rapidly-exploring Random Trees algorithm */
+        class GreedyRRTstar : public base::Planner
+        {
+        public:
+            /** \brief Constructor */
+            GreedyRRTstar(const base::SpaceInformationPtr &si);
+
+            ~GreedyRRTstar() override;
+
+            void getPlannerData(base::PlannerData &data) const override;
+
+            base::PlannerStatus solve(const base::PlannerTerminationCondition &ptc) override;
+
+            void clear() override;
+
+            /** \brief Set the range the planner is supposed to use.
+
+                This parameter greatly influences the runtime of the
+                algorithm. It represents the maximum length of a
+                motion to be added in the tree of motions. */
+            void setRange(double distance)
+            {
+                maxDistance_ = distance;
+            }
+
+            /** \brief Get the range the planner is using */
+            double getRange() const
+            {
+                return maxDistance_;
+            }
+
+            /** \brief Option that delays collision checking procedures.
+                When it is enabled, all neighbors are sorted by cost. The
+                planner then goes through this list, starting with the lowest
+                cost, checking for collisions in order to find a parent. The planner
+                stops iterating through the list when a collision free parent is found.
+                This prevents the planner from collision checking each neighbor, reducing
+                computation time in scenarios where collision checking procedures are expensive.*/
+            void setDelayCC(bool delayCC)
+            {
+                delayCC_ = delayCC;
+            }
+
+            /** \brief Get the state of the delayed collision checking option */
+            bool getDelayCC() const
+            {
+                return delayCC_;
+            }
+
+            /** \brief Option that delays rewiring procedures until an initial solution is found */
+            void setDelayRewiring(bool delayRewiring)
+            {
+                delayRewiring_ = delayRewiring;
+            }
+
+            /** \brief Get the state of the delayed rewiring option */
+            bool getDelayRewiring() const
+            {
+                return delayRewiring_;
+            }
+
+            /** \brief Option to use greedy best cost as gating to reject xnew during vertex expansion process.
+             * If this is set to false, current solution cost will be used as gating cost instead */
+            void setGreedyHeuristicGating(bool useGreedyHeuristicGating)
+            {
+                useGreedyHeuristicGating_ = useGreedyHeuristicGating;
+            }
+
+            /** \brief Get the state of the greedy heuristic gating option */
+            bool getGreedyHeuristicGating() const
+            {
+                return useGreedyHeuristicGating_;
+            }
+
+            /** \brief Option to use the balanced bidirectional search (ensures that both trees are the same size) */
+            void setBalancedSearch(bool useBalancedBiDirectionalSearch)
+            {
+                useBalancedBiDirectionalSearch_ = useBalancedBiDirectionalSearch;
+            }
+
+            /** \brief Get the state of the balanced bidirectional search option */
+            bool getBalancedSearch() const
+            {
+                return useBalancedBiDirectionalSearch_;
+            }
+
+            /** \brief Controls whether the tree is pruned during the search. This pruning removes
+                a vertex if and only if it \e and all its descendents passes the pruning condition.
+                The pruning condition is whether the lower-bounding estimate of a solution
+                constrained to pass the the \e vertex is greater than the current solution.
+                Considering the descendents of a vertex prevents removing a descendent
+                that may actually be capable of later providing a better solution once
+                its incoming path passes through a different vertex (e.g., a change in homotopy class). */
+            void setTreePruning(bool prune);
+
+            /** \brief Get the state of the pruning option. */
+            bool getTreePruning() const
+            {
+                return useTreePruning_;
+            }
+
+            /** \brief Set the fractional change in solution cost necessary for pruning to occur, i.e.,
+                prune if the new solution is at least X% better than the old solution.
+                (e.g., 0.0 will prune after every new solution, while 1.0 will never prune.) */
+            void setPruneThreshold(const double pp)
+            {
+                pruneThreshold_ = pp;
+            }
+
+            /** \brief Get the current prune states percentage threshold parameter. */
+            double getPruneThreshold() const
+            {
+                return pruneThreshold_;
+            }
+
+            /** \brief Use the measure of the pruned subproblem instead of the measure of the entire problem domain (if
+            such an expression exists and a solution is present).
+            Currently the only method to calculate this measure in closed-form is through a informed sampler, so this
+            option also requires that. */
+            void setPrunedMeasure(bool informedMeasure);
+
+            /** \brief Get the state of using the pruned measure */
+            bool getPrunedMeasure() const
+            {
+                return usePrunedMeasure_;
+            }
+
+            /** \brief Use direct sampling of the heuristic for the generation of random samples (e.g., x_rand).
+           If a direct sampling method is not defined for the objective, rejection sampling will be used by default. */
+            void setInformedSampling(bool informedSampling);
+
+            /** \brief Get the state direct heuristic sampling */
+            bool getInformedSampling() const
+            {
+                return useInformedSampling_;
+            }
+
+            /** \brief Use greedy informed sampling to exploit the existing solution path for faster convergence rates
+             */
+            void setGreedyInformedSampling(bool greedyInformedSampling)
+            {
+                useGreedyInformedSampling_ = greedyInformedSampling;
+            }
+
+            /** \brief Get the state greedy informed sampling */
+            bool getGreedyInformedSampling() const
+            {
+                return useGreedyInformedSampling_;
+            }
+
+            /** \brief Controls whether pruning and new-state rejection uses an admissible cost-to-come estimate or not
+             */
+            void setAdmissibleCostToCome(const bool admissible)
+            {
+                useAdmissibleCostToCome_ = admissible;
+            }
+
+            /** \brief Get the admissibility of the pruning and new-state rejection heuristic */
+            bool getAdmissibleCostToCome() const
+            {
+                return useAdmissibleCostToCome_;
+            }
+
+            /** \brief Use a k-nearest search for rewiring instead of a r-disc search. */
+            void setKNearest(bool useKNearest)
+            {
+                useKNearest_ = useKNearest;
+            }
+
+            /** \brief Get the state of using a k-nearest search for rewiring. */
+            bool getKNearest() const
+            {
+                return useKNearest_;
+            }
+
+            /** \brief Set the number of attempts to make while performing rejection or informed sampling */
+            void setNumSamplingAttempts(unsigned int numAttempts)
+            {
+                numSampleAttempts_ = numAttempts;
+            }
+
+            /** \brief Get the number of attempts to make while performing rejection or informed sampling */
+            unsigned int getNumSamplingAttempts() const
+            {
+                return numSampleAttempts_;
+            }
+
+            /** \brief Set the rewiring scale factor, s, such that r_rrg = s \times r_rrg* (or k_rrg = s \times k_rrg*)
+             */
+            void setRewireFactor(double rewireFactor)
+            {
+                rewireFactor_ = rewireFactor;
+                calculateRewiringLowerBounds();
+            }
+
+            /** \brief Set the rewiring scale factor, s, such that r_rrg = s \times r_rrg* > r_rrg* (or k_rrg = s \times
+             * k_rrg* > k_rrg*) */
+            double getRewireFactor() const
+            {
+                return rewireFactor_;
+            }
+
+            /** \brief Set a different nearest neighbors datastructure */
+            template <template <typename T> class NN>
+            void setNearestNeighbors()
+            {
+                if ((tStart_ && tStart_->size() != 0) || (tGoal_ && tGoal_->size() != 0))
+                    OMPL_WARN("Calling setNearestNeighbors will clear all states.");
+                clear();
+                tStart_ = std::make_shared<NN<Motion *>>();
+                tGoal_ = std::make_shared<NN<Motion *>>();
+                setup();
+            }
+
+            void setup() override;
+
+            /** \brief Set the greedy biasing ratio
+             *
+             * This ratio controls the exploration and exploitation of the random sampling
+             * process by sampling either from the informed set or from the greedy informed set.
+             * This probability is a real number between 0.0 and 1.0; if 0.0, it samples from the
+             * informed set with pure exploration, otherwise, setting to 1.0 will only sample from
+             * the greedy informed set with no exploration. */
+            void setGreedyBiasingRatio(double greedyBiasingRatio)
+            {
+                greedyBiasingRatio_ = greedyBiasingRatio;
+            }
+
+            /** \brief Get the greedy biasing ratio the planner is using */
+            double getGreedyBiasingRatio() const
+            {
+                return greedyBiasingRatio_;
+            }
+
+            unsigned int numIterations() const
+            {
+                return iterations_;
+            }
+
+            ompl::base::Cost bestCost() const
+            {
+                return bestCost_;
+            }
+
+            ompl::base::Cost greedyBestCost() const
+            {
+                return greedyBestCost_;
+            }
+
+            using Edge = std::pair<ompl::base::State *, ompl::base::State *>;
+
+            /** \brief Get all current edges from the start tree. */
+            std::vector<Edge> getStartTreeEdges() const;
+
+            /** \brief Get all current edges from the goal tree. */
+            std::vector<Edge> getGoalTreeEdges() const;
+
+            /** \brief Get all current connection edges between start and goal trees. */
+            std::vector<Edge> getConnectionEdges() const;
+
+        protected:
+            /** \brief Representation of a motion */
+            class Motion
+            {
+            public:
+                Motion() = default;
+
+                Motion(const base::SpaceInformationPtr &si) : state(si->allocState())
+                {
+                }
+
+                ~Motion() = default;
+
+                /** \brief The state contained by the motion */
+                base::State *state{nullptr};
+
+                /** \brief The parent motion in the exploration tree */
+                Motion *parent{nullptr};
+
+                /** \brief The root of the tree that the state belongs to*/
+                const base::State *root{nullptr};
+
+                /** \brief The cost up to this motion */
+                base::Cost cost;
+
+                /** \brief The incremental cost of this motion's parent to this motion (this is stored to save distance
+                 * computations in the updateChildCosts() method) */
+                base::Cost incCost;
+
+                /** \brief The set of motions descending from the current motion */
+                std::vector<Motion *> children;
+
+                /** \brief The connected motion from the other tree */
+                Motion *connection{nullptr};
+
+                /** \brief Set to true if this motion is connected to the other tree */
+                bool isConnectionPoint{false};
+            };
+
+            /** \brief A nearest-neighbor datastructure representing a tree of motions */
+            typedef std::shared_ptr<NearestNeighbors<Motion *>> TreeData;
+
+            /** \brief Gets the neighbours of a given motion, using either k-nearest of radius as appropriate. */
+            void getNeighbors(TreeData &tree, Motion *motion, std::vector<Motion *> &nbh) const;
+
+            /** \brief Removes the given motion from the parent's child list */
+            void removeFromParent(Motion *m);
+
+            /** \brief Updates the cost of the children of this node if the cost up to this node has changed */
+            void updateChildCosts(Motion *m);
+
+            /** \brief Add the children of a vertex to the given list. */
+            void addChildrenToList(std::queue<Motion *, std::deque<Motion *>> *motionList, Motion *motion);
+
+            /** \brief Check whether the given motion passes the specified cost threshold, meaning it will be \e kept
+             * during pruning */
+            bool keepCondition(const Motion *motion, const base::Cost &threshold, bool isStartTree) const;
+
+            /** \brief Prunes all those states which estimated total cost is higher than pruneTreeCost.
+                Returns the number of motions pruned. Depends on the parameter set by
+               setPruneStatesImprovementThreshold() */
+            int pruneTrees(const base::Cost &pruneTreeCost);
+
+            /** \brief Prunes all those states which estimated total cost is higher than pruneTreeCost.
+                Returns the number of motions pruned. Depends on the parameter set by
+               setPruneStatesImprovementThreshold() */
+            int pruneTree(TreeData &tree, const base::Cost &pruneTreeCost, bool isTreeStart);
+
+            /** \brief Computes the solution cost heuristically as the cost to come from start to the motion plus
+                 the cost to go from the motion to the goal. If the parameter \e use_admissible_heuristic
+                 (\e setAdmissibleCostToCome()) is true, a heuristic estimate of the cost to come is used;
+                 otherwise, the current cost to come to the motion is used (which may overestimate the cost
+                 through the motion). */
+            base::Cost solutionHeuristic(const Motion *motion, bool isTreeStart) const;
+
+            /** \brief Heuristically computes the cost to come from start to the motion, given a start or goal tree. */
+            ompl::base::Cost costToComeHeuristic(Motion *motion, bool isStartTree) const;
+
+            /** \brief Heuristically computes the cost to go from the motion to the goal, given a start or goal tree. */
+            ompl::base::Cost costToGoHeuristic(Motion *motion, bool isStartTree) const;
+
+            /** \brief Heuristically computes the cost to go from the motion to the goal, given a start or goal tree. */
+            ompl::base::Cost costToGoHeuristic(base::State *state, bool isStartTree) const;
+
+            /** \brief Information attached to growing a tree of motions (used internally) */
+            struct TreeGrowingInfo
+            {
+                base::State *xstate;
+                Motion *xmotion;
+                bool start;
+                bool checkForSolution;
+            };
+
+            /** \brief The state of the tree after an attempt to extend it */
+            enum GrowState
+            {
+                /// no progress has been made
+                TRAPPED,
+                /// progress has been made towards the randomly sampled state
+                ADVANCED,
+                /// the randomly sampled state was reached
+                REACHED
+            };
+
+            /** \brief Free the memory allocated by this planner */
+            void freeMemory();
+
+            // For sorting a list of costs and getting only their sorted indices
+            struct CostIndexCompare
+            {
+                CostIndexCompare(const std::vector<base::Cost> &costs, const base::OptimizationObjective &opt)
+                  : costs_(costs), opt_(opt)
+                {
+                }
+                bool operator()(unsigned i, unsigned j)
+                {
+                    return opt_.isCostBetterThan(costs_[i], costs_[j]);
+                }
+                const std::vector<base::Cost> &costs_;
+                const base::OptimizationObjective &opt_;
+            };
+
+            /** \brief Compute distance between motions (actually distance between contained states) */
+            double distanceFunction(const Motion *a, const Motion *b) const
+            {
+                return si_->distance(a->state, b->state);
+            }
+
+            /** \brief number of attempt to rewire trees */
+            unsigned int rewireTest{0};
+
+            /** \brief number of generated states*/
+            unsigned int statesGenerated{0};
+
+            /** \brief vectors used in solve function */
+            std::vector<base::Cost> costs;
+            std::vector<base::Cost> incCosts;
+            std::vector<std::size_t> sortedCostIndices;
+            std::vector<int> valid;
+
+            bool checkForSolution{false};
+
+            std::vector<Motion *> nbh;
+
+            /** \brief Grow a tree towards a random state */
+            GrowState growTree(TreeData &tree, TreeGrowingInfo &tgi, Motion *rmotion, CostIndexCompare &compareFn);
+
+            /** \brief Calculate the k_RRG* and r_RRG* terms */
+            void calculateRewiringLowerBounds();
+
+            /** \brief Generate a sample */
+            bool sampleUniform(base::State *statePtr);
+
+            /** \brief Create the samplers */
+            void allocSampler();
+
+            /** \brief An informed sampler */
+            base::InformedSamplerPtr infSampler_;
+
+            /** \brief The start tree */
+            TreeData tStart_;
+
+            /** \brief The goal tree */
+            TreeData tGoal_;
+
+            /** \brief A flag that toggles between expanding the start tree (true) or goal tree (false). */
+            bool startTree_{true};
+
+            /** \brief A fration of time a random state is sampled from the greedy informed set to control
+             * the exploration and exploitation process.  */
+            double greedyBiasingRatio_{.9};
+
+            /** \brief The maximum length of a motion to be added to a tree */
+            double maxDistance_{0.};
+
+            /** \brief Flag indicating whether intermediate states are added to the built tree of motions */
+            bool addIntermediateStates_;
+
+            /** \brief The random number generator */
+            RNG rng_;
+
+            /** \brief Option to use k-nearest search for rewiring */
+            bool useKNearest_{true};
+
+            /** \brief The rewiring factor, s, so that r_rrt = s \times r_rrt* > r_rrt* (or k_rrt = s \times k_rrt* >
+             * k_rrt*) */
+            double rewireFactor_{1.1};
+
+            /** \brief A constant for k-nearest rewiring calculations */
+            double k_rrt_{0u};
+
+            /** \brief A constant for r-disc rewiring calculations */
+            double r_rrt_{0.};
+
+            /** \brief Option to delay and reduce collision checking within iterations */
+            bool delayCC_{true};
+
+            /** \brief Option to delay the rewiring until initial solution has been found */
+            bool delayRewiring_{true};
+
+            /** \brief Option to use greedy best cost as gating to reject xnew during vertex expansion process.
+             * If this is set to false, current solution cost will be used as gating cost instead. */
+            bool useGreedyHeuristicGating_{false};
+
+            /** \brief Option to make the bidirectional search balanced */
+            bool useBalancedBiDirectionalSearch_{true};
+
+            /** \brief The measure of the problem when we pruned it (if this isn't in use, it will be set to
+             * si_->getSpaceMeasure())*/
+            double prunedMeasure_{0.};
+
+            /** \brief The tree is pruned when the change in solution cost is greater than this fraction. */
+            double pruneThreshold_{.05};
+
+            /** \brief Option to use the informed measure */
+            bool usePrunedMeasure_{false};
+
+            /** \brief Option to use informed sampling */
+            bool useInformedSampling_{false};
+
+            /** \brief Option to use informed sampling */
+            bool useGreedyInformedSampling_{false};
+
+            /** \brief The admissibility of the new-state rejection heuristic. */
+            bool useAdmissibleCostToCome_{true};
+
+            /** \brief The number of attempts to make at informed sampling */
+            unsigned int numSampleAttempts_{100u};
+
+            /** \brief Stores the start states as Motions. */
+            std::vector<Motion *> startMotions_;
+
+            /** \brief Stores the goal states as Motions. */
+            std::vector<Motion *> goalMotions_;
+
+            /** \brief A list of states in the tree that satisfy the goal condition */
+            std::vector<Motion *> bestGoalMotions_;
+
+            /** \brief The best goal motion. */
+            Motion *bestGoalMotion_{nullptr};
+
+            /** \brief Best cost found so far by algorithm */
+            base::Cost bestCost_{std::numeric_limits<double>::quiet_NaN()};
+
+            /** \brief Best greedy cost found so far by algorithm */
+            base::Cost greedyBestCost_{std::numeric_limits<double>::quiet_NaN()};
+
+            /** \brief The cost at which the graph was last pruned */
+            base::Cost prunedCost_{std::numeric_limits<double>::quiet_NaN()};
+
+            /** \brief Objective we're optimizing */
+            base::OptimizationObjectivePtr opt_;
+
+            /** \brief The pair of states in each tree connected during planning.  Used for PlannerData computation */
+            std::pair<Motion *, Motion *> bestConnectionPoint_;
+
+            /** \brief A list of The pair of states in each tree connected during planning.  Used for PlannerData
+             * computation */
+            std::vector<std::pair<Motion *, Motion *>> connectionPoints_;
+
+            /** \brief The status of the tree pruning option. */
+            bool useTreePruning_{false};
+
+            /** \brief Distance between the nearest pair of start tree and goal tree nodes. */
+            double distanceBetweenTrees_;
+
+            /** \brief Number of iterations the algorithm performed */
+            unsigned int iterations_{0u};
+
+            ///////////////////////////////////////
+            // Planner progress property functions
+            std::string numIterationsProperty() const
+            {
+                return std::to_string(numIterations());
+            }
+
+            std::string bestCostProperty() const
+            {
+                return std::to_string(bestCost().value());
+            }
+        };
+    }  // namespace geometric
+}  // namespace ompl
+
+#endif

--- a/src/ompl/geometric/planners/rrt/GreedyRRTstar.h
+++ b/src/ompl/geometric/planners/rrt/GreedyRRTstar.h
@@ -42,6 +42,7 @@
 #include "ompl/datastructures/NearestNeighbors.h"
 #include "ompl/base/goals/GoalState.h"
 
+#include <functional>
 #include <limits>
 #include <vector>
 #include <queue>
@@ -109,6 +110,16 @@ namespace ompl
                 return maxDistance_;
             }
 
+            /** \brief Set a custom distance function for nearest-neighbor queries.
+             *
+             * When set, nearest-neighbor lookups use this function instead of the
+             * state-space distance.  Must be called before setup(). */
+            void
+            setNNDistanceFunction(std::function<double(const ompl::base::State *, const ompl::base::State *)> distFun)
+            {
+                nnDistFun_ = std::move(distFun);
+            }
+
             /** \brief Option that delays collision checking procedures.
                 When it is enabled, all neighbors are sorted by cost. The
                 planner then goes through this list, starting with the lowest
@@ -139,17 +150,17 @@ namespace ompl
                 return delayRewiring_;
             }
 
-            /** \brief Option to use greedy best cost as gating to reject xnew during vertex expansion process.
-             * If this is set to false, current solution cost will be used as gating cost instead */
-            void setGreedyHeuristicGating(bool useGreedyHeuristicGating)
+            /** \brief Option to use greedy best cost during tree pruning process.
+             * If this is set to false, current solution cost will be used as pruning cost instead */
+            void setGreedyCostForTreePruning(bool useGreedyCostForTreePruning)
             {
-                useGreedyHeuristicGating_ = useGreedyHeuristicGating;
+                useGreedyCostForTreePruning_ = useGreedyCostForTreePruning;
             }
 
-            /** \brief Get the state of the greedy heuristic gating option */
-            bool getGreedyHeuristicGating() const
+            /** \brief Get the state of the greedy heuristic pruning option */
+            bool getGreedyCostForTreePruning() const
             {
-                return useGreedyHeuristicGating_;
+                return useGreedyCostForTreePruning_;
             }
 
             /** \brief Option to use the balanced bidirectional search (ensures that both trees are the same size) */
@@ -535,12 +546,15 @@ namespace ompl
             /** \brief Option to delay and reduce collision checking within iterations */
             bool delayCC_{true};
 
+            /** \brief Optional custom distance function for nearest-neighbor queries. */
+            std::function<double(const ompl::base::State *, const ompl::base::State *)> nnDistFun_;
+
             /** \brief Option to delay the rewiring until initial solution has been found */
             bool delayRewiring_{true};
 
-            /** \brief Option to use greedy best cost as gating to reject xnew during vertex expansion process.
-             * If this is set to false, current solution cost will be used as gating cost instead. */
-            bool useGreedyHeuristicGating_{false};
+            /** \brief Option to use greedy best cost during tree pruning process.
+             * If this is set to false, current solution cost will be used as pruning cost instead. */
+            bool useGreedyCostForTreePruning_{true};
 
             /** \brief Option to make the bidirectional search balanced */
             bool useBalancedBiDirectionalSearch_{true};

--- a/src/ompl/geometric/planners/rrt/src/GreedyRRTstar.cpp
+++ b/src/ompl/geometric/planners/rrt/src/GreedyRRTstar.cpp
@@ -1,0 +1,1577 @@
+/*********************************************************************
+ * Software License Agreement (BSD License)
+ *
+ *  Copyright (c) 2025, University of Toronto
+ *  All rights reserved.
+ *
+ *  Redistribution and use in source and binary forms, with or without
+ *  modification, are permitted provided that the following conditions
+ *  are met:
+ *
+ *   * Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *   * Redistributions in binary form must reproduce the above
+ *     copyright notice, this list of conditions and the following
+ *     disclaimer in the documentation and/or other materials provided
+ *     with the distribution.
+ *   * Neither the name of University of Toronto nor the names of its
+ *     contributors may be used to endorse or promote products derived
+ *     from this software without specific prior written permission.
+ *
+ *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ *  "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ *  LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ *  FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ *  COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ *  INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ *  BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ *  LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ *  CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ *  LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ *  ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ *  POSSIBILITY OF SUCH DAMAGE.
+ *********************************************************************/
+
+/* Authors: Phone Thiha Kyaw */
+
+#include "ompl/geometric/planners/rrt/GreedyRRTstar.h"
+#include "ompl/base/goals/GoalSampleableRegion.h"
+#include "ompl/base/objectives/PathLengthOptimizationObjective.h"
+#include "ompl/tools/config/SelfConfig.h"
+#include "ompl/util/String.h"
+#include "ompl/util/GeometricEquations.h"
+#include "ompl/base/samplers/InformedStateSampler.h"
+
+#include <algorithm>
+#include <boost/math/constants/constants.hpp>
+#include <limits>
+#include <vector>
+
+ompl::geometric::GreedyRRTstar::GreedyRRTstar(const base::SpaceInformationPtr &si) : base::Planner(si, "GreedyRRTstar")
+{
+    specs_.approximateSolutions = true;
+    specs_.recognizedGoal = base::GOAL_SAMPLEABLE_REGION;
+    specs_.directed = true;
+
+    Planner::declareParam<double>("range", this, &GreedyRRTstar::setRange, &GreedyRRTstar::getRange, "0.:1.:10000.");
+    Planner::declareParam<double>("rewire_factor", this, &GreedyRRTstar::setRewireFactor,
+                                  &GreedyRRTstar::getRewireFactor, "1.0:0.01:2.0");
+    Planner::declareParam<double>("greedy_biasing_ratio", this, &GreedyRRTstar::setGreedyBiasingRatio,
+                                  &GreedyRRTstar::getGreedyBiasingRatio, "0.:0.01:1.0");
+    Planner::declareParam<bool>("use_k_nearest", this, &GreedyRRTstar::setKNearest, &GreedyRRTstar::getKNearest, "0,1");
+    Planner::declareParam<bool>("delay_collision_checking", this, &GreedyRRTstar::setDelayCC,
+                                &GreedyRRTstar::getDelayCC, "0,1");
+    Planner::declareParam<bool>("delay_rewiring", this, &GreedyRRTstar::setDelayRewiring,
+                                &GreedyRRTstar::getDelayRewiring, "0,1");
+    Planner::declareParam<bool>("greedy_heuristic_gating", this, &GreedyRRTstar::setGreedyHeuristicGating,
+                                &GreedyRRTstar::getGreedyHeuristicGating, "0,1");
+    Planner::declareParam<bool>("balanced_search", this, &GreedyRRTstar::setBalancedSearch,
+                                &GreedyRRTstar::getBalancedSearch, "0,1");
+    Planner::declareParam<unsigned int>("number_sampling_attempts", this, &GreedyRRTstar::setNumSamplingAttempts,
+                                        &GreedyRRTstar::getNumSamplingAttempts, "10:10:100000");
+
+    bestConnectionPoint_ = std::make_pair<Motion *, Motion *>(nullptr, nullptr);
+    connectionPoints_.clear();
+    distanceBetweenTrees_ = std::numeric_limits<double>::infinity();
+
+    addPlannerProgressProperty("iterations INTEGER", [this] { return numIterationsProperty(); });
+    addPlannerProgressProperty("best cost REAL", [this] { return bestCostProperty(); });
+
+    setAdmissibleCostToCome(true);
+    setInformedSampling(true);
+    setGreedyInformedSampling(true);
+    setTreePruning(true);
+    setPrunedMeasure(true);
+}
+
+ompl::geometric::GreedyRRTstar::~GreedyRRTstar()
+{
+    freeMemory();
+}
+
+void ompl::geometric::GreedyRRTstar::setup()
+{
+    Planner::setup();
+    tools::SelfConfig sc(si_, getName());
+    sc.configurePlannerRange(maxDistance_);
+
+    if (!tStart_)
+        tStart_.reset(tools::SelfConfig::getDefaultNearestNeighbors<Motion *>(this));
+    if (!tGoal_)
+        tGoal_.reset(tools::SelfConfig::getDefaultNearestNeighbors<Motion *>(this));
+    tStart_->setDistanceFunction([this](const Motion *a, const Motion *b) { return distanceFunction(a, b); });
+    tGoal_->setDistanceFunction([this](const Motion *a, const Motion *b) { return distanceFunction(a, b); });
+
+    // Setup optimization objective
+    //
+    // If no optimization objective was specified, then default to
+    // optimizing path length as computed by the distance() function
+    // in the state space.
+    if (pdef_)
+    {
+        if (pdef_->hasOptimizationObjective())
+            opt_ = pdef_->getOptimizationObjective();
+        else
+        {
+            OMPL_INFORM("%s: No optimization objective specified. Defaulting to optimizing path length for the allowed "
+                        "planning time.",
+                        getName().c_str());
+            opt_ = std::make_shared<base::PathLengthOptimizationObjective>(si_);
+
+            // Store the new objective in the problem def'n
+            pdef_->setOptimizationObjective(opt_);
+        }
+
+        // Set the bestCost_ and prunedCost_ as infinite
+        bestCost_ = opt_->infiniteCost();
+        greedyBestCost_ = opt_->infiniteCost();
+        prunedCost_ = opt_->infiniteCost();
+    }
+    else
+    {
+        OMPL_INFORM("%s: problem definition is not set, deferring setup completion...", getName().c_str());
+        setup_ = false;
+    }
+
+    // Get the measure of the entire space:
+    prunedMeasure_ = si_->getSpaceMeasure();
+
+    // Calculate some constants:
+    calculateRewiringLowerBounds();
+}
+
+void ompl::geometric::GreedyRRTstar::freeMemory()
+{
+    std::vector<Motion *> motions;
+
+    if (tStart_)
+    {
+        tStart_->list(motions);
+        for (auto &motion : motions)
+        {
+            if (motion->state != nullptr)
+                si_->freeState(motion->state);
+            delete motion;
+        }
+    }
+
+    if (tGoal_)
+    {
+        tGoal_->list(motions);
+        for (auto &motion : motions)
+        {
+            if (motion->state != nullptr)
+                si_->freeState(motion->state);
+            delete motion;
+        }
+    }
+}
+
+void ompl::geometric::GreedyRRTstar::clear()
+{
+    setup_ = false;
+    Planner::clear();
+    infSampler_.reset();
+    freeMemory();
+    if (tStart_)
+        tStart_->clear();
+    if (tGoal_)
+        tGoal_->clear();
+    bestConnectionPoint_ = std::make_pair<Motion *, Motion *>(nullptr, nullptr);
+    connectionPoints_.clear();
+    costs.clear();
+    incCosts.clear();
+    sortedCostIndices.clear();
+    valid.clear();
+    nbh.clear();
+    distanceBetweenTrees_ = std::numeric_limits<double>::infinity();
+
+    iterations_ = 0;
+    bestCost_ = base::Cost(std::numeric_limits<double>::quiet_NaN());
+    greedyBestCost_ = base::Cost(std::numeric_limits<double>::quiet_NaN());
+    prunedCost_ = base::Cost(std::numeric_limits<double>::quiet_NaN());
+    prunedMeasure_ = 0.0;
+
+    goalMotions_.clear();
+    startMotions_.clear();
+
+    bestGoalMotion_ = nullptr;
+    bestGoalMotions_.clear();
+}
+
+ompl::geometric::GreedyRRTstar::GrowState ompl::geometric::GreedyRRTstar::growTree(TreeData &tree, TreeGrowingInfo &tgi,
+                                                                                   Motion *rmotion,
+                                                                                   CostIndexCompare &compareFn)
+{
+    tgi.checkForSolution = false;
+
+    /* find closest state in the tree */
+    Motion *nmotion = tree->nearest(rmotion);
+
+    /* assume we can reach the state we go towards */
+    bool reach = true;
+
+    /* find state to add */
+    base::State *dstate = rmotion->state;
+    double d = si_->distance(nmotion->state, rmotion->state);
+    if (d > maxDistance_)
+    {
+        si_->getStateSpace()->interpolate(nmotion->state, rmotion->state, maxDistance_ / d, tgi.xstate);
+
+        /* Check if we have moved at all. Due to some stranger state spaces (e.g., the constrained state spaces),
+         * interpolate can fail and no progress is made. Without this check, the algorithm gets stuck in a loop as it
+         * thinks it is making progress, when none is actually occurring. */
+        if (si_->equalStates(nmotion->state, tgi.xstate))
+            return TRAPPED;
+
+        dstate = tgi.xstate;
+        reach = false;
+    }
+
+    /////////////////////////////////////////////////////////////////////////////////////
+
+    // x_new is rejected if connecting to it does not improve the current best cost (or greedy best cost)
+    // check if g(xnear) + c(xnear, xnew) + hhat(xnew) can improve that cost
+    // this will also make sure both trees are not overlapping each other
+
+    if (bestGoalMotion_)
+    {
+        auto soln_heuristic_cost =
+            opt_->combineCosts(opt_->combineCosts(nmotion->cost, opt_->motionCost(nmotion->state, dstate)),
+                               costToGoHeuristic(dstate, tgi.start));
+
+        if (!opt_->isCostBetterThan(soln_heuristic_cost, useGreedyHeuristicGating_ ? greedyBestCost_ : bestCost_))
+        {
+            return TRAPPED;
+        }
+    }
+
+    /////////////////////////////////////////////////////////////////////////////////////
+
+    bool validMotion = tgi.start ? si_->checkMotion(nmotion->state, dstate) :
+                                   si_->isValid(dstate) && si_->checkMotion(dstate, nmotion->state);
+
+    if (!validMotion)
+    {
+        return TRAPPED;
+    }
+
+    Motion *motion = new Motion(si_);
+    si_->copyState(motion->state, dstate);
+    motion->parent = nmotion;
+    motion->root = nmotion->root;
+    motion->isConnectionPoint = false;
+    motion->incCost = opt_->motionCost(nmotion->state, motion->state);
+    motion->cost = opt_->combineCosts(nmotion->cost, motion->incCost);
+
+    // we delay the parent selection and rewiring until we found an initial solution
+    if (delayRewiring_)
+    {
+        if (!bestGoalMotion_)
+        {
+            tree->add(motion);
+            tgi.xmotion = motion;
+            motion->parent->children.push_back(motion);
+
+            return reach ? REACHED : ADVANCED;
+        }
+    }
+
+    // Find nearby neighbors of the new motion
+    getNeighbors(tree, motion, nbh);
+
+    rewireTest += nbh.size();
+    ++statesGenerated;
+
+    // cache for distance computations
+    //
+    // Our cost caches only increase in size, so they're only
+    // resized if they can't fit the current neighborhood
+    if (costs.size() < nbh.size())
+    {
+        costs.resize(nbh.size());
+        incCosts.resize(nbh.size());
+        sortedCostIndices.resize(nbh.size());
+    }
+
+    // cache for motion validity (only useful in a symmetric space)
+    //
+    // Our validity caches only increase in size, so they're
+    // only resized if they can't fit the current neighborhood
+    if (valid.size() < nbh.size())
+        valid.resize(nbh.size());
+    std::fill(valid.begin(), valid.begin() + nbh.size(), 0);
+
+    // Finding the nearest neighbor to connect to
+    // By default, neighborhood states are sorted by cost, and collision checking
+    // is performed in increasing order of cost
+    if (delayCC_)
+    {
+        // calculate all costs and distances
+        for (std::size_t i = 0; i < nbh.size(); ++i)
+        {
+            incCosts[i] = opt_->motionCost(nbh[i]->state, motion->state);
+            costs[i] = opt_->combineCosts(nbh[i]->cost, incCosts[i]);
+        }
+
+        // sort the nodes
+        //
+        // we're using index-value pairs so that we can get at
+        // original, unsorted indices
+        for (std::size_t i = 0; i < nbh.size(); ++i)
+            sortedCostIndices[i] = i;
+        std::sort(sortedCostIndices.begin(), sortedCostIndices.begin() + nbh.size(), compareFn);
+
+        // collision check until a valid motion is found
+        //
+        // ASYMMETRIC CASE: it's possible that none of these
+        // neighbors are valid. This is fine, because motion
+        // already has a connection to the tree through
+        // nmotion (with populated cost fields!).
+        for (std::vector<std::size_t>::const_iterator i = sortedCostIndices.begin();
+             i != sortedCostIndices.begin() + nbh.size(); ++i)
+        {
+            if (nbh[*i] == nmotion ||
+                ((!useKNearest_ || si_->distance(nbh[*i]->state, motion->state) < maxDistance_) &&
+                 (tgi.start ? si_->checkMotion(nbh[*i]->state, motion->state) :
+                              si_->isValid(motion->state) && si_->checkMotion(motion->state, nbh[*i]->state))))
+            {
+                motion->incCost = incCosts[*i];
+                motion->cost = costs[*i];
+                motion->parent = nbh[*i];
+                valid[*i] = 1;
+                break;
+            }
+            else
+                valid[*i] = -1;
+        }
+    }
+    else  // if not delayCC
+    {
+        motion->incCost = opt_->motionCost(nmotion->state, motion->state);
+        motion->cost = opt_->combineCosts(nmotion->cost, motion->incCost);
+        // find which one we connect the new state to
+        for (std::size_t i = 0; i < nbh.size(); ++i)
+        {
+            if (nbh[i] != nmotion)
+            {
+                incCosts[i] = opt_->motionCost(nbh[i]->state, motion->state);
+                costs[i] = opt_->combineCosts(nbh[i]->cost, incCosts[i]);
+
+                if (opt_->isCostBetterThan(costs[i], motion->cost))
+                {
+                    if ((!useKNearest_ || si_->distance(nbh[i]->state, motion->state) < maxDistance_) &&
+                        si_->checkMotion(nbh[i]->state, motion->state))
+                    {
+                        motion->incCost = incCosts[i];
+                        motion->cost = costs[i];
+                        motion->parent = nbh[i];
+                        valid[i] = 1;
+                    }
+                    else
+                        valid[i] = -1;
+                }
+            }
+            else
+            {
+                incCosts[i] = motion->incCost;
+                costs[i] = motion->cost;
+                valid[i] = 1;
+            }
+        }
+    }
+
+    tree->add(motion);
+    motion->parent->children.push_back(motion);
+    tgi.xmotion = motion;
+
+    // rewiring
+    for (std::size_t i = 0; i < nbh.size(); ++i)
+    {
+        if (nbh[i] != motion->parent)
+        {
+            base::Cost nbhIncCost;
+            if (opt_->isSymmetric())
+                nbhIncCost = incCosts[i];
+            else
+                nbhIncCost = opt_->motionCost(motion->state, nbh[i]->state);
+            base::Cost nbhNewCost = opt_->combineCosts(motion->cost, nbhIncCost);
+            if (opt_->isCostBetterThan(nbhNewCost, nbh[i]->cost))
+            {
+                bool motionValid;
+                if (valid[i] == 0)
+                {
+                    motionValid = (!useKNearest_ || si_->distance(nbh[i]->state, motion->state) < maxDistance_) &&
+                                  si_->checkMotion(motion->state, nbh[i]->state);
+                }
+                else
+                {
+                    motionValid = (valid[i] == 1);
+                }
+
+                if (motionValid)
+                {
+                    // Remove this node from its parent list
+                    removeFromParent(nbh[i]);
+
+                    // Add this node to the new parent
+                    nbh[i]->parent = motion;
+                    nbh[i]->root = motion->root;
+                    nbh[i]->incCost = nbhIncCost;
+                    nbh[i]->cost = nbhNewCost;
+                    nbh[i]->parent->children.push_back(nbh[i]);
+
+                    // Update the costs of the node's children
+                    updateChildCosts(nbh[i]);
+
+                    tgi.checkForSolution = true;
+                }
+            }
+        }
+    }
+
+    /////////////////////////////////////////////////////////////////////////////////////
+
+    return reach ? REACHED : ADVANCED;
+}
+
+ompl::base::Cost ompl::geometric::GreedyRRTstar::costToComeHeuristic(Motion *motion, bool isStartTree) const
+{
+    if (isStartTree)
+    {
+        // find best cost to come heuristic
+        ompl::base::Cost best_cost_to_come_heuristic = opt_->infiniteCost();
+
+        // Find the min from each start
+        for (auto &startMotion : startMotions_)
+        {
+            best_cost_to_come_heuristic = opt_->betterCost(
+                best_cost_to_come_heuristic, opt_->motionCostHeuristic(startMotion->state, motion->state));
+        }
+
+        return best_cost_to_come_heuristic;
+    }
+
+    base::Cost costToCome = opt_->infiniteCost();
+
+    // Find the min from each goal
+    for (auto &goalMotion : goalMotions_)
+    {
+        costToCome = opt_->betterCost(
+            costToCome, opt_->motionCostHeuristic(motion->state, goalMotion->state));  // lower-bounding cost from the
+                                                                                       // state to the goal
+    }
+
+    return costToCome;
+}
+
+ompl::base::Cost ompl::geometric::GreedyRRTstar::costToGoHeuristic(Motion *motion, bool isStartTree) const
+{
+    if (isStartTree)
+    {
+        base::Cost costToGo = opt_->infiniteCost();
+
+        // Find the min from each goal
+        for (auto &goalMotion : goalMotions_)
+        {
+            costToGo = opt_->betterCost(
+                costToGo, opt_->motionCostHeuristic(motion->state, goalMotion->state));  // lower-bounding cost from the
+                                                                                         // state to the goal
+        }
+
+        return costToGo;
+    }
+
+    // find best cost to come heuristic
+    ompl::base::Cost best_cost_to_come_heuristic = opt_->infiniteCost();
+
+    // Find the min from each start
+    for (auto &startMotion : startMotions_)
+    {
+        best_cost_to_come_heuristic =
+            opt_->betterCost(best_cost_to_come_heuristic, opt_->motionCostHeuristic(startMotion->state, motion->state));
+    }
+
+    return best_cost_to_come_heuristic;
+}
+
+ompl::base::Cost ompl::geometric::GreedyRRTstar::costToGoHeuristic(base::State *state, bool isStartTree) const
+{
+    if (isStartTree)
+    {
+        base::Cost costToGo = opt_->infiniteCost();
+
+        // Find the min from each goal
+        for (auto &goalMotion : goalMotions_)
+        {
+            costToGo = opt_->betterCost(
+                costToGo, opt_->motionCostHeuristic(state, goalMotion->state));  // lower-bounding cost from the
+                                                                                 // state to the goal
+        }
+
+        return costToGo;
+    }
+
+    // find best cost to come heuristic
+    ompl::base::Cost best_cost_to_come_heuristic = opt_->infiniteCost();
+
+    // Find the min from each start
+    for (auto &startMotion : startMotions_)
+    {
+        best_cost_to_come_heuristic =
+            opt_->betterCost(best_cost_to_come_heuristic, opt_->motionCostHeuristic(startMotion->state, state));
+    }
+
+    return best_cost_to_come_heuristic;
+}
+
+ompl::base::PlannerStatus ompl::geometric::GreedyRRTstar::solve(const base::PlannerTerminationCondition &ptc)
+{
+    checkValidity();
+    auto *goal = dynamic_cast<base::GoalSampleableRegion *>(pdef_->getGoal().get());
+
+    if (goal == nullptr)
+    {
+        OMPL_ERROR("%s: Unknown type of goal", getName().c_str());
+        return base::PlannerStatus::UNRECOGNIZED_GOAL_TYPE;
+    }
+
+    while (const base::State *st = pis_.nextStart())
+    {
+        auto *motion = new Motion(si_);
+        si_->copyState(motion->state, st);
+        motion->cost = opt_->identityCost();
+        motion->root = motion->state;
+        tStart_->add(motion);
+        startMotions_.push_back(motion);
+    }
+
+    // And assure that, if we're using an informed sampler, it's reset
+    infSampler_.reset();
+
+    if (tStart_->size() == 0)
+    {
+        OMPL_ERROR("%s: Motion planning start tree could not be initialized!", getName().c_str());
+        return base::PlannerStatus::INVALID_START;
+    }
+
+    if (!goal->couldSample())
+    {
+        OMPL_ERROR("%s: Insufficient states in sampleable goal region", getName().c_str());
+        return base::PlannerStatus::INVALID_GOAL;
+    }
+
+    const base::ReportIntermediateSolutionFn intermediateSolutionCallback = pdef_->getIntermediateSolutionCallback();
+
+    TreeGrowingInfo tgi;
+    tgi.xstate = si_->allocState();
+
+    Motion *approxsol = nullptr;
+    double approxdif = std::numeric_limits<double>::infinity();
+    auto *rmotion = new Motion(si_);
+
+    valid.clear();
+    rewireTest = 0;
+    statesGenerated = 0;
+    costs.clear();
+    incCosts.clear();
+    sortedCostIndices.clear();
+    nbh.clear();
+
+    // our functor for sorting nearest neighbors
+    CostIndexCompare compareFn(costs, *opt_);
+
+    if (tGoal_->size() == 0 || pis_.getSampledGoalsCount() < tGoal_->size() / 2)
+    {
+        const base::State *st = tGoal_->size() == 0 ? pis_.nextGoal(ptc) : pis_.nextGoal();
+        if (st != nullptr)
+        {
+            auto *motion = new Motion(si_);
+            si_->copyState(motion->state, st);
+            motion->root = motion->state;
+            motion->cost = opt_->identityCost();
+            tGoal_->add(motion);
+            goalMotions_.push_back(motion);
+        }
+
+        if (tGoal_->size() == 0)
+        {
+            OMPL_ERROR("%s: Unable to sample any valid states for goal tree", getName().c_str());
+            return base::PlannerStatus::INVALID_GOAL;
+        }
+    }
+
+    // Allocate a sampler if necessary
+    if (!infSampler_)
+    {
+        OMPL_INFORM("%s: Creating informed sampler...", getName().c_str());
+        allocSampler();
+    }
+
+    OMPL_INFORM("%s: Starting planning with %d states already in datastructure (%d start and %d goal states). Size of "
+                "best goal motions: %d",
+                getName().c_str(), (int)(tStart_->size() + tGoal_->size()), (int)(tStart_->size()),
+                (int)(tGoal_->size()), bestGoalMotions_.size());
+
+    if (bestGoalMotion_)
+        OMPL_INFORM("%s: Starting planning with existing solution of cost %.5f", getName().c_str(), bestCost_.value());
+
+    if (useKNearest_)
+        OMPL_INFORM("%s: Initial k-nearest value of %u", getName().c_str(),
+                    (unsigned int)std::ceil(k_rrt_ * log((double)(tStart_->size() + tGoal_->size() + 1u))));
+    else
+        OMPL_INFORM("%s: Initial rewiring radius of %.2f", getName().c_str(),
+                    std::min(maxDistance_, r_rrt_ * std::pow(log((double)(tStart_->size() + tGoal_->size() + 1u)) /
+                                                                 ((double)(tStart_->size() + tGoal_->size() + 1u)),
+                                                             1 / (double)(si_->getStateDimension()))));
+
+    while (!ptc)
+    {
+        iterations_++;
+
+        TreeData &tree = startTree_ ? tStart_ : tGoal_;
+        tgi.start = startTree_;
+        startTree_ = !startTree_;
+        TreeData &otherTree = startTree_ ? tStart_ : tGoal_;
+
+        if (useBalancedBiDirectionalSearch_)
+        {
+            if ((std::abs(static_cast<float>(tree->size() - otherTree->size())) / tree->size()) < 1.f)
+            {
+                startTree_ = !startTree_;
+
+                TreeData &tree = startTree_ ? tStart_ : tGoal_;
+                tgi.start = startTree_;
+                startTree_ = !startTree_;
+                TreeData &otherTree = startTree_ ? tStart_ : tGoal_;
+            }
+        }
+
+        if (tGoal_->size() == 0 || pis_.getSampledGoalsCount() < tGoal_->size() / 2)
+        {
+            const base::State *st = tGoal_->size() == 0 ? pis_.nextGoal(ptc) : pis_.nextGoal();
+            if (st != nullptr)
+            {
+                auto *motion = new Motion(si_);
+                si_->copyState(motion->state, st);
+                motion->root = motion->state;
+                motion->cost = opt_->identityCost();
+                tGoal_->add(motion);
+                goalMotions_.push_back(motion);
+            }
+
+            if (tGoal_->size() == 0)
+            {
+                OMPL_ERROR("%s: Unable to sample any valid states for goal tree", getName().c_str());
+                break;
+            }
+        }
+
+        /* sample random state */
+        if (!sampleUniform(rmotion->state))
+            continue;
+
+        checkForSolution = false;
+        GrowState gs = growTree(tree, tgi, rmotion, compareFn);
+
+        if (gs != TRAPPED)
+        {
+            /* remember which motion was just added */
+            Motion *addedMotion = tgi.xmotion;
+
+            /* attempt to connect trees */
+
+            /* if reached, it means we used rstate directly, no need top copy again */
+            if (gs != REACHED)
+                si_->copyState(rmotion->state, tgi.xstate);
+
+            tgi.start = startTree_;
+
+            if (!tgi.checkForSolution)
+            {
+                GrowState gsc = ADVANCED;
+                while (gsc == ADVANCED)
+                    gsc = growTree(otherTree, tgi, rmotion, compareFn);
+
+                /* update distance between trees */
+                const double newDist = tree->getDistanceFunction()(addedMotion, otherTree->nearest(addedMotion));
+                if (newDist < distanceBetweenTrees_)
+                {
+                    distanceBetweenTrees_ = newDist;
+                }
+
+                Motion *startMotion = tgi.start ? tgi.xmotion : addedMotion;
+                Motion *goalMotion = tgi.start ? addedMotion : tgi.xmotion;
+
+                /* if we connected the trees in a valid way (start and goal pair is valid)*/
+                if (gsc == REACHED && goal->isStartGoalPairValid(startMotion->root, goalMotion->root))
+                {
+                    startMotion->isConnectionPoint = true;
+                    startMotion->connection = goalMotion;
+
+                    goalMotion->isConnectionPoint = true;
+                    goalMotion->connection = startMotion;
+
+                    bestGoalMotions_.push_back(goalMotion);
+
+                    checkForSolution = true;
+                }
+                else
+                {
+                    // We didn't reach the goal, but if we were extending the start
+                    // tree, then we can mark/improve the approximate path so far.
+                    if (tgi.start)
+                    {
+                        // We were working from the startTree.
+                        double dist = 0.0;
+                        goal->isSatisfied(tgi.xmotion->state, &dist);
+                        if (dist < approxdif)
+                        {
+                            approxdif = dist;
+                            approxsol = tgi.xmotion;
+                        }
+                    }
+                }
+            }
+
+            if (checkForSolution || tgi.checkForSolution)
+            {
+                bool updatedSolution = false;
+                if (!bestGoalMotion_ && !bestGoalMotions_.empty())
+                {
+                    bestGoalMotion_ = bestGoalMotions_.front();
+                    bestCost_ = opt_->combineCosts(bestGoalMotion_->connection->cost, bestGoalMotion_->cost);
+                    updatedSolution = true;
+
+                    OMPL_INFORM("%s: Found an initial solution with a cost of %.2f in %u iterations (%u "
+                                "vertices in both trees(%u in Start Tree and %u in Goal Tree))",
+                                getName().c_str(), bestCost_, iterations_, tStart_->size() + tGoal_->size(),
+                                tStart_->size(), tGoal_->size());
+                }
+                else
+                {
+                    // We already have a solution, iterate through the list of goal vertices
+                    // and see if there's any improvement.
+                    for (auto &goalMotion : bestGoalMotions_)
+                    {
+                        if (!goalMotion->connection || !goalMotion)
+                        {
+                            continue;
+                        }
+
+                        // Is this goal motion better than the (current) best?
+                        auto new_cost = opt_->combineCosts(goalMotion->connection->cost, goalMotion->cost);
+
+                        if (opt_->isCostBetterThan(new_cost, bestCost_))
+                        {
+                            bestGoalMotion_ = goalMotion;
+                            bestCost_ = new_cost;
+                            updatedSolution = true;
+
+                            // Check if it satisfies the optimization objective, if it does, break the for loop
+                            if (opt_->isSatisfied(bestCost_))
+                            {
+                                break;
+                            }
+                        }
+                    }
+                }
+
+                if (useGreedyInformedSampling_ && !bestGoalMotions_.empty())
+                {
+                    ompl::base::Cost c_max{-std::numeric_limits<double>::infinity()};
+
+                    Motion *iterMotion = bestGoalMotion_->connection;  // starting from best start point
+                    while (iterMotion != nullptr)
+                    {
+                        // combine heuristic costs f^: cost-to-come (g^) + cost-to-go (h^)
+                        auto c_best = opt_->combineCosts(costToComeHeuristic(iterMotion, true),
+                                                         costToGoHeuristic(iterMotion, true));
+
+                        if (opt_->isCostBetterThan(c_max, c_best))
+                        {
+                            c_max = c_best;
+                        }
+
+                        iterMotion = iterMotion->parent;
+                    }
+
+                    iterMotion = bestGoalMotion_;  // starting from best goal point itself
+                    while (iterMotion != nullptr)
+                    {
+                        // combine heuristic costs f^: cost-to-come (g^) + cost-to-go (h^)
+                        auto c_best = opt_->combineCosts(costToComeHeuristic(iterMotion, false),
+                                                         costToGoHeuristic(iterMotion, false));
+
+                        if (opt_->isCostBetterThan(c_max, c_best))
+                        {
+                            c_max = c_best;
+                        }
+
+                        iterMotion = iterMotion->parent;
+                    }
+
+                    // check if there is an improvement in the greedy cost
+                    if (opt_->isCostBetterThan(c_max, greedyBestCost_))
+                    {
+                        greedyBestCost_ = c_max;
+                        updatedSolution = true;
+                    }
+                }
+
+                if (updatedSolution)
+                {
+                    if (useTreePruning_)
+                    {
+                        if (greedyBiasingRatio_ <= 0.5)
+                            pruneTrees(bestCost_);
+                        else
+                            pruneTrees(greedyBestCost_);
+                    }
+
+                    if (intermediateSolutionCallback)
+                    {
+                        Motion *solution = bestGoalMotion_->connection;
+                        std::vector<Motion *> mpath1;
+                        while (solution != nullptr)
+                        {
+                            mpath1.push_back(solution);
+                            solution = solution->parent;
+                        }
+
+                        solution = bestGoalMotion_;
+                        std::vector<Motion *> mpath2;
+                        while (solution != nullptr)
+                        {
+                            mpath2.push_back(solution);
+                            solution = solution->parent;
+                        }
+
+                        std::vector<const base::State *> spath;
+
+                        spath.reserve(mpath1.size() + mpath2.size());
+                        for (int i = mpath1.size() - 1; i >= 0; --i)
+                            spath.push_back(mpath1[i]->state);
+                        for (auto &i : mpath2)
+                            spath.push_back(i->state);
+
+                        intermediateSolutionCallback(this, spath, bestCost_);
+                    }
+                }
+            }
+        }
+
+        // terminate if a sufficient solution is found
+        if (bestGoalMotion_ && opt_->isSatisfied(bestCost_))
+            break;
+    }
+
+    bool solutionFound = false;
+    if (bestGoalMotion_)
+    {
+        ptc.terminate();
+        solutionFound = true;
+
+        Motion *solution = bestGoalMotion_->connection;
+        std::vector<Motion *> mpath1;
+        while (solution != nullptr)
+        {
+            mpath1.push_back(solution);
+            solution = solution->parent;
+        }
+
+        solution = bestGoalMotion_;
+        std::vector<Motion *> mpath2;
+        while (solution != nullptr)
+        {
+            mpath2.push_back(solution);
+            solution = solution->parent;
+        }
+
+        auto path(std::make_shared<PathGeometric>(si_));
+        path->getStates().reserve(mpath1.size() + mpath2.size());
+        for (int i = mpath1.size() - 1; i >= 0; --i)
+            path->append(mpath1[i]->state);
+        for (auto &i : mpath2)
+            path->append(i->state);
+
+        // Add the solution path.
+        base::PlannerSolution psol(path);
+        psol.setPlannerName(getName());
+
+        // If we don't have a goal motion, the solution is approximate
+        if (!bestGoalMotion_)
+            psol.setApproximate(approxdif);
+
+        psol.setOptimized(opt_, opt_->combineCosts(bestGoalMotion_->connection->cost, bestGoalMotion_->cost),
+                          opt_->isSatisfied(bestCost_));
+        pdef_->addSolutionPath(psol);
+    }
+    else if (approxsol)
+    {
+        ptc.terminate();
+        solutionFound = true;
+
+        /* construct the solution path */
+        std::vector<Motion *> mpath;
+
+        Motion *solution = approxsol;
+        while (solution != nullptr)
+        {
+            mpath.push_back(solution);
+            solution = solution->parent;
+        }
+
+        auto path(std::make_shared<PathGeometric>(si_));
+        for (int i = mpath.size() - 1; i >= 0; --i)
+            path->append(mpath[i]->state);
+
+        // Add the solution path.
+        base::PlannerSolution psol(path);
+        psol.setPlannerName(getName());
+        psol.setApproximate(approxdif);
+
+        // Does the solution satisfy the optimization objective?
+        psol.setOptimized(opt_, approxsol->cost, opt_->isSatisfied(bestCost_));
+        pdef_->addSolutionPath(psol);
+    }
+
+    OMPL_INFORM("%s: Created %u new states. All states in both trees %u (%u start + %u goal). \nChecked %u rewire "
+                "options. %u connection points in graph. Final solution cost "
+                "%.3f",
+                getName().c_str(), statesGenerated, tStart_->size() + tGoal_->size(), tStart_->size(), tGoal_->size(),
+                rewireTest, connectionPoints_.size(), bestCost_);
+
+    // free memory
+    si_->freeState(tgi.xstate);
+    if (rmotion->state)
+        si_->freeState(rmotion->state);
+    delete rmotion;
+
+    return base::PlannerStatus(solutionFound, bestGoalMotion_ == nullptr);
+}
+
+void ompl::geometric::GreedyRRTstar::removeFromParent(Motion *m)
+{
+    for (auto it = m->parent->children.begin(); it != m->parent->children.end(); ++it)
+    {
+        if (*it == m)
+        {
+            m->parent->children.erase(it);
+            break;
+        }
+    }
+}
+
+void ompl::geometric::GreedyRRTstar::updateChildCosts(Motion *m)
+{
+    for (std::size_t i = 0; i < m->children.size(); ++i)
+    {
+        m->children[i]->cost = opt_->combineCosts(m->cost, m->children[i]->incCost);
+        updateChildCosts(m->children[i]);
+    }
+}
+
+void ompl::geometric::GreedyRRTstar::getNeighbors(TreeData &tree, Motion *motion, std::vector<Motion *> &nbh) const
+{
+    auto cardDbl = static_cast<double>(tStart_->size() + tGoal_->size() + 1u);
+    if (useKNearest_)
+    {
+        //- k-nearest RRT*
+        unsigned int k = std::ceil(k_rrt_ * log(cardDbl));
+        tree->nearestK(motion, k, nbh);
+    }
+    else
+    {
+        double r = std::min(
+            maxDistance_, r_rrt_ * std::pow(log(cardDbl) / cardDbl, 1 / static_cast<double>(si_->getStateDimension())));
+        tree->nearestR(motion, r, nbh);
+    }
+}
+
+std::vector<ompl::geometric::GreedyRRTstar::Edge> ompl::geometric::GreedyRRTstar::getStartTreeEdges() const
+{
+    std::vector<Motion *> motions;
+    if (tStart_)
+        tStart_->list(motions);
+
+    std::vector<ompl::geometric::GreedyRRTstar::Edge> edges;
+    for (auto &motion : motions)
+    {
+        if (motion->parent)
+        {
+            base::State *v = si_->allocState();
+            base::State *v_parent = si_->allocState();
+
+            si_->copyState(v, motion->state);
+            si_->copyState(v_parent, motion->parent->state);
+
+            edges.emplace_back(std::make_pair(v_parent, v));
+        }
+    }
+
+    return edges;
+}
+
+std::vector<ompl::geometric::GreedyRRTstar::Edge> ompl::geometric::GreedyRRTstar::getGoalTreeEdges() const
+{
+    std::vector<Motion *> motions;
+    if (tGoal_)
+        tGoal_->list(motions);
+
+    std::vector<ompl::geometric::GreedyRRTstar::Edge> edges;
+    for (auto &motion : motions)
+    {
+        if (motion->parent)
+        {
+            base::State *v = si_->allocState();
+            base::State *v_parent = si_->allocState();
+
+            si_->copyState(v, motion->state);
+            si_->copyState(v_parent, motion->parent->state);
+
+            edges.emplace_back(std::make_pair(v, v_parent));
+        }
+    }
+
+    return edges;
+}
+
+std::vector<ompl::geometric::GreedyRRTstar::Edge> ompl::geometric::GreedyRRTstar::getConnectionEdges() const
+{
+    std::vector<ompl::geometric::GreedyRRTstar::Edge> edges;
+    for (auto &connectionPoint : connectionPoints_)
+    {
+        base::State *start_v = si_->allocState();
+        base::State *goal_v = si_->allocState();
+
+        si_->copyState(start_v, connectionPoint.first->state);
+        si_->copyState(goal_v, connectionPoint.second->state);
+
+        edges.emplace_back(std::make_pair(start_v, goal_v));
+    }
+
+    return edges;
+}
+
+void ompl::geometric::GreedyRRTstar::getPlannerData(base::PlannerData &data) const
+{
+    Planner::getPlannerData(data);
+
+    std::vector<Motion *> motions;
+    if (tStart_)
+        tStart_->list(motions);
+
+    for (auto &motion : motions)
+    {
+        if (motion->parent == nullptr)
+            data.addStartVertex(base::PlannerDataVertex(motion->state, 1));
+        else
+        {
+            data.addEdge(base::PlannerDataVertex(motion->parent->state, 1), base::PlannerDataVertex(motion->state, 1));
+        }
+    }
+
+    motions.clear();
+    if (tGoal_)
+        tGoal_->list(motions);
+
+    for (auto &motion : motions)
+    {
+        if (motion->parent == nullptr)
+            data.addGoalVertex(base::PlannerDataVertex(motion->state, 2));
+        else
+        {
+            // The edges in the goal tree are reversed to be consistent with start tree
+            data.addEdge(base::PlannerDataVertex(motion->state, 2), base::PlannerDataVertex(motion->parent->state, 2));
+        }
+    }
+
+    // Add some info.
+    data.properties["approx goal distance REAL"] = ompl::toString(distanceBetweenTrees_);
+}
+
+int ompl::geometric::GreedyRRTstar::pruneTrees(const base::Cost &pruneTreeCost)
+{
+    // Variable
+    // The percent improvement (expressed as a [0,1] fraction) in cost
+    double fracBetter;
+    // The number pruned
+    int numPruned = 0;
+
+    if (opt_->isFinite(prunedCost_))
+    {
+        fracBetter = std::abs((pruneTreeCost.value() - prunedCost_.value()) / prunedCost_.value());
+    }
+    else
+    {
+        fracBetter = 1.0;
+    }
+
+    if (fracBetter > pruneThreshold_)
+    {
+        numPruned = pruneTree(tStart_, pruneTreeCost, true);
+        numPruned += pruneTree(tGoal_, pruneTreeCost, false);
+    }
+
+    return numPruned;
+}
+
+int ompl::geometric::GreedyRRTstar::pruneTree(TreeData &tree, const base::Cost &pruneTreeCost, bool isTreeStart)
+{
+    int numPruned = 0;
+    // We are only pruning motions if they, AND all descendents, have a estimated cost greater than pruneTreeCost
+    // The easiest way to do this is to find leaves that should be pruned and ascend up their ancestry until a
+    // motion is found that is kept.
+    // To avoid making an intermediate copy of the NN structure, we process the tree by descending down from the
+    // start(s).
+    // In the first pass, all Motions with a cost below pruneTreeCost, or Motion's with children with costs below
+    // pruneTreeCost are added to the replacement NN structure,
+    // while all other Motions are stored as either a 'leaf' or 'chain' Motion. After all the leaves are
+    // disconnected and deleted, we check
+    // if any of the the chain Motions are now leaves, and repeat that process until done.
+    // This avoids (1) copying the NN structure into an intermediate variable and (2) the use of the expensive
+    // NN::remove() method.
+
+    // Variable
+    // The queue of Motions to process:
+    std::queue<Motion *, std::deque<Motion *>> motionQueue;
+    // The list of leaves to prune
+    std::queue<Motion *, std::deque<Motion *>> leavesToPrune;
+    // The list of chain vertices to recheck after pruning
+    std::list<Motion *> chainsToRecheck;
+
+    tree->clear();
+
+    if (isTreeStart)
+    {
+        // Put all the starts into the tStart_ structure and their children into the queue:
+        // We do this so that start states are never pruned.
+        for (auto &startMotion : startMotions_)
+        {
+            // Add to the tStart_
+            tree->add(startMotion);
+
+            // Add their children to the queue:
+            addChildrenToList(&motionQueue, startMotion);
+        }
+    }
+    else
+    {
+        // Put all the starts into the tGoal_ structure and their children into the queue:
+        // We do this so that start states are never pruned.
+        for (auto &goalMotion : goalMotions_)
+        {
+            // Add to the tGoal_
+            tree->add(goalMotion);
+
+            // Add their children to the queue:
+            addChildrenToList(&motionQueue, goalMotion);
+        }
+    }
+
+    while (motionQueue.empty() == false)
+    {
+        // Test, can the current motion ever provide a better solution?
+        if (keepCondition(motionQueue.front(), pruneTreeCost, isTreeStart))
+        {
+            // Yes it can, so it definitely won't be pruned
+            // Add it back into the NN structure
+            tree->add(motionQueue.front());
+
+            // Add it's children to the queue
+            addChildrenToList(&motionQueue, motionQueue.front());
+        }
+        else
+        {
+            // No it can't, but does it have children?
+            if (motionQueue.front()->children.empty() == false)
+            {
+                // Yes it does.
+                // We can minimize the number of intermediate chain motions if we check their children
+                // If any of them won't be pruned, then this motion won't either. This intuitively seems
+                // like a nice balance between following the descendents forever.
+
+                // Variable
+                // Whether the children are definitely to be kept.
+                bool keepAChild = false;
+
+                // Find if any child is definitely not being pruned.
+                for (unsigned int i = 0u; keepAChild == false && i < motionQueue.front()->children.size(); ++i)
+                {
+                    // Test if the child can ever provide a better solution
+                    keepAChild = keepCondition(motionQueue.front()->children.at(i), pruneTreeCost, isTreeStart);
+                }
+
+                // Are we *definitely* keeping any of the children?
+                if (keepAChild)
+                {
+                    // Yes, we are, so we are not pruning this motion
+                    // Add it back into the NN structure.
+                    tree->add(motionQueue.front());
+                }
+                else
+                {
+                    // No, we aren't. This doesn't mean we won't though
+                    // Move this Motion to the temporary list
+                    chainsToRecheck.push_back(motionQueue.front());
+                }
+
+                // Either way. add it's children to the queue
+                addChildrenToList(&motionQueue, motionQueue.front());
+            }
+            else
+            {
+                // No, so we will be pruning this motion:
+                leavesToPrune.push(motionQueue.front());
+            }
+        }
+
+        // Pop the iterator, std::list::erase returns the next iterator
+        motionQueue.pop();
+    }
+
+    // We now have a list of Motions to definitely remove, and a list of Motions to recheck
+    // Iteratively check the two lists until there is nothing to to remove
+    while (leavesToPrune.empty() == false)
+    {
+        // First empty the current leaves-to-prune
+        while (leavesToPrune.empty() == false)
+        {
+            // If this leaf is a goal, remove it from the goal set
+            if (leavesToPrune.front()->isConnectionPoint == true)
+            {
+                Motion *leave_to_prune = leavesToPrune.front();
+
+                if (leave_to_prune == bestGoalMotion_->connection || leave_to_prune == bestGoalMotion_)
+                {
+                    OMPL_ERROR("%s: Pruning the best connection points.", getName().c_str());
+                }
+
+                // remove it if it is in the goal
+                if (!isTreeStart)
+                {
+                    bestGoalMotions_.erase(
+                        std::remove(bestGoalMotions_.begin(), bestGoalMotions_.end(), leave_to_prune),
+                        bestGoalMotions_.end());
+                    leave_to_prune->connection = nullptr;
+                    leave_to_prune->isConnectionPoint = false;
+                }
+                else
+                {
+                    bestGoalMotions_.erase(
+                        std::remove(bestGoalMotions_.begin(), bestGoalMotions_.end(), leave_to_prune->connection),
+                        bestGoalMotions_.end());
+                    leave_to_prune->connection = nullptr;
+                    leave_to_prune->isConnectionPoint = false;
+                }
+            }
+
+            // Remove the leaf from its parent
+            removeFromParent(leavesToPrune.front());
+
+            // Erase the actual motion
+            // First free the state
+            si_->freeState(leavesToPrune.front()->state);
+
+            // then delete the pointer
+            delete leavesToPrune.front();
+
+            // And finally remove it from the list, erase returns the next iterator
+            leavesToPrune.pop();
+
+            // Update our counter
+            ++numPruned;
+        }
+
+        // Now, we need to go through the list of chain vertices and see if any are now leaves
+        auto mIter = chainsToRecheck.begin();
+        while (mIter != chainsToRecheck.end())
+        {
+            // Is the Motion a leaf?
+            if ((*mIter)->children.empty() == true)
+            {
+                // It is, add to the removal queue
+                leavesToPrune.push(*mIter);
+
+                // Remove from this queue, getting the next
+                mIter = chainsToRecheck.erase(mIter);
+            }
+            else
+            {
+                // Is isn't, skip to the next
+                ++mIter;
+            }
+        }
+    }
+
+    // Now finally add back any vertices left in chainsToReheck.
+    // These are chain vertices that have descendents that we want to keep
+    for (const auto &r : chainsToRecheck)
+        // Add the motion back to the NN struct:
+        tree->add(r);
+
+    // All done pruning.
+    // Update the cost at which we've pruned:
+    prunedCost_ = pruneTreeCost;
+
+    // And if we're using the pruned measure, the measure to which we've pruned
+    if (usePrunedMeasure_)
+    {
+        prunedMeasure_ = infSampler_->getInformedMeasure(prunedCost_);
+
+        if (useKNearest_ == false)
+        {
+            calculateRewiringLowerBounds();
+        }
+    }
+    // No else, prunedMeasure_ is the si_ measure by default.
+    return numPruned;
+}
+
+void ompl::geometric::GreedyRRTstar::addChildrenToList(std::queue<Motion *, std::deque<Motion *>> *motionList,
+                                                       Motion *motion)
+{
+    for (auto &child : motion->children)
+    {
+        motionList->push(child);
+    }
+}
+
+bool ompl::geometric::GreedyRRTstar::keepCondition(const Motion *motion, const base::Cost &threshold,
+                                                   bool isTreeStart) const
+{
+    // We keep if the cost-to-come-heuristic of motion is <= threshold, by checking
+    // if !(threshold < heuristic), as if b is not better than a, then a is better than, or equal to, b
+    if (bestGoalMotion_)
+    {
+        // If the threshold is the theoretical minimum, the bestGoalMotion_ will
+        // sometimes fail the test due to floating point precision. Avoid that.
+        if (isTreeStart && motion == bestGoalMotion_->connection)
+        {
+            return true;
+        }
+
+        if (!isTreeStart && motion == bestGoalMotion_)
+        {
+            return true;
+        }
+    }
+
+    return !opt_->isCostBetterThan(threshold, solutionHeuristic(motion, isTreeStart));
+}
+
+ompl::base::Cost ompl::geometric::GreedyRRTstar::solutionHeuristic(const Motion *motion, bool isTreeStart) const
+{
+    base::Cost costToCome = motion->cost;
+    if (isTreeStart)
+    {
+        if (useAdmissibleCostToCome_)
+        {
+            // Start with infinite cost
+            costToCome = opt_->infiniteCost();
+
+            // Find the min from each start
+            for (auto &startMotion : startMotions_)
+            {
+                costToCome =
+                    opt_->betterCost(costToCome, opt_->motionCostHeuristic(startMotion->state,
+                                                                           motion->state));  // lower-bounding cost from
+                                                                                             // the start to the state
+            }
+        }
+        else
+        {
+            costToCome = motion->cost;  // current cost from the state to the goal
+        }
+
+        base::Cost costToGo = opt_->infiniteCost();
+
+        // Find the min from each goal
+        for (auto &goalMotion : goalMotions_)
+        {
+            costToGo = opt_->betterCost(
+                costToGo, opt_->motionCostHeuristic(motion->state, goalMotion->state));  // lower-bounding cost from the
+                                                                                         // state to the goal
+        }
+
+        return opt_->combineCosts(costToCome, costToGo);  // add the two costs
+    }
+    else
+    {
+        // The tree is goal tree
+        if (useAdmissibleCostToCome_)
+        {
+            // Start with infinite cost
+            costToCome = opt_->infiniteCost();
+
+            // Find the min from each goal
+            for (auto &goalMotion : goalMotions_)
+            {
+                costToCome = opt_->betterCost(
+                    costToCome,
+                    opt_->motionCostHeuristic(motion->state, goalMotion->state));  // lower-bounding cost from the
+                                                                                   // goal to the state
+            }
+        }
+        else
+        {
+            costToCome = motion->cost;  // current cost from the state to the goal
+        }
+        // Find the min from each start
+        base::Cost costToGo = opt_->infiniteCost();
+        for (auto &startMotion : startMotions_)
+        {
+            costToGo = opt_->betterCost(
+                costToGo, opt_->motionCostHeuristic(motion->state, startMotion->state));  // lower-bounding cost from
+                                                                                          // the start to the state
+        }
+        return opt_->combineCosts(costToCome, costToGo);  // add the two costs
+    }
+}
+
+void ompl::geometric::GreedyRRTstar::setTreePruning(const bool prune)
+{
+    if (static_cast<bool>(opt_) == true)
+    {
+        if (opt_->hasCostToGoHeuristic() == false)
+        {
+            OMPL_INFORM("%s: No cost-to-go heuristic set. Informed techniques will not work well.", getName().c_str());
+        }
+    }
+
+    // If we just disabled tree pruning, but we wee using prunedMeasure, we need to disable that as it required myself
+    if (prune == false && getPrunedMeasure() == true)
+    {
+        setPrunedMeasure(false);
+    }
+
+    // Store
+    useTreePruning_ = prune;
+}
+
+void ompl::geometric::GreedyRRTstar::setPrunedMeasure(bool informedMeasure)
+{
+    if (static_cast<bool>(opt_) == true)
+    {
+        if (opt_->hasCostToGoHeuristic() == false)
+        {
+            OMPL_INFORM("%s: No cost-to-go heuristic set. Informed techniques will not work well.", getName().c_str());
+        }
+    }
+
+    // This option only works with informed sampling
+    if (informedMeasure == true && (useInformedSampling_ == false || useTreePruning_ == false))
+    {
+        OMPL_ERROR("%s: InformedMeasure requires InformedSampling and TreePruning.", getName().c_str());
+    }
+
+    // Check if we're changed and update parameters if we have:
+    if (informedMeasure != usePrunedMeasure_)
+    {
+        // Store the setting
+        usePrunedMeasure_ = informedMeasure;
+
+        // Update the prunedMeasure_ appropriately, if it has been configured.
+        if (setup_ == true)
+        {
+            if (usePrunedMeasure_)
+            {
+                prunedMeasure_ = infSampler_->getInformedMeasure(prunedCost_);
+            }
+            else
+            {
+                prunedMeasure_ = si_->getSpaceMeasure();
+            }
+        }
+
+        // And either way, update the rewiring radius if necessary
+        if (useKNearest_ == false)
+        {
+            calculateRewiringLowerBounds();
+        }
+    }
+}
+
+void ompl::geometric::GreedyRRTstar::setInformedSampling(bool informedSampling)
+{
+    if (static_cast<bool>(opt_) == true)
+    {
+        if (opt_->hasCostToGoHeuristic() == false)
+        {
+            OMPL_INFORM("%s: No cost-to-go heuristic set. Informed techniques will not work well.", getName().c_str());
+        }
+    }
+
+    // If we just disabled tree pruning, but we are using prunedMeasure, we need to disable that as it required myself
+    if (informedSampling == false && getPrunedMeasure() == true)
+    {
+        setPrunedMeasure(false);
+    }
+
+    // Check if we're changing the setting of informed sampling. If we are, we will need to create a new sampler, which
+    // we only want to do if one is already allocated.
+    if (informedSampling != useInformedSampling_)
+    {
+        // If we're disabled informedSampling, and prunedMeasure is enabled, we need to disable that
+        if (informedSampling == false && usePrunedMeasure_ == true)
+        {
+            setPrunedMeasure(false);
+        }
+
+        // Store the value
+        useInformedSampling_ = informedSampling;
+
+        // If we currently have a sampler, we need to make a new one
+        if (infSampler_)
+        {
+            // Reset the sampler
+            infSampler_.reset();
+
+            // Create the sampler
+            // we cannot do this here since moveit creates the planner before goal states are given
+            // informed set requires at least one start and goal
+            // allocSampler();
+        }
+    }
+}
+
+void ompl::geometric::GreedyRRTstar::allocSampler()
+{
+    // We are using informed sampling, this can end-up reverting to rejection sampling in some cases
+    infSampler_ = opt_->allocInformedStateSampler(pdef_, numSampleAttempts_);
+}
+
+bool ompl::geometric::GreedyRRTstar::sampleUniform(base::State *statePtr)
+{
+    // I dont want to trigger the random number generation here yet
+    // since we don't need it until we found an initial solution
+    if (!bestGoalMotion_)
+    {
+        // Simply return a state from the regular sampler
+        // infSampler handles that internally since bestCost is still inf
+        infSampler_->sampleUniform(statePtr, bestCost_);
+        return true;
+    }
+
+    // sample from the greedy informed set
+    if (rng_.uniform01() < greedyBiasingRatio_)
+        return infSampler_->sampleUniform(statePtr, greedyBestCost_);
+
+    // sample from the informed set
+    return infSampler_->sampleUniform(statePtr, bestCost_);
+}
+
+void ompl::geometric::GreedyRRTstar::calculateRewiringLowerBounds()
+{
+    const auto dimDbl = static_cast<double>(si_->getStateDimension());
+
+    // k_rrt > 2^(d + 1) * e * (1 + 1 / d).  K-nearest RRT*
+    k_rrt_ = rewireFactor_ * (std::pow(2, dimDbl + 1) * boost::math::constants::e<double>() * (1.0 + 1.0 / dimDbl));
+
+    // r_rrt > (2*(1+1/d))^(1/d)*(measure/ballvolume)^(1/d)
+    // If we're not using the informed measure, prunedMeasure_ will be set to si_->getSpaceMeasure();
+    r_rrt_ = rewireFactor_ *
+             std::pow(2 * (1.0 + 1.0 / dimDbl) * (prunedMeasure_ / unitNBallMeasure(si_->getStateDimension())),
+                      1.0 / dimDbl);
+}

--- a/src/ompl/geometric/planners/rrt/src/GreedyRRTstar.cpp
+++ b/src/ompl/geometric/planners/rrt/src/GreedyRRTstar.cpp
@@ -63,8 +63,8 @@ ompl::geometric::GreedyRRTstar::GreedyRRTstar(const base::SpaceInformationPtr &s
                                 &GreedyRRTstar::getDelayCC, "0,1");
     Planner::declareParam<bool>("delay_rewiring", this, &GreedyRRTstar::setDelayRewiring,
                                 &GreedyRRTstar::getDelayRewiring, "0,1");
-    Planner::declareParam<bool>("greedy_heuristic_gating", this, &GreedyRRTstar::setGreedyHeuristicGating,
-                                &GreedyRRTstar::getGreedyHeuristicGating, "0,1");
+    Planner::declareParam<bool>("greedy_cost_for_tree_pruning", this, &GreedyRRTstar::setGreedyCostForTreePruning,
+                                &GreedyRRTstar::getGreedyCostForTreePruning, "0,1");
     Planner::declareParam<bool>("balanced_search", this, &GreedyRRTstar::setBalancedSearch,
                                 &GreedyRRTstar::getBalancedSearch, "0,1");
     Planner::declareParam<unsigned int>("number_sampling_attempts", this, &GreedyRRTstar::setNumSamplingAttempts,
@@ -99,8 +99,18 @@ void ompl::geometric::GreedyRRTstar::setup()
         tStart_.reset(tools::SelfConfig::getDefaultNearestNeighbors<Motion *>(this));
     if (!tGoal_)
         tGoal_.reset(tools::SelfConfig::getDefaultNearestNeighbors<Motion *>(this));
-    tStart_->setDistanceFunction([this](const Motion *a, const Motion *b) { return distanceFunction(a, b); });
-    tGoal_->setDistanceFunction([this](const Motion *a, const Motion *b) { return distanceFunction(a, b); });
+    if (nnDistFun_)
+    {
+        tStart_->setDistanceFunction([this](const Motion *a, const Motion *b)
+                                     { return nnDistFun_(a->state, b->state); });
+        tGoal_->setDistanceFunction([this](const Motion *a, const Motion *b)
+                                    { return nnDistFun_(a->state, b->state); });
+    }
+    else
+    {
+        tStart_->setDistanceFunction([this](const Motion *a, const Motion *b) { return distanceFunction(a, b); });
+        tGoal_->setDistanceFunction([this](const Motion *a, const Motion *b) { return distanceFunction(a, b); });
+    }
 
     // Setup optimization objective
     //
@@ -230,17 +240,16 @@ ompl::geometric::GreedyRRTstar::GrowState ompl::geometric::GreedyRRTstar::growTr
 
     /////////////////////////////////////////////////////////////////////////////////////
 
-    // x_new is rejected if connecting to it does not improve the current best cost (or greedy best cost)
+    // x_new is rejected if connecting to it does not improve the current best cost
     // check if g(xnear) + c(xnear, xnew) + hhat(xnew) can improve that cost
     // this will also make sure both trees are not overlapping each other
-
     if (bestGoalMotion_)
     {
         auto soln_heuristic_cost =
             opt_->combineCosts(opt_->combineCosts(nmotion->cost, opt_->motionCost(nmotion->state, dstate)),
                                costToGoHeuristic(dstate, tgi.start));
 
-        if (!opt_->isCostBetterThan(soln_heuristic_cost, useGreedyHeuristicGating_ ? greedyBestCost_ : bestCost_))
+        if (!opt_->isCostBetterThan(soln_heuristic_cost, bestCost_))
         {
             return TRAPPED;
         }
@@ -546,9 +555,6 @@ ompl::base::PlannerStatus ompl::geometric::GreedyRRTstar::solve(const base::Plan
         startMotions_.push_back(motion);
     }
 
-    // And assure that, if we're using an informed sampler, it's reset
-    infSampler_.reset();
-
     if (tStart_->size() == 0)
     {
         OMPL_ERROR("%s: Motion planning start tree could not be initialized!", getName().c_str());
@@ -560,8 +566,6 @@ ompl::base::PlannerStatus ompl::geometric::GreedyRRTstar::solve(const base::Plan
         OMPL_ERROR("%s: Insufficient states in sampleable goal region", getName().c_str());
         return base::PlannerStatus::INVALID_GOAL;
     }
-
-    const base::ReportIntermediateSolutionFn intermediateSolutionCallback = pdef_->getIntermediateSolutionCallback();
 
     TreeGrowingInfo tgi;
     tgi.xstate = si_->allocState();
@@ -690,7 +694,7 @@ ompl::base::PlannerStatus ompl::geometric::GreedyRRTstar::solve(const base::Plan
             if (!tgi.checkForSolution)
             {
                 GrowState gsc = ADVANCED;
-                while (gsc == ADVANCED)
+                while (gsc == ADVANCED && !ptc)
                     gsc = growTree(otherTree, tgi, rmotion, compareFn);
 
                 /* update distance between trees */
@@ -823,13 +827,13 @@ ompl::base::PlannerStatus ompl::geometric::GreedyRRTstar::solve(const base::Plan
                 {
                     if (useTreePruning_)
                     {
-                        if (greedyBiasingRatio_ <= 0.5)
-                            pruneTrees(bestCost_);
-                        else
+                        if (useGreedyCostForTreePruning_)
                             pruneTrees(greedyBestCost_);
+                        else
+                            pruneTrees(bestCost_);
                     }
 
-                    if (intermediateSolutionCallback)
+                    if (auto intermediateSolutionCallback = pdef_->getIntermediateSolutionCallback())
                     {
                         Motion *solution = bestGoalMotion_->connection;
                         std::vector<Motion *> mpath1;

--- a/src/ompl/geometric/planners/rrt/src/GreedyRRTstar.cpp
+++ b/src/ompl/geometric/planners/rrt/src/GreedyRRTstar.cpp
@@ -633,23 +633,21 @@ ompl::base::PlannerStatus ompl::geometric::GreedyRRTstar::solve(const base::Plan
     {
         iterations_++;
 
-        TreeData &tree = startTree_ ? tStart_ : tGoal_;
-        tgi.start = startTree_;
-        startTree_ = !startTree_;
-        TreeData &otherTree = startTree_ ? tStart_ : tGoal_;
-
-        if (useBalancedBiDirectionalSearch_)
+        // Balanced bidirectional search
         {
-            if ((std::abs(static_cast<float>(tree->size() - otherTree->size())) / tree->size()) < 1.f)
+            TreeData &curTree = startTree_ ? tStart_ : tGoal_;
+            TreeData &curOther = startTree_ ? tGoal_ : tStart_;
+            const auto asize = static_cast<float>(curTree->size());
+            const auto bsize = static_cast<float>(curOther->size());
+            if (!useBalancedBiDirectionalSearch_ ||
+                (std::abs(asize - bsize) / std::max(asize, 1.0f)) < 1.f)
             {
                 startTree_ = !startTree_;
-
-                TreeData &tree = startTree_ ? tStart_ : tGoal_;
-                tgi.start = startTree_;
-                startTree_ = !startTree_;
-                TreeData &otherTree = startTree_ ? tStart_ : tGoal_;
             }
         }
+        TreeData &tree = startTree_ ? tStart_ : tGoal_;
+        tgi.start = startTree_;
+        TreeData &otherTree = startTree_ ? tGoal_ : tStart_;
 
         if (tGoal_->size() == 0 || pis_.getSampledGoalsCount() < tGoal_->size() / 2)
         {
@@ -688,8 +686,11 @@ ompl::base::PlannerStatus ompl::geometric::GreedyRRTstar::solve(const base::Plan
             /* if reached, it means we used rstate directly, no need top copy again */
             if (gs != REACHED)
                 si_->copyState(rmotion->state, tgi.xstate);
-
-            tgi.start = startTree_;
+            
+            // The connect phase grows otherTree (the opposite of the grown tree), so
+            // tgi.start must be otherTree's identity here. tree was grown above with
+            // tgi.start = startTree_; flip it for the connect.
+            tgi.start = !startTree_;
 
             if (!tgi.checkForSolution)
             {


### PR DESCRIPTION
I would like to contribute an implementation of our planner, Greedy RRT* (G-RRT*), to OMPL, based on the following preprint: [https://arxiv.org/abs/2405.03411](https://arxiv.org/abs/2405.03411)

This paper has been out for a while, and it took me some time to clean things up and prepare a proper PR, but I’m happy to finally open it now.

In short, G-RRT* is a bidirectional planner, similar to RRTConnect, but with additional RRT*-style rewiring and greedy heuristic properties that make it anytime and allow it to converge faster than using informed sampling alone on most planning problems. I have also tested it on high-dimensional planning problems and MotionBenchMaker tasks; further details and experimental results are available in the manuscript.

<img width="1339" height="340" alt="Screenshot 2025-11-25 at 12 02 31 AM" src="https://github.com/user-attachments/assets/78c2ad26-136f-4deb-8b73-7d4733b2d04b" />


To my knowledge, OMPL currently does not really have a bidirectional, RRT*-like anytime planner (for example, RRT*-Connect) so I believe this would be a useful addition for the community to experiment with and build upon. G-RRT* works very similar to RRT*-Connect but it has better heuristics and some additional properties which will make it find solutions very fast and converge faster.