### PR TITLE
Fix STRRT* Use-after-free in constructSolution + fix rewireGoalTree bugs

### DIFF
--- a/src/ompl/geometric/planners/rrt/src/STRRTstar.cpp
+++ b/src/ompl/geometric/planners/rrt/src/STRRTstar.cpp
@@ -1017,7 +1017,7 @@ bool ompl::geometric::STRRTstar::rewireGoalTree(Motion *addedMotion)
                 Motion *p = otherMotion->parent;
                 while (p != nullptr)
                 {
-                    p->numConnections-=otherMotion->numConnections;
+                    p->numConnections -= otherMotion->numConnections;
                     p = p->parent;
                 }
             }
@@ -1032,7 +1032,7 @@ bool ompl::geometric::STRRTstar::rewireGoalTree(Motion *addedMotion)
             {
                 for (Motion *c : queue.front()->children)
                 {
-                    queue.push(c); 
+                    queue.push(c);
                 }
                 queue.front()->root = addedMotion->root;
                 queue.pop();
@@ -1043,7 +1043,7 @@ bool ompl::geometric::STRRTstar::rewireGoalTree(Motion *addedMotion)
                 Motion *p = otherMotion->parent;
                 while (p != nullptr)
                 {
-                    p->numConnections+=otherMotion->numConnections;
+                    p->numConnections += otherMotion->numConnections;
                     p = p->parent;
                 }
                 if (otherMotion->root->as<ompl::base::CompoundState>()

--- a/src/ompl/geometric/planners/rrt/src/STRRTstar.cpp
+++ b/src/ompl/geometric/planners/rrt/src/STRRTstar.cpp
@@ -1025,7 +1025,7 @@ bool ompl::geometric::STRRTstar::rewireGoalTree(Motion *addedMotion)
             otherMotion->parent = addedMotion;
             otherMotion->root = addedMotion->root;
             addedMotion->children.push_back(otherMotion);
-            // change root state of descendents
+            // change root state of descendants
             std::queue<Motion *> queue;
             queue.push(otherMotion);
             while (!queue.empty())

--- a/src/ompl/geometric/planners/rrt/src/STRRTstar.cpp
+++ b/src/ompl/geometric/planners/rrt/src/STRRTstar.cpp
@@ -628,8 +628,8 @@ void ompl::geometric::STRRTstar::constructSolution(
     }
 
     bestSolution_ = path;
-    auto reachedGaol = path->getState(path->getStateCount() - 1);
-    bestTime_ = reachedGaol->as<ompl::base::CompoundState>()->as<ompl::base::TimeStateSpace::StateType>(1)->position;
+    auto reachedGoal = path->getState(path->getStateCount() - 1);
+    bestTime_ = reachedGoal->as<ompl::base::CompoundState>()->as<ompl::base::TimeStateSpace::StateType>(1)->position;
 
     if (intermediateSolutionCallback)
     {
@@ -647,7 +647,7 @@ void ompl::geometric::STRRTstar::constructSolution(
 
     // loop as long as a new solution is found by rewiring the goal tree
     if (newSolution != nullptr)
-        constructSolution(newSolution->connectionPoint, goalMotion, intermediateSolutionCallback, ptc);
+        constructSolution(newSolution->connectionPoint, newSolution, intermediateSolutionCallback, ptc);
 }
 
 void ompl::geometric::STRRTstar::pruneStartTree()

--- a/src/ompl/geometric/planners/rrt/src/STRRTstar.cpp
+++ b/src/ompl/geometric/planners/rrt/src/STRRTstar.cpp
@@ -1017,7 +1017,7 @@ bool ompl::geometric::STRRTstar::rewireGoalTree(Motion *addedMotion)
                 Motion *p = otherMotion->parent;
                 while (p != nullptr)
                 {
-                    p->numConnections--;
+                    p->numConnections-=otherMotion->numConnections;
                     p = p->parent;
                 }
             }
@@ -1025,13 +1025,25 @@ bool ompl::geometric::STRRTstar::rewireGoalTree(Motion *addedMotion)
             otherMotion->parent = addedMotion;
             otherMotion->root = addedMotion->root;
             addedMotion->children.push_back(otherMotion);
+            // change root state of descendents
+            std::queue<Motion *> queue;
+            queue.push(otherMotion);
+            while (!queue.empty())
+            {
+                for (Motion *c : queue.front()->children)
+                {
+                    queue.push(c); 
+                }
+                queue.front()->root = addedMotion->root;
+                queue.pop();
+            }
             // increase connection count of new ancestors
             if (otherMotion->numConnections > 0)
             {
                 Motion *p = otherMotion->parent;
                 while (p != nullptr)
                 {
-                    p->numConnections++;
+                    p->numConnections+=otherMotion->numConnections;
                     p = p->parent;
                 }
                 if (otherMotion->root->as<ompl::base::CompoundState>()

--- a/tests/geometric/spacetime/STRRTstar_test.cpp
+++ b/tests/geometric/spacetime/STRRTstar_test.cpp
@@ -420,17 +420,17 @@ public:
 
         BOOST_CHECK(rewiredChild->root == validGoal->state);
         BOOST_CHECK(rewiredChild->numConnections == 5);
-        BOOST_CHECK(rewiredChild->parent == validGoal);
+        BOOST_CHECK(rewiredChild->parent == newValidGoalancestor);
         BOOST_CHECK(rewiredChild->children.size() == 1);
 
         BOOST_CHECK(staleRootGrandchild->root == validGoal->state);
         BOOST_CHECK(staleRootGrandchild->numConnections == 5);
-        BOOST_CHECK(staleRootGrandchild->parent == validGoal);
+        BOOST_CHECK(staleRootGrandchild->parent == rewiredChild);
         BOOST_CHECK(staleRootGrandchild->children.size() == 1);
 
         BOOST_CHECK(staleRootGrandGrandchild->root == validGoal->state);
         BOOST_CHECK(staleRootGrandGrandchild->numConnections == 5);
-        BOOST_CHECK(staleRootGrandGrandchild->parent == validGoal);
+        BOOST_CHECK(staleRootGrandGrandchild->parent == staleRootGrandchild);
         BOOST_CHECK(staleRootGrandGrandchild->children.size() == 0);
 
     }

--- a/tests/geometric/spacetime/STRRTstar_test.cpp
+++ b/tests/geometric/spacetime/STRRTstar_test.cpp
@@ -101,7 +101,7 @@ public:
         base::SpaceInformationPtr si = std::make_shared<base::SpaceInformation>(space);
 
         // Set state validity checking for this space
-        if(addObstacle)
+        if (addObstacle)
         {
             si->setStateValidityChecker([](const base::State *state) { return isStateValidHyperball(state); });
         }
@@ -165,17 +165,16 @@ protected:
 class STRRTstarTestAccess : public geometric::STRRTstar
 {
 public:
-
     static std::shared_ptr<base::SpaceInformation> makeSpaceTimeStateSpace()
     {
         double vMax = 1.0;
         std::shared_ptr<ompl::base::RealVectorStateSpace> vectorSpace(std::make_shared<base::RealVectorStateSpace>(1));
-                base::RealVectorBounds bounds(1);
+        base::RealVectorBounds bounds(1);
         bounds.setLow(-1.0);
         bounds.setHigh(1.0);
         vectorSpace->setBounds(bounds);
-        std::shared_ptr<base::SpaceTimeStateSpace> timeSpace = std::make_shared<base::SpaceTimeStateSpace>(vectorSpace, vMax);
-
+        std::shared_ptr<base::SpaceTimeStateSpace> timeSpace =
+            std::make_shared<base::SpaceTimeStateSpace>(vectorSpace, vMax);
 
         timeSpace->setTimeBounds(0.0, 10.0);
 
@@ -193,13 +192,13 @@ public:
     // create such tree that will trigger recursion in the constructSolution() and segfault
     void constructPrunedRecursiveSolution()
     {
-        std::cout<<"Simulated recusion in constructSolution() test"<<std::endl;
+        std::cout << "Simulated recusion in constructSolution() test" << std::endl;
         setRange(1.0);
-        setOptimumApproxFactor(0.6);// so 4.0 > 5.0*0.6 > 2.0 
+        setOptimumApproxFactor(0.6);  // so 4.0 > 5.0*0.6 > 2.0
         setup();
 
         minimumTime_ = 0.0;
-        upperTimeBound_ = 5.0; // must be > then invalidGoal time
+        upperTimeBound_ = 5.0;  // must be > then invalidGoal time
         isTimeBounded_ = true;
 
         startMotion_ = makeMotion(0.0, 0.0);
@@ -227,7 +226,6 @@ public:
         invalidGoal->children.push_back(connectedInvalidDescendant);
         tGoal_->add(connectedInvalidDescendant);
 
-
         // Nodes:
         // S   = startMotion_                 (x=0.0, t=0.0)
         // CID = connectedInvalidDescendant   (x=0.9, t=1.5)
@@ -242,33 +240,30 @@ public:
         //   4.0 |                                      IG   [invalid goal root]
         //       |                                     /
         //       |                                    /
-        //       |                                   / 
+        //       |                                   /
         //       |                                  /
         //       |                                 |
         //   2.0 |                                 |    VG   [valid goal]
-        //       |                                 |    
+        //       |                                 |
         //       |                                 |
         //   1.5 |                              __CID
-        //       |                             / 
-        //       |                      ______/   
+        //       |                             /
+        //       |                      ______/
         //       |           __________/
         //       | _________/
-        //       |/        
+        //       |/
         //   0.0 *------------------------------------------> coordinate x
         //     S (0.0)                              0.9  1.0
         //    start
 
-                
         constructSolution(startMotion_, invalidGoal, base::ReportIntermediateSolutionFn(),
                           base::plannerNonTerminatingCondition());
-                         
     }
 
-
-    // test to check the bug: ascendants if the rewired node will not have updated ->root. 
+    // test to check the bug: ascendants if the rewired node will not have updated ->root.
     void rewireGoalTreeUpdatesDescendantRoots()
     {
-        std::cout<<"Check ascendats root after rewire test"<<std::endl;
+        std::cout << "Check ascendats root after rewire test" << std::endl;
         setRange(1.0);
         setOptimumApproxFactor(1);
         setup();
@@ -288,7 +283,6 @@ public:
         newValidGoalancestor->parent = validGoal;
         validGoal->children.push_back(newValidGoalancestor);
         tGoal_->add(newValidGoalancestor);
-
 
         auto *invalidGoal = makeMotion(1.0, 4.0);
         invalidGoal->root = invalidGoal->state;
@@ -317,7 +311,6 @@ public:
         staleRootGrandchild->numConnections = 5;
         tGoal_->add(staleRootGrandchild);
 
-
         auto *staleRootGrandGrandchild = makeMotion(0.3, 0.5);
         staleRootGrandGrandchild->parent = staleRootGrandchild;
         staleRootGrandGrandchild->root = invalidGoal->state;
@@ -326,7 +319,6 @@ public:
         tGoal_->add(staleRootGrandGrandchild);
 
         rewireGoalTree(newValidGoalancestor);
-  
 
         // Goal-tree layout for rewireGoalTreeUpdatesDescendantRoots()
         // (We assume, that staleRootGrandGrandchild num connections = 5)
@@ -349,8 +341,8 @@ public:
         //     |                                          /
         // 3.0 |                                      IGA
         //     |                                     /
-        //     |                                  __/ 
-        //     |                                 |  
+        //     |                                  __/
+        //     |                                 |
         // 2.0 |                                 |      VG
         //     |                                 |     /
         // 1.5 |                                 |   NVGA
@@ -382,9 +374,9 @@ public:
         //     |                                           /
         //     |                                          / [old branch]
         // 3.0 |                                       IGA
-        //     |                                      
-        //     |                                      
-        //     |                                    
+        //     |
+        //     |
+        //     |
         // 2.0 |                                        VG
         //     |                                       /
         // 1.5 |                                     NVGA
@@ -410,7 +402,6 @@ public:
         BOOST_CHECK(newValidGoalancestor->parent == validGoal);
         BOOST_CHECK(newValidGoalancestor->children.size() == 1);
 
-
         BOOST_CHECK(invalidGoal->numConnections == 0);
 
         BOOST_CHECK(invalidGoalancestor->root == invalidGoal->state);
@@ -432,8 +423,8 @@ public:
         BOOST_CHECK(staleRootGrandGrandchild->numConnections == 5);
         BOOST_CHECK(staleRootGrandGrandchild->parent == staleRootGrandchild);
         BOOST_CHECK(staleRootGrandGrandchild->children.size() == 0);
-
     }
+
 private:
     Motion *makeMotion(double position, double time)
     {
@@ -444,10 +435,6 @@ private:
         return motion;
     }
 };
-
-
-
-
 
 // Define the test suite
 BOOST_FIXTURE_TEST_SUITE(SpaceTimePlanningTestFixture, SpaceTimeTestFixture)
@@ -522,7 +509,6 @@ BOOST_AUTO_TEST_CASE(spacetime_rewore_goal_tree_updates_descendant_roots)
     BOOST_CHECK_NO_THROW(planner.rewireGoalTreeUpdatesDescendantRoots());
 }
 
-
 // // Stress test for pruning and final time optimising with different seeds
 BOOST_AUTO_TEST_CASE(spacetime_planning_stress)
 {
@@ -532,12 +518,11 @@ BOOST_AUTO_TEST_CASE(spacetime_planning_stress)
     {
         BOOST_TEST_CONTEXT("stress run " << i)
         {
-            runSpaceTimePlanner(0.0, 20.0, 0.5, 6, {-1.0, -1.0, -1.0, -1.0, -1.0, -1.0},
-                                {1.0, 1.0, 1.0, 1.0, 1.0, 1.0}, true, 0.99,
+            runSpaceTimePlanner(0.0, 20.0, 0.5, 6, {-1.0, -1.0, -1.0, -1.0, -1.0, -1.0}, {1.0, 1.0, 1.0, 1.0, 1.0, 1.0},
+                                true, 0.99,
                                 true);  // 6D diagonal movement with goal time optimisation
         }
     }
 }
-
 
 BOOST_AUTO_TEST_SUITE_END()

--- a/tests/geometric/spacetime/STRRTstar_test.cpp
+++ b/tests/geometric/spacetime/STRRTstar_test.cpp
@@ -18,6 +18,16 @@ bool isStateValid(const base::State *state)
     return pos < std::numeric_limits<double>::infinity();
 }
 
+bool isStateValidHyperball(const ompl::base::State *state)
+{
+    const auto *values =
+        state->as<ompl::base::CompoundState>()->as<ompl::base::RealVectorStateSpace::StateType>(0)->values;
+    double s = 0.0;
+    for (unsigned int i = 0; i < 6; ++i)
+        s += values[i] * values[i];
+    return (s > 0.1) && (s < 24);
+}
+
 class SpaceTimeMotionValidator : public base::MotionValidator
 {
 public:
@@ -72,7 +82,7 @@ public:
     // A generic planning function that can be called by different tests with different time bounds
     void runSpaceTimePlanner(double startTime, double endTime, double vMax = 0.2, unsigned int dimensions = 1,
                              std::vector<double> startPos = {0.0}, std::vector<double> goalPos = {1.0},
-                             bool expectSuccess = true)
+                             bool expectSuccess = true, double OptimumApproxFactor = 1.0, bool addObstacle = false)
     {
         // Construct the state space we are planning in
         auto vectorSpace(std::make_shared<base::RealVectorStateSpace>(dimensions));
@@ -91,7 +101,14 @@ public:
         base::SpaceInformationPtr si = std::make_shared<base::SpaceInformation>(space);
 
         // Set state validity checking for this space
-        si->setStateValidityChecker([](const base::State *state) { return isStateValid(state); });
+        if(addObstacle)
+        {
+            si->setStateValidityChecker([](const base::State *state) { return isStateValidHyperball(state); });
+        }
+        else
+        {
+            si->setStateValidityChecker([](const base::State *state) { return isStateValid(state); });
+        }
         si->setMotionValidator(std::make_shared<SpaceTimeMotionValidator>(si));
 
         // Define a simple setup class
@@ -119,6 +136,7 @@ public:
         // Construct the planner
         auto *strrtStar = new geometric::STRRTstar(si);
         strrtStar->setRange(vMax);
+        strrtStar->setOptimumApproxFactor(OptimumApproxFactor);
         ss.setPlanner(base::PlannerPtr(strrtStar));
 
         ompl::base::IterationTerminationCondition itc(1000);
@@ -142,6 +160,124 @@ public:
 protected:
     bool verbose_;
 };
+
+// Define test cases with fixed tree to test functions and to determenistically reproduce segfault
+class STRRTstarTestAccess : public geometric::STRRTstar
+{
+public:
+
+    static std::shared_ptr<base::SpaceInformation> makeSpaceTimeStateSpace()
+    {
+        double vMax = 1.0;
+        std::shared_ptr<ompl::base::RealVectorStateSpace> vectorSpace(std::make_shared<base::RealVectorStateSpace>(1));
+                base::RealVectorBounds bounds(1);
+        bounds.setLow(-1.0);
+        bounds.setHigh(1.0);
+        vectorSpace->setBounds(bounds);
+        std::shared_ptr<base::SpaceTimeStateSpace> timeSpace = std::make_shared<base::SpaceTimeStateSpace>(vectorSpace, vMax);
+
+
+        timeSpace->setTimeBounds(0.0, 10.0);
+
+        std::shared_ptr<base::SpaceInformation> space = std::make_shared<base::SpaceInformation>(timeSpace);
+        space->setStateValidityChecker([](const base::State *state) { return isStateValid(state); });
+        space->setMotionValidator(std::make_shared<SpaceTimeMotionValidator>(space));
+        space->setup();
+        return space;
+    }
+
+    explicit STRRTstarTestAccess() : STRRTstar(makeSpaceTimeStateSpace())
+    {
+    }
+
+    // create such tree that will trigger recursion in the constructSolution() and segfault
+    void constructPrunedRecursiveSolution()
+    {
+        std::cout<<"Simulated recusion in constructSolution() test"<<std::endl;
+        setRange(1.0);
+        setOptimumApproxFactor(0.6);// so 4.0 > 5.0*0.6 > 2.0 
+        setup();
+
+        minimumTime_ = 0.0;
+        upperTimeBound_ = 5.0; // must be > then invalidGoal time
+        isTimeBounded_ = true;
+
+        startMotion_ = makeMotion(0.0, 0.0);
+        startMotion_->root = startMotion_->state;
+        tStart_->add(startMotion_);
+
+        auto *validGoal = makeMotion(1.0, 2.0);
+        validGoal->root = validGoal->state;
+        goalMotions_.push_back(validGoal);
+        tGoal_->add(validGoal);
+
+        // The connected descendant is rewired to validGoal during pruning,
+        // while its original invalid goal root is deleted.
+        auto *invalidGoal = makeMotion(1.0, 4.0);
+        invalidGoal->root = invalidGoal->state;
+        invalidGoal->numConnections = 1;
+        goalMotions_.push_back(invalidGoal);
+        tGoal_->add(invalidGoal);
+
+        auto *connectedInvalidDescendant = makeMotion(0.9, 1.5);
+        connectedInvalidDescendant->parent = invalidGoal;
+        connectedInvalidDescendant->root = invalidGoal->state;
+        connectedInvalidDescendant->connectionPoint = startMotion_;
+        connectedInvalidDescendant->numConnections = 1;
+        invalidGoal->children.push_back(connectedInvalidDescendant);
+        tGoal_->add(connectedInvalidDescendant);
+
+
+        // Nodes:
+        // S   = startMotion_                 (x=0.0, t=0.0)
+        // CID = connectedInvalidDescendant   (x=0.9, t=1.5)
+        // VG  = validGoal                    (x=1.0, t=2.0)
+        // IG  = invalidGoal                  (x=1.0, t=4.0)
+        // CID.connectionPoint -> S     shown as straight line S * CID
+        // CID.parent          -> IG    shown as parent edge IG * CID
+        // CID.root            -> IG.state
+
+        //     time t
+        //       ^
+        //   4.0 |                                      IG   [invalid goal root]
+        //       |                                      *
+        //       |                                     *
+        //       |                                    * 
+        //       |                                   *
+        //       |                                  *
+        //   2.0 |                                 *    VG   [valid goal]
+        //       |                                 *    *
+        //       |                                 *
+        //   1.5 |                                CID
+        //       |                              ***
+        //       |                         ******
+        //       |                    *****
+        //       |           *********
+        //       |  *********        
+        //   0.0 *------------------------------------------> coordinate x
+        //     S (0.0)                              0.9  1.0
+        //    start
+
+                
+        constructSolution(startMotion_, invalidGoal, base::ReportIntermediateSolutionFn(),
+                          base::plannerNonTerminatingCondition());
+                         
+    }
+
+private:
+    Motion *makeMotion(double position, double time)
+    {
+        auto *motion = new Motion(si_);
+        auto *compound = motion->state->as<base::CompoundState>();
+        compound->as<base::RealVectorStateSpace::StateType>(0)->values[0] = position;
+        compound->as<base::TimeStateSpace::StateType>(1)->position = time;
+        return motion;
+    }
+};
+
+
+
+
 
 // Define the test suite
 BOOST_FIXTURE_TEST_SUITE(SpaceTimePlanningTestFixture, SpaceTimeTestFixture)
@@ -199,5 +335,30 @@ BOOST_AUTO_TEST_CASE(spacetime_planning_3d_diagonal)
 {
     runSpaceTimePlanner(0.0, 15.0, 0.3, 3, {0.0, 0.0, 0.0}, {1.0, 1.0, 1.0});  // 3D diagonal movement
 }
+
+// Test case with fixed tree for broken recursive and use-after-free in constructSolution
+BOOST_AUTO_TEST_CASE(spacetime_pruned_goal_solution_uses_rewired_goal_motion)
+{
+    STRRTstarTestAccess planner;
+
+    BOOST_CHECK_NO_THROW(planner.constructPrunedRecursiveSolution());
+}
+
+// Stress test for pruning and final time optimising with different seeds
+BOOST_AUTO_TEST_CASE(spacetime_planning_stress)
+{
+    const unsigned int runs = 100;
+
+    for (unsigned int i = 0; i < runs; ++i)
+    {
+        BOOST_TEST_CONTEXT("stress run " << i)
+        {
+            runSpaceTimePlanner(0.0, 20.0, 0.5, 6, {-1.0, -1.0, -1.0, -1.0, -1.0, -1.0},
+                                {1.0, 1.0, 1.0, 1.0, 1.0, 1.0}, true, 0.99,
+                                true);  // 6D diagonal movement with goal time optimisation
+        }
+    }
+}
+
 
 BOOST_AUTO_TEST_SUITE_END()

--- a/tests/geometric/spacetime/STRRTstar_test.cpp
+++ b/tests/geometric/spacetime/STRRTstar_test.cpp
@@ -240,20 +240,20 @@ public:
         //     time t
         //       ^
         //   4.0 |                                      IG   [invalid goal root]
-        //       |                                      *
-        //       |                                     *
-        //       |                                    * 
-        //       |                                   *
-        //       |                                  *
-        //   2.0 |                                 *    VG   [valid goal]
-        //       |                                 *    *
-        //       |                                 *
-        //   1.5 |                                CID
-        //       |                              ***
-        //       |                         ******
-        //       |                    *****
-        //       |           *********
-        //       |  *********        
+        //       |                                     /
+        //       |                                    /
+        //       |                                   / 
+        //       |                                  /
+        //       |                                 |
+        //   2.0 |                                 |    VG   [valid goal]
+        //       |                                 |    
+        //       |                                 |
+        //   1.5 |                              __CID
+        //       |                             / 
+        //       |                      ______/   
+        //       |           __________/
+        //       | _________/
+        //       |/        
         //   0.0 *------------------------------------------> coordinate x
         //     S (0.0)                              0.9  1.0
         //    start
@@ -264,6 +264,176 @@ public:
                          
     }
 
+
+    // test to check the bug: ascendants if the rewired node will not have updated ->root. 
+    void rewireGoalTreeUpdatesDescendantRoots()
+    {
+        std::cout<<"Check ascendats root after rewire test"<<std::endl;
+        setRange(1.0);
+        setOptimumApproxFactor(1);
+        setup();
+
+        upperTimeBound_ = 5.0;
+        isTimeBounded_ = true;
+
+        auto *validGoal = makeMotion(0.99, 2.0);
+        validGoal->root = validGoal->state;
+        validGoal->numConnections = 0;
+        goalMotions_.push_back(validGoal);
+        tGoal_->add(validGoal);
+
+        auto *newValidGoalancestor = makeMotion(0.95, 1.5);
+        newValidGoalancestor->root = validGoal->state;
+        newValidGoalancestor->numConnections = 0;
+        newValidGoalancestor->parent = validGoal;
+        validGoal->children.push_back(newValidGoalancestor);
+        tGoal_->add(newValidGoalancestor);
+
+
+        auto *invalidGoal = makeMotion(1.0, 4.0);
+        invalidGoal->root = invalidGoal->state;
+        invalidGoal->numConnections = 5;
+        goalMotions_.push_back(invalidGoal);
+        tGoal_->add(invalidGoal);
+
+        auto *invalidGoalancestor = makeMotion(0.95, 3.0);
+        invalidGoalancestor->root = invalidGoal->state;
+        invalidGoalancestor->numConnections = 5;
+        invalidGoalancestor->parent = invalidGoal;
+        invalidGoal->children.push_back(invalidGoalancestor);
+        tGoal_->add(invalidGoalancestor);
+
+        auto *rewiredChild = makeMotion(0.9, 1.2);
+        rewiredChild->parent = invalidGoalancestor;
+        rewiredChild->root = invalidGoal->state;
+        rewiredChild->numConnections = 5;
+        invalidGoalancestor->children.push_back(rewiredChild);
+        tGoal_->add(rewiredChild);
+
+        auto *staleRootGrandchild = makeMotion(0.6, 0.8);
+        staleRootGrandchild->parent = rewiredChild;
+        staleRootGrandchild->root = invalidGoal->state;
+        rewiredChild->children.push_back(staleRootGrandchild);
+        staleRootGrandchild->numConnections = 5;
+        tGoal_->add(staleRootGrandchild);
+
+
+        auto *staleRootGrandGrandchild = makeMotion(0.3, 0.5);
+        staleRootGrandGrandchild->parent = staleRootGrandchild;
+        staleRootGrandGrandchild->root = invalidGoal->state;
+        staleRootGrandchild->children.push_back(staleRootGrandGrandchild);
+        staleRootGrandGrandchild->numConnections = 5;
+        tGoal_->add(staleRootGrandGrandchild);
+
+        rewireGoalTree(newValidGoalancestor);
+  
+
+        // Goal-tree layout for rewireGoalTreeUpdatesDescendantRoots()
+        // (We assume, that staleRootGrandGrandchild num connections = 5)
+        // Nodes:
+        // VG    = validGoal                 (x=0.99, t=2.0), root -> VG.state
+        // NVGA  = newValidGoalancestor      (x=0.95, t=1.5), parent -> VG,  root -> VG.state
+        //
+        // IG    = invalidGoal               (x=1.00, t=4.0), root -> IG.state
+        // IGA   = invalidGoalancestor       (x=0.95, t=3.0), parent -> IG,  root -> IG.state
+        // RC    = rewiredChild              (x=0.90, t=1.2), parent -> IGA, root -> IG.state
+        // SRG   = staleRootGrandchild       (x=0.60, t=0.8), parent -> RC,  root -> IG.state
+        // SRGG  = staleRootGrandGrandchild  (x=0.30, t=0.5), parent -> SRG, root -> IG.state
+        //
+        // Before rewire:
+        //
+        // time t
+        //   ^
+        // 4.0 |                                            IG
+        //     |                                           /
+        //     |                                          /
+        // 3.0 |                                      IGA
+        //     |                                     /
+        //     |                                  __/ 
+        //     |                                 |  
+        // 2.0 |                                 |      VG
+        //     |                                 |     /
+        // 1.5 |                                 |   NVGA
+        //     |                                 |
+        // 1.2 |                                RC
+        //     |                       _________/
+        // 0.8 |                    SRG
+        //     |           _________/
+        // 0.5 |        SRGG (num_connections=5)
+        //     |
+        // 0.0 +----------------------------------------------------> coordinate x
+        //              0.30        0.60        0.90 0.95 0.99 1.00
+        //
+        // Parent edges before:
+        //   VG  -> NVGA
+        //   IG  -> IGA -> RC -> SRG -> SRGG
+        //
+        // Root values before:
+        //   NVGA.root = VG.state
+        //   IGA.root  = IG.state
+        //   RC.root   = IG.state
+        //   SRG.root  = IG.state
+        //   SRGG.root = IG.state
+        //
+        //
+        // time t
+        //   ^
+        // 4.0 |                                            IG
+        //     |                                           /
+        //     |                                          / [old branch]
+        // 3.0 |                                       IGA
+        //     |                                      
+        //     |                                      
+        //     |                                    
+        // 2.0 |                                        VG
+        //     |                                       /
+        // 1.5 |                                     NVGA
+        //     |                                  ___/    [rewired here]
+        // 1.2 |                                RC
+        //     |                       _________/
+        // 0.8 |                    SRG
+        //     |           _________/
+        // 0.5 |        SRGG (num_connections=5)
+        //     |
+        // 0.0 +----------------------------------------------------> coordinate x
+        //              0.30        0.60        0.90 0.95 0.99 1.00
+        //
+        // Parent edges after:
+        //   VG -> NVGA -> RC -> SRG -> SRGG
+        //   IG -> IGA
+        //
+
+        BOOST_CHECK(validGoal->numConnections = 5);
+
+        BOOST_CHECK(newValidGoalancestor->root == validGoal->state);
+        BOOST_CHECK(newValidGoalancestor->numConnections == 5);
+        BOOST_CHECK(newValidGoalancestor->parent == validGoal);
+        BOOST_CHECK(newValidGoalancestor->children.size() == 1);
+
+
+        BOOST_CHECK(invalidGoal->numConnections == 0);
+
+        BOOST_CHECK(invalidGoalancestor->root == invalidGoal->state);
+        BOOST_CHECK(invalidGoalancestor->numConnections == 0);
+        BOOST_CHECK(invalidGoalancestor->parent == invalidGoal);
+        BOOST_CHECK(invalidGoalancestor->children.size() == 0);
+
+        BOOST_CHECK(rewiredChild->root == validGoal->state);
+        BOOST_CHECK(rewiredChild->numConnections == 5);
+        BOOST_CHECK(rewiredChild->parent == validGoal);
+        BOOST_CHECK(rewiredChild->children.size() == 1);
+
+        BOOST_CHECK(staleRootGrandchild->root == validGoal->state);
+        BOOST_CHECK(staleRootGrandchild->numConnections == 5);
+        BOOST_CHECK(staleRootGrandchild->parent == validGoal);
+        BOOST_CHECK(staleRootGrandchild->children.size() == 1);
+
+        BOOST_CHECK(staleRootGrandGrandchild->root == validGoal->state);
+        BOOST_CHECK(staleRootGrandGrandchild->numConnections == 5);
+        BOOST_CHECK(staleRootGrandGrandchild->parent == validGoal);
+        BOOST_CHECK(staleRootGrandGrandchild->children.size() == 0);
+
+    }
 private:
     Motion *makeMotion(double position, double time)
     {
@@ -344,21 +514,30 @@ BOOST_AUTO_TEST_CASE(spacetime_pruned_goal_solution_uses_rewired_goal_motion)
     BOOST_CHECK_NO_THROW(planner.constructPrunedRecursiveSolution());
 }
 
-// Stress test for pruning and final time optimising with different seeds
-BOOST_AUTO_TEST_CASE(spacetime_planning_stress)
+// Test case with fixed tree for broken recursive and use-after-free in constructSolution
+BOOST_AUTO_TEST_CASE(spacetime_rewore_goal_tree_updates_descendant_roots)
 {
-    const unsigned int runs = 100;
+    STRRTstarTestAccess planner;
 
-    for (unsigned int i = 0; i < runs; ++i)
-    {
-        BOOST_TEST_CONTEXT("stress run " << i)
-        {
-            runSpaceTimePlanner(0.0, 20.0, 0.5, 6, {-1.0, -1.0, -1.0, -1.0, -1.0, -1.0},
-                                {1.0, 1.0, 1.0, 1.0, 1.0, 1.0}, true, 0.99,
-                                true);  // 6D diagonal movement with goal time optimisation
-        }
-    }
+    BOOST_CHECK_NO_THROW(planner.rewireGoalTreeUpdatesDescendantRoots());
 }
+
+
+// // Stress test for pruning and final time optimising with different seeds
+// BOOST_AUTO_TEST_CASE(spacetime_planning_stress)
+// {
+//     const unsigned int runs = 100;
+
+//     for (unsigned int i = 0; i < runs; ++i)
+//     {
+//         BOOST_TEST_CONTEXT("stress run " << i)
+//         {
+//             runSpaceTimePlanner(0.0, 20.0, 0.5, 6, {-1.0, -1.0, -1.0, -1.0, -1.0, -1.0},
+//                                 {1.0, 1.0, 1.0, 1.0, 1.0, 1.0}, true, 0.99,
+//                                 true);  // 6D diagonal movement with goal time optimisation
+//         }
+//     }
+// }
 
 
 BOOST_AUTO_TEST_SUITE_END()

--- a/tests/geometric/spacetime/STRRTstar_test.cpp
+++ b/tests/geometric/spacetime/STRRTstar_test.cpp
@@ -25,7 +25,7 @@ bool isStateValidHyperball(const ompl::base::State *state)
     double s = 0.0;
     for (unsigned int i = 0; i < 6; ++i)
         s += values[i] * values[i];
-    return (s > 0.1) && (s < 24);
+    return (s > 0.1);
 }
 
 class SpaceTimeMotionValidator : public base::MotionValidator
@@ -514,7 +514,7 @@ BOOST_AUTO_TEST_CASE(spacetime_pruned_goal_solution_uses_rewired_goal_motion)
     BOOST_CHECK_NO_THROW(planner.constructPrunedRecursiveSolution());
 }
 
