### PR TITLE
don't define uninstall target if already defined

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -156,9 +156,10 @@ if(NOT SKBUILD)
       "${CMAKE_CURRENT_SOURCE_DIR}/CMakeModules/cmake_uninstall.cmake.in"
       "${CMAKE_CURRENT_BINARY_DIR}/cmake_uninstall.cmake"
       IMMEDIATE @ONLY)
-    add_custom_target(uninstall
-      COMMAND ${CMAKE_COMMAND} -P "${CMAKE_CURRENT_BINARY_DIR}/cmake_uninstall.cmake")
-
+    if(NOT TARGET uninstall)
+        add_custom_target(uninstall
+            COMMAND ${CMAKE_COMMAND} -P "${CMAKE_CURRENT_BINARY_DIR}/cmake_uninstall.cmake")
+    endif()
     include(CPackSettings)
 
     # install catkin package.xml (needed for ROS installation)


### PR DESCRIPTION
don't define uninstall target if already defined (which can happen when ompl is used as a git submodule)