### PR TITLE
Comment out BLITstar::costCombine declaration

### DIFF
--- a/src/ompl/geometric/planners/lazyinformedtrees/BLITstar.h
+++ b/src/ompl/geometric/planners/lazyinformedtrees/BLITstar.h
@@ -101,8 +101,6 @@ namespace ompl
             ompl::base::PlannerStatus
             solve(const ompl::base::PlannerTerminationCondition &terminationCondition) override;
              
-            /** \brief Operate + . Comment this out 
-            ompl::base::Cost costCombine(ompl::base::Cost c1, ompl::base::Cost c2);*/
             /** \brief Get the planner data. */
             void getPlannerData(base::PlannerData &data) const override;
 	    
@@ -136,7 +134,6 @@ namespace ompl
             /** \brief Get the maximum number of goals BLIT* will sample from sampleable goal regions. */
             unsigned int getMaxNumberOfGoals() const;
             
-            // void runTime();
             /**\brief Above references inherit from BLIT*. */
             
             /** \brief Perform sparse/compelete collision detection. */


### PR DESCRIPTION
This PR comments out the unused "BLITstar::costCombine" declaration in "BLITstar.h". 
In some build configurations, the Python bindings fail to import because the symbol does not exist.