### PR TITLE
ci: produce release tarball with vendored submodules

### DIFF
--- a/.github/workflows/release_tarball.yml
+++ b/.github/workflows/release_tarball.yml
@@ -1,0 +1,98 @@
+name: Release Tarball
+
+on:
+  release:
+    types: [published]
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: Existing tag to build a release tarball for (e.g. 2.0.0)
+        required: true
+        type: string
+
+jobs:
+  build-tarball:
+    name: Build ompl-${{ github.event.release.tag_name || inputs.tag }}.tar.gz
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - name: Resolve tag
+        id: tag
+        run: |
+          if [ "${{ github.event_name }}" = "release" ]; then
+            echo "name=${{ github.event.release.tag_name }}" >> "$GITHUB_OUTPUT"
+          else
+            echo "name=${{ inputs.tag }}" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Check out tag with submodules
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ steps.tag.outputs.name }}
+          submodules: recursive
+          fetch-depth: 1
+
+      - name: Vendor submodule content into the working tree
+        # actions/checkout has already fetched submodule content. Strip the
+        # submodule machinery (.gitmodules + nested .git pointers under
+        # external/*) so the tree looks like a flat checkout. The release
+        # tarball will then contain external/{vamp,nanobind} as regular files,
+        # which is what downstream packagers (bloom, dpkg-source, pip sdist
+        # consumers, etc.) need — `git archive` does not recurse submodules,
+        # so this is the only path through which release-artifact consumers
+        # see VAMP and the nanobind-backed Python bindings at build time.
+        run: |
+          rm -f .gitmodules
+          find external -mindepth 2 -name '.git' -print0 | xargs -0 -r rm -rf
+
+      - name: Build tarball
+        id: tarball
+        run: |
+          TAG="${{ steps.tag.outputs.name }}"
+          BASE="ompl-${TAG}"
+          mkdir -p /tmp/stage
+          # Versioned top-level directory in the tarball, no VCS metadata,
+          # no CI config (.github), no editor cruft.
+          rsync -a \
+            --exclude='.git' \
+            --exclude='.github' \
+            --exclude='.gitignore' \
+            --exclude='.gitmodules' \
+            --exclude='.dockerignore' \
+            --exclude='.clang-format' \
+            --exclude='.pre-commit-config.yaml' \
+            ./ "/tmp/stage/${BASE}/"
+          tar -C /tmp/stage -czf "${BASE}.tar.gz" "${BASE}"
+          sha256sum "${BASE}.tar.gz" > "${BASE}.tar.gz.sha256"
+          ls -lh "${BASE}.tar.gz" "${BASE}.tar.gz.sha256"
+          echo "tarball=${BASE}.tar.gz" >> "$GITHUB_OUTPUT"
+
+      - name: Sanity-check tarball contents
+        run: |
+          TAG="${{ steps.tag.outputs.name }}"
+          BASE="ompl-${TAG}"
+          # The two files whose absence has historically caused
+          # OMPL_HAVE_NANOBIND=0 and OMPL_HAVE_VAMP=FALSE on release builds.
+          tar -tzf "${BASE}.tar.gz" | grep -E \
+            "^${BASE}/external/(vamp|nanobind)/CMakeLists.txt$" \
+            || { echo "::error::vendored submodule CMakeLists not in tarball"; exit 1; }
+
+      - name: Upload to GitHub Release
+        if: github.event_name == 'release'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          TAG: ${{ steps.tag.outputs.name }}
+          TARBALL: ${{ steps.tarball.outputs.tarball }}
+        run: |
+          gh release upload "$TAG" "$TARBALL" "${TARBALL}.sha256" \
+            --repo "${{ github.repository }}" --clobber
+
+      - name: Upload as workflow artifact (manual dispatch)
+        if: github.event_name == 'workflow_dispatch'
+        uses: actions/upload-artifact@v4
+        with:
+          name: ompl-${{ steps.tag.outputs.name }}-tarball
+          path: |
+            ompl-*.tar.gz
+            ompl-*.tar.gz.sha256

--- a/doc/releaseChecklist.txt
+++ b/doc/releaseChecklist.txt
@@ -16,7 +16,6 @@ Steps to release a new version:
     - docker tag ompl:x.y.z kavrakilab/ompl:x.y.z
       docker push kavrakilab/ompl:x.y.z
 * update plannerarena if needed; pull new docker images on plannerarena.org and restart web service
