### PR TITLE
Update package.xml for next ROS release

### DIFF
--- a/package.xml
+++ b/package.xml
@@ -18,20 +18,44 @@
   <buildtool_depend>cmake</buildtool_depend>
   <buildtool_depend>pkg-config</buildtool_depend>
 
-  <depend>eigen</depend>
-  <depend>libboost-program-options-dev</depend>
-  <depend>libboost-serialization-dev</depend>
-  <!-- Required by Boost >= 1.90's modular CMake configs: boost_serialization's
-       config recursively find_package()'s boost_system, which is shipped in
-       its own apt package starting with 1.90 and is not pulled in transitively
-       by libboost-serialization-dev. -->
-  <depend>libboost-system-dev</depend>
-  <depend>libflann-dev</depend>
+  <!-- Eigen is header-only — no runtime linkage. -->
+  <build_depend>eigen</build_depend>
+
+  <!-- libompl.so links libboost_serialization; demo binaries link
+       libboost_program_options. Both are needed at runtime, but only the -dev
+       packages at build time. -->
+  <build_depend>libboost-program-options-dev</build_depend>
+  <build_depend>libboost-serialization-dev</build_depend>
+  <exec_depend>libboost-program-options</exec_depend>
+  <exec_depend>libboost-serialization</exec_depend>
+
+  <!-- Build-only: Boost >= 1.90's modular CMake configs make
+       boost_serialization's config recursively find_package() boost_system,
+       which is shipped as its own apt package starting with 1.90 and is not
+       pulled in transitively by libboost-serialization-dev. Boost.System is
+       header-only since 1.69 and OMPL doesn't use it directly, so no runtime
+       dep is required. -->
+  <build_depend>libboost-system-dev</build_depend>
+
+  <!-- FLANN is an optional nearest-neighbor backend; package.xml requires
+       it so it's always available in ROS builds. -->
+  <build_depend>libflann-dev</build_depend>
+  <exec_depend>libflann</exec_depend>
+
+  <!-- yaml-cpp is used by the multicopter demo. The current rosdep mapping
+       has no separate runtime key (the 'yaml-cpp' key resolves to
+       libyaml-cpp-dev, which transitively provides the runtime), so this
+       stays a <depend> until a libyaml-cpp runtime key is added to
+       ros/rosdistro. -->
   <depend>yaml-cpp</depend>
-  <!-- For Python bindings via the bundled nanobind submodule:
-       OMPLDependencies.cmake calls find_package(Python ... COMPONENTS
-       Interpreter Development.Module) which needs Python headers. -->
-  <depend>python3-dev</depend>
+
+  <!-- nanobind builds Python extension modules with Development.Module:
+       the resulting .so files do not link libpython — Python provides
+       symbols at dlopen time. So python3 headers are needed at build time
+       only; users will invariably already have python3 installed (it's
+       essential on every supported platform), and dh_python3 adds the
+       correct runtime dep automatically when building the binary deb. -->
+  <build_depend>python3-dev</build_depend>
 
   <export>
     <build_type>cmake</build_type>

--- a/package.xml
+++ b/package.xml
@@ -18,44 +18,18 @@
   <buildtool_depend>cmake</buildtool_depend>
   <buildtool_depend>pkg-config</buildtool_depend>
 
-  <!-- Eigen is header-only — no runtime linkage. -->
-  <build_depend>eigen</build_depend>
-
-  <!-- libompl.so links libboost_serialization; demo binaries link
-       libboost_program_options. Both are needed at runtime, but only the -dev
-       packages at build time. -->
-  <build_depend>libboost-program-options-dev</build_depend>
-  <build_depend>libboost-serialization-dev</build_depend>
-  <exec_depend>libboost-program-options</exec_depend>
-  <exec_depend>libboost-serialization</exec_depend>
-
-  <!-- Build-only: Boost >= 1.90's modular CMake configs make
-       boost_serialization's config recursively find_package() boost_system,
-       which is shipped as its own apt package starting with 1.90 and is not
-       pulled in transitively by libboost-serialization-dev. Boost.System is
-       header-only since 1.69 and OMPL doesn't use it directly, so no runtime
-       dep is required. -->
-  <build_depend>libboost-system-dev</build_depend>
-
-  <!-- FLANN is an optional nearest-neighbor backend; package.xml requires
-       it so it's always available in ROS builds. -->
-  <build_depend>libflann-dev</build_depend>
-  <exec_depend>libflann</exec_depend>
-
-  <!-- yaml-cpp is used by the multicopter demo. The current rosdep mapping
-       has no separate runtime key (the 'yaml-cpp' key resolves to
-       libyaml-cpp-dev, which transitively provides the runtime), so this
-       stays a <depend> until a libyaml-cpp runtime key is added to
-       ros/rosdistro. -->
   <depend>yaml-cpp</depend>
 
-  <!-- nanobind builds Python extension modules with Development.Module:
-       the resulting .so files do not link libpython — Python provides
-       symbols at dlopen time. So python3 headers are needed at build time
-       only; users will invariably already have python3 installed (it's
-       essential on every supported platform), and dh_python3 adds the
-       correct runtime dep automatically when building the binary deb. -->
+  <build_depend>eigen</build_depend>
+  <build_depend>libboost-program-options-dev</build_depend>
+  <build_depend>libboost-serialization-dev</build_depend>
+  <build_depend>libboost-system-dev</build_depend>
+  <build_depend>libflann-dev</build_depend>
   <build_depend>python3-dev</build_depend>
+
+  <exec_depend>libboost-program-options</exec_depend>
+  <exec_depend>libboost-serialization</exec_depend>
+  <exec_depend>libflann</exec_depend>
 
   <export>
     <build_type>cmake</build_type>

