### PR TITLE
Remove redundant Boost system dependency

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -47,7 +47,7 @@ set_package_properties(Boost PROPERTIES
     URL "https://www.boost.org"
     PURPOSE "Used throughout OMPL for data serialization, graphs, etc.")
 set(Boost_USE_MULTITHREADED ON)
-find_package(Boost 1.68 REQUIRED COMPONENTS serialization filesystem system program_options)
+find_package(Boost 1.68 REQUIRED COMPONENTS serialization filesystem program_options)
 
 # on macOS we need to check whether to use libc++ or libstdc++ with clang++
 if(CMAKE_CXX_COMPILER_ID MATCHES "^(Apple)?Clang$")


### PR DESCRIPTION
This PR removes the explicit requirement for the Boost `system` component in the `main` branch (though it appears to have been partially addressed in recent refactors).

In modern Boost versions (including 1.90 found in Ubuntu Resolute), the `system` component is header-only. Explicitly requesting it via `find_package` causes configuration failures on Resolute because the `libboost-system-dev` package is essentially empty/missing CMake configuration files.

Verified on Ubuntu Resolute (26.04) with Boost 1.90.

Reference build in the ROS 2 Lyrical build farm: https://build.ros2.org/view/Lbin_uR64/job/Lbin_uR64__ompl__ubuntu_resolute_amd64__binary/15/

Assisted-by: Gemini CLI:2.0-Flash [run_shell_command]