-* cmake --build /tmp/build -t package_source, since github tagged release doesn't include vamp submodule
 * cmake --build /tmp/build -t website to update web site repo (assumed to exist in ${HOME}/src/ompl.github.io)
     - open ~/src/ompl.github.io/index.html in a browser and check that everything looks sane
 * If new blog posts have been added since last release:
@@ -30,7 +29,13 @@ Steps to release a new version:
     - Macports: https://github.com/macports/macports-ports/tree/master/science/ompl
     - HomeBrew: https://github.com/Homebrew/homebrew-core/blob/master/Formula/o/ompl.rb
     - vcpkg: https://github.com/microsoft/vcpkg/tree/master/ports/ompl
-* push changes to ompl repos on github. Create release, include release notes, attach ompl-Source-x.y.z.tar.gz (output of `cmake --build /tmp/build -t package_source`)
+* push changes to ompl repos on github. Create the release with release notes;
+  the `.github/workflows/release_tarball.yml` workflow runs on `release: published`
+  and attaches ompl-x.y.z.tar.gz (with `external/{vamp,nanobind}` vendored in) to
+  the release. This tarball is the canonical source artifact for downstream
+  packagers (ROS bloom, distro packagers, pip sdist consumers) -- anything
+  reaching for "what does an OMPL release archive look like" should point here,
+  not at GitHub's auto-generated source tarball, which excludes submodules.
 * update version on https://en.wikipedia.org/wiki/OMPL
 * announce on ompl-users@lists.sourceforge.net, robot-motion@mit.edu, robotics worldwide
 * after release update version in top-level CMakeLists.txt for next release


### PR DESCRIPTION
# Add release-tarball workflow so downstream packagers get `external/{vamp,nanobind}`

Adds `.github/workflows/release_tarball.yml`. On every published GitHub Release it builds `ompl-<tag>.tar.gz` with `external/vamp` and `external/nanobind` pre-populated, sanity-checks that both `CMakeLists.txt` files are present, and attaches the tarball + `.sha256` to the Release. **No changes to `main`, the build system, or the existing dev/maintainer workflow** — `.gitmodules` is still the source of truth for upstream pins.

## Why

`git archive` does not recurse submodules ([docs](https://git-scm.com/docs/git-archive)), and every release artifact path is rooted in `git archive`: bloom, `dpkg-source`, pip sdist, and GitHub's auto-generated tarball. OMPL silently disables both features when the submodule trees are missing:

```
CMake Warning at CMakeModules/VampConfig.cmake:25 (message):
  VAMP submodule not found. ...
CMake Warning at CMakeLists.txt:97 (message):
  OMPL_BUILD_PYTHON_BINDINGS is ON but Nanobind is not found. ...
```

(reproduced from the `ros-rolling-ompl 1.7.0` buildfarm log). Net effect: **every binary OMPL release we've shipped has had Python bindings and VAMP silently disabled** despite both defaulting to `ON`. PyPI wheels escape this only because `wheels_build.yml` does its own `submodules: recursive` checkout. The maintainers were already aware of the issue — `doc/releaseChecklist.txt` had a manual `cmake --build … -t package_source` step to work around it. This PR removes that manual step.

## Why this approach and not the others

- **Vendor into `main`**: ~120 MB of new files (mostly `vamp/resources/`), loses the submodule pin tracking. No.
- **`FetchContent`**: the ROS buildfarm passes `-DFETCHCONTENT_FULLY_DISCONNECTED=ON` (so does Debian). Would make OMPL un-buildable on those platforms.
- **System `nanobind` via `find_package`**: not in apt yet, doesn't help VAMP.
- **bloom-side hook**: bloom has no first-class hook for this.

The workflow is the smallest change that fixes every consumer at once, doesn't ask the project to take on a structural commitment, and is trivially revertible (delete the file).

## What downstream packagers do

Point their source URL at the new asset:

```
https://github.com/ompl/ompl/releases/download/<tag>/ompl-<tag>.tar.gz
```

For ROS, the `ompl-release` bloom track gets `vcs_type: tar` with that URL templated by `:{version}`. I'll handle that as part of the 2.0.0 bloom release.

Also updates `doc/releaseChecklist.txt`: drops the manual `package_source` step (the workflow does it on `release: published`) and points devs at the workflow as the canonical "what does an OMPL release archive look like" reference.
