### PR TITLE
docs: add description about the prerequisite - c++ - for the latest castxml (#1110)

### DIFF
--- a/doc/markdown/installation.md
+++ b/doc/markdown/installation.md
@@ -41,6 +41,7 @@ sudo apt-get install ros-`rosversion -d`-ompl</pre>
         Please see <a href="https://moveit.ai">MoveIt</a> for further information.
       </div>
     </div>
+    <p><strong>Note:</strong> Generating Python bindings from source requires a C++11-compatible compiler, as <a href="https://github.com/CastXML/CastXML">CastXML</a> (used for binding generation) depends on C++11.</p>
   </div>
 
   <!-- Fedora -->

--- a/py-bindings/README.md
+++ b/py-bindings/README.md
@@ -7,6 +7,10 @@ The Python bindings mirror OMPL’s C++ API. For detailed usage, refer to:
 - The [C++ OMPL documentation](https://ompl.kavrakilab.org/)  
 - The sample scripts in the `pyexamples/` directory  
 
+## Prerequisites
+
+Generating Python bindings requires a **C++11-compatible compiler**, as [CastXML](https://github.com/CastXML/CastXML) (used for binding generation) depends on C++11.
+
 ## How is Nanobind organized?
 
 We use **Nanobind** to generate Python bindings for OMPL. For every OMPL header, there is a corresponding binding file in the `bindings/` directory, organized into subfolders that mirror OMPL’s module structure. For example, all bindings for `ompl::base` live under `bindings/base`.


### PR DESCRIPTION
# Issue

- #1110

# Changes

To inform users of the prerequisite (c++), I update the two documents:

- doc/markdown/installation.md
- py-bindings/README.md

