### PR TITLE
Default VAMP_PORTABLE_BUILD to ON when building Debian packages

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -12,7 +12,7 @@ add_feature_info(OMPL_BUILD_VAMP "${OMPL_BUILD_VAMP}" "Whether to build VAMP sub
 # is exported by dpkg-buildpackage / debhelper, so this catches the ROS buildfarm
 # and any apt-builds-from-source automatically). Direct `cmake ..` developer
 # builds keep the native-ISA default.
-if(DEFINED ENV{DEB_BUILD_OPTIONS})
+if(DEFINED ENV{DEB_BUILD_OPTIONS} OR SKBUILD)
     set(_VAMP_PORTABLE_DEFAULT ON)
 else()
     set(_VAMP_PORTABLE_DEFAULT OFF)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -8,7 +8,16 @@ option(VAMP_BUILD_PYTHON_BINDINGS "Build VAMP Python bindings (requires OMPL_BUI
 add_feature_info(VAMP_BUILD_PYTHON_BINDINGS "${VAMP_BUILD_PYTHON_BINDINGS}" "Whether to build VAMP Python bindings.")
 option(OMPL_BUILD_VAMP "Build VAMP submodule" ON)
 add_feature_info(OMPL_BUILD_VAMP "${OMPL_BUILD_VAMP}" "Whether to build VAMP submodule.")
-option(VAMP_PORTABLE_BUILD "Build VAMP with portable SIMD settings for distribution (package maintainers)" OFF)
+# Default to portable SIMD when invoked from a Debian/dpkg build (DEB_BUILD_OPTIONS
+# is exported by dpkg-buildpackage / debhelper, so this catches the ROS buildfarm
+# and any apt-builds-from-source automatically). Direct `cmake ..` developer
+# builds keep the native-ISA default.
+if(DEFINED ENV{DEB_BUILD_OPTIONS})
+    set(_VAMP_PORTABLE_DEFAULT ON)
+else()
+    set(_VAMP_PORTABLE_DEFAULT OFF)
+endif()
+option(VAMP_PORTABLE_BUILD "Build VAMP with portable SIMD settings for distribution (package maintainers)" ${_VAMP_PORTABLE_DEFAULT})
 add_feature_info(VAMP_PORTABLE_BUILD "${VAMP_PORTABLE_BUILD}" "Whether to build VAMP with portable SIMD settings for distribution (package maintainers).")
 
 option(OMPL_BUILD_PYTHON_BINDINGS "Build OMPL Python bindings" ON)


### PR DESCRIPTION
## Default `VAMP_PORTABLE_BUILD` to ON when building Debian packages                                                                                                                                                                                                          
                                                                                                                                                                                                                                                                              
  ### Why                                                                                                                                                                                                                                                                       
                                                                                                                                                                                                                                                                                
  When OMPL is consumed via apt (`ros-rolling-ompl`, `ros-jazzy-ompl`, distro debs, anyone redistributing a binary deb), VAMP's SIMD intrinsics need to be compiled for an ISA baseline that *every* user's CPU supports — not the build host's CPU. The current default (`OFF`)
   compiles VAMP for whatever ISA extensions the buildfarm/CI host happens to advertise, which today often includes AVX-512.                                                                                                                                                    
                                                                                                                                                                                                                                                                                
  The failure mode is silent and ugly: a deb built on an AVX-512 host installs fine, configures fine, even loads fine — and then `SIGILL`s deep in a motion-planning hot path the first time VAMP issues a vector instruction. Most consumer Intel CPUs still don't have AVX-512
   (it was disabled in Alder Lake / Raptor Lake), and AMD only added it in Zen 4 (2022), so the affected user population is large. The `option()` description in `CMakeLists.txt` already says *"for distribution (package maintainers)"* — i.e., this knob exists exactly for
  this case. It just isn't getting turned on automatically anywhere.                                                                                                                                                                                                            
                  
  ### What this PR does

  A single change to `CMakeLists.txt`: if `DEB_BUILD_OPTIONS` is set in the environment, default `VAMP_PORTABLE_BUILD` to `ON`. Otherwise leave it `OFF` as today.                                                                                                              
   
  ```cmake                                                                                                                                                                                                                                                                      
  if(DEFINED ENV{DEB_BUILD_OPTIONS})
      set(_VAMP_PORTABLE_DEFAULT ON)                                                                                                                                                                                                                                            
  else()
      set(_VAMP_PORTABLE_DEFAULT OFF)                                                                                                                                                                                                                                           
  endif()                                                                                                                                                                                                                                                                       
  option(VAMP_PORTABLE_BUILD "Build VAMP with portable SIMD settings for distribution (package maintainers)" ${_VAMP_PORTABLE_DEFAULT})
                                                                                                                                                                                                                                                                                
  DEB_BUILD_OPTIONS is exported by dpkg-buildpackage / debhelper for every Debian build — bloom-generated ROS buildfarm jobs, apt source rebuilds, downstream distro packaging — and is unset for direct cmake .. and colcon build invocations. Net effect:                     
                                                                                                                                                                                                                                                                                
  ┌─────────────────────────────────────────────────────────┬────────────────────────────────────────┐                                                                                                                                                                          
  │                       Invocation                        │      VAMP_PORTABLE_BUILD default       │
  ├─────────────────────────────────────────────────────────┼────────────────────────────────────────┤
  │ Developer source build (cmake .. / colcon build / IDE)  │ OFF — unchanged, native SIMD preserved │
  ├─────────────────────────────────────────────────────────┼────────────────────────────────────────┤
  │ ROS buildfarm binarydeb job                             │ ON — portable, safe to redistribute    │                                                                                                                                                                          
  ├─────────────────────────────────────────────────────────┼────────────────────────────────────────┤                                                                                                                                                                          
  │ Downstream distro maintainer rebuilding from source deb │ ON                                     │                                                                                                                                                                          
  ├─────────────────────────────────────────────────────────┼────────────────────────────────────────┤                                                                                                                                                                          
  │ Anyone passing -DVAMP_PORTABLE_BUILD=... explicitly     │ their choice (override always wins)    │
  └─────────────────────────────────────────────────────────┴────────────────────────────────────────┘   