### PR TITLE
PlannerDataStorage: validate deserialized state buffer length

### DIFF
--- a/src/ompl/base/PlannerDataStorage.h
+++ b/src/ompl/base/PlannerDataStorage.h
@@ -39,10 +39,12 @@
 
 #include "ompl/base/PlannerData.h"
 #include "ompl/util/Console.h"
+#include <boost/archive/archive_exception.hpp>
 #include <boost/archive/binary_oarchive.hpp>
 #include <boost/archive/binary_iarchive.hpp>
 #include <boost/serialization/vector.hpp>
 #include <boost/serialization/utility.hpp>
+#include <cstddef>
 #include <fstream>
 
 namespace ompl
@@ -175,11 +177,25 @@ namespace ompl
             virtual void loadVertices(PlannerData &pd, unsigned int numVertices, boost::archive::binary_iarchive &ia)
             {
                 const StateSpacePtr &space = pd.getSpaceInformation()->getStateSpace();
+                const std::size_t expectedStateBytes = space->getSerializationLength();
                 std::vector<State *> states;
                 for (unsigned int i = 0; i < numVertices; ++i)
                 {
                     PlannerDataVertexData vertexData;
                     ia >> vertexData;
+
+                    // The serialized state buffer is read directly from the archive, so its size
+                    // is determined by the archive contents rather than by the local state space.
+                    // space->deserialize() performs a fixed-length memcpy of expectedStateBytes
+                    // bytes from this buffer; a buffer shorter than that (including an empty
+                    // buffer, where &state_[0] is itself undefined) would cause an out-of-bounds
+                    // heap read. Reject such archives before touching the buffer.
+                    if (vertexData.state_.size() < expectedStateBytes)
+                    {
+                        delete vertexData.v_;
+                        throw boost::archive::archive_exception(
+                            boost::archive::archive_exception::input_stream_error);
+                    }
 
                     // Deserializing all data in the vertex (except the state)
                     const PlannerDataVertex *v = vertexData.v_;

--- a/tests/base/planner_data.cpp
+++ b/tests/base/planner_data.cpp
@@ -582,3 +582,49 @@ BOOST_AUTO_TEST_CASE(Serialization)
     for (auto &state : states)
         space->freeState(state);
 }
+
+// Storage subclass that intentionally writes an empty state buffer to exercise
+// PlannerDataStorage::loadVertices()'s length validation. A faithful store()
+// always writes exactly space->getSerializationLength() bytes; here we
+// short-circuit storeVertices() to produce an archive a malicious caller could
+// craft.
+class TruncatedStorage : public base::PlannerDataStorage
+{
+protected:
+    void storeVertices(const base::PlannerData &pd, boost::archive::binary_oarchive &oa) override
+    {
+        for (unsigned int i = 0; i < pd.numVertices(); ++i)
+        {
+            PlannerDataVertexData vertexData;
+            vertexData.v_ = &pd.getVertex(i);
+            vertexData.type_ = PlannerDataVertexData::STANDARD;
+            vertexData.state_.clear();
+            oa << vertexData;
+        }
+    }
+};
+
+BOOST_AUTO_TEST_CASE(LoadRejectsTruncatedStateBuffer)
+{
+    auto space(std::make_shared<base::RealVectorStateSpace>(2));
+    base::RealVectorBounds bounds(2);
+    bounds.setLow(-1);
+    bounds.setHigh(1);
+    space->setBounds(bounds);
+    auto si(std::make_shared<base::SpaceInformation>(space));
+
+    base::PlannerData data(si);
+    base::State *s = space->allocState();
+    data.addVertex(base::PlannerDataVertex(s));
+
+    TruncatedStorage badStorage;
+    badStorage.store(data, "testdata-truncated");
+    space->freeState(s);
+
+    // load() must reject the short buffer (returning false) rather than
+    // letting space->deserialize() memcpy past the end of vertexData.state_.
+    base::PlannerData data2(si);
+    base::PlannerDataStorage storage;
+    BOOST_CHECK(!storage.load("testdata-truncated", data2));
+    BOOST_CHECK_EQUAL(data2.numVertices(), 0u);
+}


### PR DESCRIPTION
## Summary

`PlannerDataStorage::loadVertices()` passes `&vertexData.state_[0]` to
`space->deserialize()` without checking that `vertexData.state_` is at
least as large as the state space expects. Because the buffer's size
comes from the archive contents rather than from the local state space,
a malformed archive could drive `deserialize()` — which is a
fixed-length `memcpy` in `RealVectorStateSpace`, `SO3StateSpace`,
`DiscreteStateSpace`, and `TimeStateSpace` — into a heap-buffer
out-of-bounds read. An empty `state_` is also UB on its own, since
`&state_[0]` is undefined for an empty `std::vector`.

This patch validates the buffer length once at the top of the loop and
rejects short buffers via `archive_exception::input_stream_error`, so
the existing `catch` in `load()` handles it by logging and returning
`false`. The polymorphic vertex pointer that `boost::serialization` has
already allocated is freed first to avoid a leak.

Round-trips of valid archives are unaffected — `storeVertices()` always
writes exactly `space->getSerializationLength()` bytes per state, so
`state_.size() == expectedStateBytes` holds on a faithful load.

## Test plan

- [ ] `tests/base/planner_data` round-trip test still passes
- [ ] Loading a deliberately truncated archive returns `false` and logs the error instead of crashing under ASan