--- a/package.xml
+++ b/package.xml
@@ -5,7 +5,7 @@
   <version>2.0.0</version>
   <description>OMPL is a free sampling-based motion planning library.</description>
   <maintainer email="mark@moll.ai">Mark Moll</maintainer>
-  <maintainer email="marq.razz@gmail.com">Marq Rasumessen</maintainer>
+  <maintainer email="marq.razz@gmail.com">Marq Rasmussen</maintainer>
   <maintainer email="jafar.uruc@gmail.com">Jafar Uruc</maintainer>
   <license>BSD</license>
 

--- a/package.xml
+++ b/package.xml
@@ -1,5 +1,6 @@
 <?xml version="1.0"?>
-<package format="2">
+<?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
+<package format="3">
   <name>ompl</name>
   <version>2.0.0</version>
   <description>OMPL is a free sampling-based motion planning library.</description>
@@ -15,20 +16,22 @@
   <author>Kavraki Lab</author>
 
   <buildtool_depend>cmake</buildtool_depend>
+  <buildtool_depend>pkg-config</buildtool_depend>
 
-  <build_depend>cmake</build_depend>
-  <build_depend>libboost-program-options-dev</build_depend>
-  <build_depend>libboost-serialization-dev</build_depend>
-  <build_depend>eigen</build_depend>
-  <build_depend>pkg-config</build_depend>
-  <build_depend>libflann-dev</build_depend>
-  <build_depend>yaml-cpp</build_depend>
-
-  <exec_depend>libboost-program-options</exec_depend>
-  <exec_depend>libboost-serialization</exec_depend>
-  <exec_depend>eigen</exec_depend>
-  <exec_depend>libflann-dev</exec_depend>
-  <exec_depend>yaml-cpp</exec_depend>
+  <depend>eigen</depend>
+  <depend>libboost-program-options-dev</depend>
+  <depend>libboost-serialization-dev</depend>
+  <!-- Required by Boost >= 1.90's modular CMake configs: boost_serialization's
+       config recursively find_package()'s boost_system, which is shipped in
+       its own apt package starting with 1.90 and is not pulled in transitively
+       by libboost-serialization-dev. -->
+  <depend>libboost-system-dev</depend>
+  <depend>libflann-dev</depend>
+  <depend>yaml-cpp</depend>
+  <!-- For Python bindings via the bundled nanobind submodule:
+       OMPLDependencies.cmake calls find_package(Python ... COMPONENTS
+       Interpreter Development.Module) which needs Python headers. -->
+  <depend>python3-dev</depend>
 
   <export>
     <build_type>cmake</build_type>


### PR DESCRIPTION
### Fix Rolling buildfarm `binarydeb` failure + modernize package.xml to format 3                                                                                                                                                                                              
                                                                                                                                                                                                                                                                              
  ### Problem                                                                                                                                                                                                                                                                   
                                                                                                                                                                                                                                                                                
  The latest Rolling buildfarm run for `ros-rolling-ompl` (1.7.0-3resolute.20260507.064404) failed at the binarydeb configure step:                                                                                                                                             
                                                                                                                                                                                                                                                                                
  CMake Error at /usr/lib/x86_64-linux-gnu/cmake/Boost-1.90.0/BoostConfig.cmake:141 (find_package):                                                                                                                                                                             
    Could not find a package configuration file provided by "boost_system"
  ```                                                                                                                                                                                                                                                                         
  Call Stack (most recent call first):
    /usr/lib/x86_64-linux-gnu/cmake/Boost-1.90.0/BoostConfig.cmake:262 (boost_find_component)                                                                                                                                                                                   
    /usr/share/cmake-4.2/Modules/FindBoost.cmake:610 (find_package)                                                                                                                                                                                                             
    CMakeLists.txt:50 (find_package)                                                                                                                                                                                                                                            
  ```                                                                                                                                                                                                                                                                              
  ### Root cause                                                                                                                                                                                                                                                                
                  
  OMPL only requests `serialization` and `program_options` (`CMakeModules/OMPLDependencies.cmake`), but Boost ≥ 1.90's modular CMake configs split each component into its own apt package and resolve dependencies between them recursively. `boost_serialization-1.90.0`'s    
  config now `find_package`s `boost_system`, so without `libboost-system-dev` installed, configure fails before any code is compiled.
                                                                                                                                                                                                                                                                                
  The Debian-level transitive deps of `libboost-serialization-dev` happen to pull in `libboost-headers-dev`, `libboost-atomic-dev`, and `libboost-filesystem-dev` (visible in the failing job's `CMakeCache.txt`), but **not** `libboost-system-dev`. That's the gap rosdep     
  needs to fill.
                                                                                                                                                                                                                                                                                
  This is new behavior with Boost 1.90 — earlier Boost versions worked fine because the legacy `FindBoost.cmake` only looked for the libraries explicitly named.

  ### Changes                                                                                                                                                                                                                                                                   
                  
  - **Add `libboost-system-dev`** so rosdep installs `boost_system`'s CMake config on the buildfarm. This is the minimal fix for the reported failure.                                                                                                                          
  - **Add `python3-dev`** to declare the build-time dep introduced by the bundled nanobind submodule (`find_package(Python ... COMPONENTS Interpreter Development.Module)` in `OMPLDependencies.cmake`). Python bindings remain on by default; runtime users only need
  `python3`, which they almost always already have.                                                                                                                                                                                                                             
  - **Upgrade to `<package format="3">`** and consolidate per-target tags into `<depend>`, with `cmake` and `pkg-config` correctly classified as `<buildtool_depend>`. No semantic change in what gets installed; just modernizes the file and reduces duplication.


Once I get the build passing I will make the 2.0 release into Rolling and Lyrical.