-// Test case with fixed tree for broken recursive and use-after-free in constructSolution
+// Test case with fixed tree for wrong root in descendants and wrong numConnections in ascendants in rewireGoalTree
 BOOST_AUTO_TEST_CASE(spacetime_rewore_goal_tree_updates_descendant_roots)
 {
     STRRTstarTestAccess planner;
@@ -524,20 +524,20 @@ BOOST_AUTO_TEST_CASE(spacetime_rewore_goal_tree_updates_descendant_roots)
 
 
 // // Stress test for pruning and final time optimising with different seeds
-// BOOST_AUTO_TEST_CASE(spacetime_planning_stress)
-// {
-//     const unsigned int runs = 100;
+BOOST_AUTO_TEST_CASE(spacetime_planning_stress)
+{
+    const unsigned int runs = 100;
 
-//     for (unsigned int i = 0; i < runs; ++i)
-//     {
-//         BOOST_TEST_CONTEXT("stress run " << i)
-//         {
-//             runSpaceTimePlanner(0.0, 20.0, 0.5, 6, {-1.0, -1.0, -1.0, -1.0, -1.0, -1.0},
-//                                 {1.0, 1.0, 1.0, 1.0, 1.0, 1.0}, true, 0.99,
-//                                 true);  // 6D diagonal movement with goal time optimisation
-//         }
-//     }
-// }
+    for (unsigned int i = 0; i < runs; ++i)
+    {
+        BOOST_TEST_CONTEXT("stress run " << i)
+        {
+            runSpaceTimePlanner(0.0, 20.0, 0.5, 6, {-1.0, -1.0, -1.0, -1.0, -1.0, -1.0},
+                                {1.0, 1.0, 1.0, 1.0, 1.0, 1.0}, true, 0.99,
+                                true);  // 6D diagonal movement with goal time optimisation
+        }
+    }
+}
 
 
 BOOST_AUTO_TEST_SUITE_END()


### PR DESCRIPTION
# Fix use-after-free in `STRRTstar::constructSolution()`

While testing solution refinement in STRRT*, I noticed that about ~5% of the runs crashed with a segmentation fault. After rerunning the failing cases with sanitizers and Valgrind, I found that the crash was caused by a use-after-free in `constructSolution()`.

`pruneGoalTree()` can invalidate the previous `goalMotion`. The old `goalMotion` was then reused as an argument in the recursive call to `constructSolution()`, even though it may already have been freed. This is also logically incorrect: after pruning the goal tree, the planner receives a new solution motion and should continue from that motion, not from the old one. The corresponding start-side connection is `newSolution->connectionPoint`.

The fix changes the recursive call from using the old `goalMotion` to using the newly found solution:

```cpp
constructSolution(newSolution->connectionPoint, newSolution, intermediateSolutionCallback, ptc);
```

I added:
- a stress test with a simple obstacle and path refinement, which triggers the recursive `constructSolution()` call and previously reproduced the segmentation fault;
- a deterministic test with a prebuilt tree that reproduces the same invalid access.

After the fix, all tests pass without segmentation faults.

I also fixed a typo in the local variable name near:

https://github.com/ompl/ompl/blob/4e9bbe060ffd4bd069d474d4a861b4de8d7c0701/src/ompl/geometric/planners/rrt/src/STRRTstar.cpp#L631-L632

The variable should be named `reachedGoal`.

# Fix rewiring in `STRRTstar::rewireGoalTree()`

While reviewing the surrounding STRRT* code, I also found two bugs in `rewireGoalTree()`:

1. When a node is rewired to a better goal-tree parent, the algorithm updates the rewired node's `root`, but does not update the `root` field of its descendants. This can leave descendants pointing to the old goal root, even though their subtree has been moved under a different root.

   This is inconsistent with the logic used when orphaned nodes are rewired in `pruneGoalTree()`, where descendants are updated through `addDescendants()`.
   https://github.com/ompl/ompl/blob/4e9bbe060ffd4bd069d474d4a861b4de8d7c0701/src/ompl/geometric/planners/rrt/src/STRRTstar.cpp#L970

2. The algorithm updates ancestor `numConnections` counters by `1`, even when the rewired subtree contains more than one connection. Since `numConnections` represents the number of start-tree connections in the node and all its descendants, ancestor counters must be adjusted by the rewired node's full `numConnections` value.
https://github.com/ompl/ompl/blob/4e9bbe060ffd4bd069d474d4a861b4de8d7c0701/src/ompl/geometric/planners/rrt/src/STRRTstar.cpp#L1020

   https://github.com/ompl/ompl/blob/4e9bbe060ffd4bd069d474d4a861b4de8d7c0701/src/ompl/geometric/planners/rrt/src/STRRTstar.cpp#L1034

I added deterministic regression tests for both rewiring issues. The tests fail on the old implementation and pass after the fixes.
