### PR TITLE
AORRTC: fix memory leak and findNeighbour padding for non-Euclidean costs

### DIFF
--- a/src/ompl/geometric/planners/rrt/AOXRRTConnect.h
+++ b/src/ompl/geometric/planners/rrt/AOXRRTConnect.h
@@ -223,11 +223,10 @@ namespace ompl
 
             std::size_t sampleAttempts{0};
 
-            /* Pad rootDist to account for floating point error
-               Needed to make sure the root is included in nearest list
-               TODO: Should use some relative epsilon for padding
-               (FLT_EPSILON is good but does not scale with the magnitude of rootDist and may be too small) */
-            const float rootDistPadding = 0.00001;
+            /** \brief Relative padding factor for rootDist to account for floating point error.
+                Needed to make sure the root is included in nearest list.
+                Uses relative epsilon so it scales with any distance metric */
+            static constexpr double rootDistRelativeEps = 1e-6;
 
             /** \brief The start tree */
             TreeData tStart_;

--- a/src/ompl/geometric/planners/rrt/src/AOXRRTConnect.cpp
+++ b/src/ompl/geometric/planners/rrt/src/AOXRRTConnect.cpp
@@ -120,6 +120,9 @@ void ompl::geometric::AOXRRTConnect::freeMemory()
 
 void ompl::geometric::AOXRRTConnect::reset(bool solvedProblem)
 {
+    // Free motions before clearing trees to avoid memory leak
+    freeMemory();
+
     tStart_->clear();
     tGoal_->clear();
 
@@ -169,7 +172,8 @@ ompl::geometric::AOXRRTConnect::Motion *ompl::geometric::AOXRRTConnect::findNeig
     Motion *nearest_motion;
     std::vector<Motion *> nearest_vec;
 
-    rootDist += rootDistPadding;
+    // Relative padding to handle floating-point error at any distance scale
+    rootDist *= (1.0 + rootDistRelativeEps);
 
     tree->nearestR(sampled_motion, rootDist, nearest_vec);
     if (nearest_vec.empty())
@@ -182,11 +186,18 @@ ompl::geometric::AOXRRTConnect::Motion *ompl::geometric::AOXRRTConnect::findNeig
     nearest_motion = nearest_vec[idx];
     auto nearest_distance = si_->distance(sampled_motion->state, nearest_motion->state);
 
-    while (nearest_motion->cost > 0 && sampled_motion->cost < nearest_motion->cost + nearest_distance)
+    while (nearest_motion->cost > 0 && sampled_motion->cost < nearest_motion->cost + nearest_distance &&
+           idx + 1 < static_cast<int>(nearest_vec.size()))
     {
         idx++;
         nearest_motion = nearest_vec[idx];
         nearest_distance = si_->distance(sampled_motion->state, nearest_motion->state);
+    }
+
+    // If we exhausted all neighbors without finding a valid connection, return nullptr
+    if (nearest_motion->cost > 0 && sampled_motion->cost < nearest_motion->cost + nearest_distance)
+    {
+        return nullptr;
     }
 
     return nearest_motion;
@@ -315,7 +326,7 @@ ompl::base::PlannerStatus ompl::geometric::AOXRRTConnect::solve(const base::Plan
     auto *cmotion = new Motion(si_);
     base::State *rstate = rmotion->state;
     bool solved = false;
-    GrowState gs;
+    GrowState gs = TRAPPED;
 
     if (goal == nullptr)
     {
@@ -334,6 +345,7 @@ ompl::base::PlannerStatus ompl::geometric::AOXRRTConnect::solve(const base::Plan
 
         /* Straight line check for first search loop
            Nested here for PDT visualize, which calls solve for each iteration */
+        tgi.xmotion = motion;
         si_->copyState(rstate, startState);
         gs = REACHED;
     }
@@ -377,13 +389,6 @@ ompl::base::PlannerStatus ompl::geometric::AOXRRTConnect::solve(const base::Plan
                 motion->root = motion->state;
                 motion->cost = 0;
 
-                /* Straight line check for start of planning
-                   Nested here for PDT visualize, which calls solve for each iteration */
-                if (tGoal_->size() == 0)
-                {
-                    tgi.xmotion = motion;
-                }
-
                 tGoal_->add(motion);
                 goalState = motion->state;
             }
@@ -419,8 +424,9 @@ ompl::base::PlannerStatus ompl::geometric::AOXRRTConnect::solve(const base::Plan
                 tgi.start = !tgi.start;
             }
 
-            /* Keep trying to connect until we reach the other tree or fail to advance */
-            while (gsc == ADVANCED)
+            /* Keep trying to connect until we reach the other tree or fail to advance.
+               Check ptc to avoid blocking for too long with expensive distance functions. */
+            while (gsc == ADVANCED && !ptc)
             {
                 gsc = growTree(otherTree, tgi, cmotion);
             }
@@ -533,6 +539,7 @@ ompl::base::PlannerStatus ompl::geometric::AOXRRTConnect::solve(const base::Plan
     /* Cleanup our memory */
     si_->freeState(tgi.xstate);
     si_->freeState(rstate);
+    si_->freeState(cmotion->state);
     delete rmotion;
     delete cmotion;
 


### PR DESCRIPTION
Hello! While testing AORRTC with non-Euclidean cost spaces, I ran into a couple of leaks and robustness issues:

- Memory leak in `AOXRRTConnect::reset()`: trees were cleared without freeing the Motion objects they hold by raw pointer. Now calls `freeMemory()` first. Also frees `cmotion->state` in `solve()` cleanup.
- `findNeighbour()` padding: absolute pad (`rootDist += 1e-5`) becomes negligible for large `rootDist` (e.g. SE2, SE3, non-Euclidean metrics), causing empty `nearestR` results. Replaced with relative pad `rootDist *= (1 + 1e-6)`.

Minor fixes bundled in:
- bounds check in `findNeighbour()` cost-iteration loop
- initialise `GrowState gs = TRAPPED`
- fix `tgi.xmotion` bookkeeping in `solve()`'s straight-line check
- inner connect loop now respects `ptc`