### PR TITLE
fix: remove macos-13 from github actions workflows

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -21,7 +21,7 @@ jobs:
           pybuilds: cp3{10,11,12,13}-manylinux_aarch64
           arch: aarch64
           id: linux_arm64
-        - os: macos-13
+        - os: macos-15-intel
           pybuilds: cp3{10,11,12,13}-macosx_x86_64
           arch: x86_64
           id: macos_x86

--- a/.github/workflows/wheels.yaml
+++ b/.github/workflows/wheels.yaml
@@ -21,7 +21,7 @@ jobs:
           pybuilds: cp3{10,11,12,13}-manylinux_aarch64
           arch: aarch64
           id: linux_arm64
-        - os: macos-13
+        - os: macos-15-intel
           pybuilds: cp3{10,11,12,13}-macosx_x86_64
           arch: x86_64
           id: macos_x86


### PR DESCRIPTION
[MacOS 13 is deprecated on GitHub Actions](https://github.blog/changelog/2025-09-19-github-actions-macos-13-runner-image-is-closing-down/) and so this will keep CI from breaking.