### PR TITLE
enable build of wheels for python3.14

### DIFF
--- a/.github/workflows/wheels_build.yml
+++ b/.github/workflows/wheels_build.yml
@@ -12,23 +12,23 @@ jobs:
       matrix:
         include:
         - os: ubuntu-latest
-          pybuilds: cp3{10,11,12,13}-manylinux_x86_64
+          pybuilds: cp3{10,11,12,13,14}-manylinux_x86_64
           arch: x86_64
           id: linux_x86_64
         - os: ubuntu-24.04-arm
-          pybuilds: cp3{10,11,12,13}-manylinux_aarch64
+          pybuilds: cp3{10,11,12,13,14}-manylinux_aarch64
           arch: aarch64
           id: linux_arm64
         - os: macos-15-intel
-          pybuilds: cp3{10,11,12,13}-macosx_x86_64
+          pybuilds: cp3{10,11,12,13,14}-macosx_x86_64
           arch: x86_64
           id: macos_x86
         - os: macos-15
-          pybuilds: cp3{10,11,12,13}-macosx_arm64
+          pybuilds: cp3{10,11,12,13,14}-macosx_arm64
           arch: arm64
           id: macos_arm64
 #        - os: windows-latest
-#          pybuilds: cp3{10,11,12,13}-win_amd64
+#          pybuilds: cp3{10,11,12,13,14}-win_amd64
 #          arch: x86_64
 #          id: windows_x86_64
     steps:


### PR DESCRIPTION
title says it all.

Closes #1425 