### PR TITLE
Adds bindings for virtual functions

### DIFF
--- a/py-bindings/base/Constraint.cpp
+++ b/py-bindings/base/Constraint.cpp
@@ -51,7 +51,13 @@ void ompl::binding::base::init_Constraint(nb::module_ &m)
         .def("getMaxIterations", &ob::Constraint::getMaxIterations)
         .def("setTolerance", &ob::Constraint::setTolerance, nb::arg("tolerance"))
         .def("setMaxIterations", &ob::Constraint::setMaxIterations, nb::arg("iterations"))
-        // .def("jacobian", &ob::Constraint::jacobian, nb::arg("x"), nb::arg("out"))
+        .def("jacobian",
+             nb::overload_cast<const Eigen::Ref<const Eigen::VectorXd> &, Eigen::Ref<Eigen::MatrixXd>>(
+                 &ob::Constraint::jacobian, nb::const_),
+             nb::arg("x"), nb::arg("out"))
+        .def("jacobian",
+             nb::overload_cast<const ob::State *, Eigen::Ref<Eigen::MatrixXd>>(&ob::Constraint::jacobian, nb::const_),
+             nb::arg("state"), nb::arg("out"))
         .def("project", nb::overload_cast<Eigen::Ref<Eigen::VectorXd>>(&ob::Constraint::project, nb::const_),
              nb::arg("x"))
         .def("project", nb::overload_cast<ob::State *>(&ob::Constraint::project, nb::const_), nb::arg("x"))

--- a/py-bindings/base/Goal.cpp
+++ b/py-bindings/base/Goal.cpp
@@ -41,5 +41,15 @@ void ompl::binding::base::init_Goal(nb::module_ &m)
         // getters
         .def("getType", &ob::Goal::getType)
         .def("hasType", &ob::Goal::hasType, nb::arg("type"))
-        .def("getSpaceInformation", &ob::Goal::getSpaceInformation, nb::rv_policy::reference_internal);
+        .def("getSpaceInformation", &ob::Goal::getSpaceInformation, nb::rv_policy::reference_internal)
+        // virtual methods
+        .def("isSatisfied", nb::overload_cast<const ob::State *>(&ob::Goal::isSatisfied, nb::const_), nb::arg("state"))
+        .def("isStartGoalPairValid", &ob::Goal::isStartGoalPairValid, nb::arg("start"), nb::arg("goal"))
+        .def("print",
+             [](const ob::Goal &g)
+             {
+                 std::ostringstream oss;
+                 g.print(oss);
+                 return oss.str();
+             });
 }

--- a/py-bindings/base/OptimizationObjective.cpp
+++ b/py-bindings/base/OptimizationObjective.cpp
@@ -3,6 +3,8 @@
 #include <nanobind/trampoline.h>
 #include <nanobind/stl/string.h>
 
+#include <sstream>
+
 #include "ompl/base/OptimizationObjective.h"
 #include "init.h"
 
@@ -142,6 +144,32 @@ void ompl::binding::base::init_OptimizationObjective(nb::module_ &m)
         // setters
         .def("setCostThreshold", &ob::OptimizationObjective::setCostThreshold, nb::arg("cost"))
         .def("setCostToGoHeuristic", &ob::OptimizationObjective::setCostToGoHeuristic, nb::arg("costToGoFn"))
+        // virtual methods
+        .def("isSatisfied", &ob::OptimizationObjective::isSatisfied, nb::arg("cost"))
+        .def("isCostBetterThan", &ob::OptimizationObjective::isCostBetterThan, nb::arg("c1"), nb::arg("c2"))
+        .def("isCostEquivalentTo", &ob::OptimizationObjective::isCostEquivalentTo, nb::arg("c1"), nb::arg("c2"))
+        .def("isFinite", &ob::OptimizationObjective::isFinite, nb::arg("cost"))
+        .def("betterCost", &ob::OptimizationObjective::betterCost, nb::arg("c1"), nb::arg("c2"))
+        .def("stateCost", &ob::OptimizationObjective::stateCost, nb::arg("state"))
+        .def("motionCost", &ob::OptimizationObjective::motionCost, nb::arg("s1"), nb::arg("s2"))
+        .def("controlCost", &ob::OptimizationObjective::controlCost, nb::arg("control"), nb::arg("steps"))
+        .def("combineCosts", &ob::OptimizationObjective::combineCosts, nb::arg("c1"), nb::arg("c2"))
+        .def("subtractCosts", &ob::OptimizationObjective::subtractCosts, nb::arg("c1"), nb::arg("c2"))
+        .def("identityCost", &ob::OptimizationObjective::identityCost)
+        .def("infiniteCost", &ob::OptimizationObjective::infiniteCost)
+        .def("initialCost", &ob::OptimizationObjective::initialCost, nb::arg("state"))
+        .def("terminalCost", &ob::OptimizationObjective::terminalCost, nb::arg("state"))
+        .def("isSymmetric", &ob::OptimizationObjective::isSymmetric)
+        .def("averageStateCost", &ob::OptimizationObjective::averageStateCost, nb::arg("numStates"))
+        .def("motionCostHeuristic", &ob::OptimizationObjective::motionCostHeuristic, nb::arg("s1"), nb::arg("s2"))
+        .def("motionCostBestEstimate", &ob::OptimizationObjective::motionCostBestEstimate, nb::arg("s1"), nb::arg("s2"))
+        .def("print",
+             [](const ob::OptimizationObjective &obj)
+             {
+                 std::ostringstream oss;
+                 obj.print(oss);
+                 return oss.str();
+             })
         .def("__repr__",
              [](const ob::OptimizationObjective &obj)
              {

--- a/py-bindings/base/Planner.cpp
+++ b/py-bindings/base/Planner.cpp
@@ -106,11 +106,28 @@ void ompl::binding::base::init_Planner(nb::module_ &m)
             { return pl.solve(fn, checkInterval); }, nb::arg("terminationConditionFn"), nb::arg("checkInterval") = 0.0)
         .def("clearQuery", &ob::Planner::clearQuery)
         .def("clear", &ob::Planner::clear)
+        .def("setup", &ob::Planner::setup)
+        .def("checkValidity", &ob::Planner::checkValidity)
         .def("getName", &ob::Planner::getName)
         .def("setName", &ob::Planner::setName, nb::arg("name"))
         .def("getSpecs", &ob::Planner::getSpecs, nb::rv_policy::reference_internal)
+        .def("getPlannerData", &ob::Planner::getPlannerData, nb::arg("data"))
         .def("params", static_cast<ob::ParamSet &(ob::Planner::*)()>(&ob::Planner::params),
              nb::rv_policy::reference_internal)
         .def("getPlannerProgressProperties", &ob::Planner::getPlannerProgressProperties,
-             nb::rv_policy::reference_internal);
+             nb::rv_policy::reference_internal)
+        .def("printProperties",
+             [](const ob::Planner &p)
+             {
+                 std::ostringstream oss;
+                 p.printProperties(oss);
+                 return oss.str();
+             })
+        .def("printSettings",
+             [](const ob::Planner &p)
+             {
+                 std::ostringstream oss;
+                 p.printSettings(oss);
+                 return oss.str();
+             });
 }

--- a/py-bindings/base/ProjectionEvaluator.cpp
+++ b/py-bindings/base/ProjectionEvaluator.cpp
@@ -59,6 +59,8 @@ void ompl::binding::base::init_ProjectionEvaluator(nb::module_ &m)
     };
     nb::class_<ompl::base::ProjectionEvaluator, PyProjectionEvaluator /* <-- trampoline */>(m, "ProjectionEvaluator")
         .def(nb::init<const ompl::base::StateSpacePtr &>(), nb::arg("space"))
+        .def("getDimension", &ompl::base::ProjectionEvaluator::getDimension)
+        .def("project", &ompl::base::ProjectionEvaluator::project, nb::arg("state"), nb::arg("projection"))
         .def("setCellSizes", nb::overload_cast<unsigned int, double>(&ompl::base::ProjectionEvaluator::setCellSizes),
              nb::arg("dim"), nb::arg("cellSize"))
         .def("mulCellSizes", &ompl::base::ProjectionEvaluator::mulCellSizes, "Multiply the cell sizes by a factor",

--- a/py-bindings/base/goals/GoalRegion.cpp
+++ b/py-bindings/base/goals/GoalRegion.cpp
@@ -28,6 +28,7 @@ void ompl::binding::base::initGoals_GoalRegion(nb::module_ &m)
              nb::arg("state"))
         .def("isSatisfied", nb::overload_cast<const ob::State *, double *>(&ob::GoalRegion::isSatisfied, nb::const_),
              nb::arg("state"), nb::arg("distance"))
+        .def("distanceGoal", &ob::GoalRegion::distanceGoal, nb::arg("state"))
         .def("setThreshold", &ob::GoalRegion::setThreshold, nb::arg("threshold"))
         .def("getThreshold", &ob::GoalRegion::getThreshold)
         .def("print", [](const ob::GoalRegion &self) { self.print(std::cout); })

--- a/py-bindings/base/goals/GoalSampleableRegion.cpp
+++ b/py-bindings/base/goals/GoalSampleableRegion.cpp
@@ -43,6 +43,9 @@ void ompl::binding::base::initGoals_GoalSampleableRegion(nb::module_ &m)
         .def("getThreshold", &ob::GoalRegion::getThreshold)
         .def("setThreshold", &ob::GoalRegion::setThreshold, nb::arg("threshold"))
 
+        .def("sampleGoal", &ob::GoalSampleableRegion::sampleGoal, nb::arg("state"))
+        .def("maxSampleCount", &ob::GoalSampleableRegion::maxSampleCount)
+
         // optional override in Python
         .def("couldSample", &ob::GoalSampleableRegion::couldSample)
 

--- a/py-bindings/base/goals/GoalState.cpp
+++ b/py-bindings/base/goals/GoalState.cpp
@@ -1,4 +1,8 @@
 #include <nanobind/nanobind.h>
+#include <nanobind/stl/shared_ptr.h>
+#include <nanobind/stl/string.h>
+#include <sstream>
+
 #include "ompl/base/goals/GoalState.h"
 #include "../init.h"
 

--- a/py-bindings/base/goals/GoalStates.cpp
+++ b/py-bindings/base/goals/GoalStates.cpp
@@ -1,4 +1,5 @@
 #include <nanobind/nanobind.h>
+#include <nanobind/stl/shared_ptr.h>
 #include <nanobind/stl/vector.h>
 #include <sstream>
 

--- a/tests/pytests/test_constraint.py
+++ b/tests/pytests/test_constraint.py
@@ -1,0 +1,32 @@
+import numpy as np
+import pytest
+
+from ompl import base as ob
+
+
+def test_constraint_jacobian_default():
+    class UnitSphere(ob.Constraint):
+        def __init__(self):
+            super().__init__(3, 1)
+
+        def function(self, x, out):
+            out[0] = x[0] * x[0] + x[1] * x[1] + x[2] * x[2] - 1.0
+
+    constraint = UnitSphere()
+    assert constraint.getAmbientDimension() == 3
+    assert constraint.getCoDimension() == 1
+
+    x = np.array([1.0, 0.0, 0.0])
+    # Eigen::Ref<MatrixXd> output must be column-major
+    out = np.zeros((1, 3), order="F")
+    # jacobian is not overridden, so it falls through to the C++ default (numerical
+    # differentiation); the gradient of x^2 + y^2 + z^2 - 1 at (1, 0, 0) is [2, 0, 0]
+    constraint.jacobian(x, out)
+
+    assert out[0, 0] == pytest.approx(2.0, abs=1e-4)
+    assert out[0, 1] == pytest.approx(0.0, abs=1e-4)
+    assert out[0, 2] == pytest.approx(0.0, abs=1e-4)
+
+
+if __name__ == "__main__":
+    test_constraint_jacobian_default()

--- a/tests/pytests/test_customize_basic.py
+++ b/tests/pytests/test_customize_basic.py
@@ -178,7 +178,77 @@ def test_customize_goal_sampleable_region():
     print("Planner result:", result)
 
 
+def test_goal_state_region_virtuals():
+    import numpy as np
+
+    space = ob.RealVectorStateSpace(2)
+    bounds = ob.RealVectorBounds(2)
+    bounds.setLow(0)
+    bounds.setHigh(1)
+    space.setBounds(bounds)
+
+    si = ob.SpaceInformation(space)
+    si.setStateValidityChecker(lambda state: True)
+    si.setup()
+
+    goal = ob.GoalState(si)
+    target = si.allocState()
+    target[0] = 0.5
+    target[1] = 0.5
+    goal.setState(target)
+
+    query = si.allocState()
+    query[0] = 0.0
+    query[1] = 0.0
+
+    assert goal.distanceGoal(query) == pytest.approx(np.hypot(0.5, 0.5))
+    assert goal.distanceGoal(target) == pytest.approx(0.0)
+    assert goal.maxSampleCount() == 1
+    assert goal.isStartGoalPairValid(query, target)
+    assert goal.isSatisfied(target)
+
+    sample = si.allocState()
+    goal.sampleGoal(sample)
+    assert sample[0] == pytest.approx(0.5)
+    assert sample[1] == pytest.approx(0.5)
+
+
+def test_goal_subclass_falls_through():
+    space = ob.RealVectorStateSpace(2)
+    bounds = ob.RealVectorBounds(2)
+    bounds.setLow(-1)
+    bounds.setHigh(1)
+    space.setBounds(bounds)
+
+    si = ob.SpaceInformation(space)
+    si.setStateValidityChecker(lambda state: True)
+    si.setup()
+
+    class SecondDimGoal(ob.Goal):
+        def __init__(self, si):
+            super().__init__(si)
+
+        def isSatisfied(self, state):
+            return abs(state[1]) < 0.1
+
+    goal = SecondDimGoal(si)
+    start = si.allocState()
+    other = si.allocState()
+
+    # isStartGoalPairValid is not overridden, so it falls through to the C++ default (True)
+    assert goal.isStartGoalPairValid(start, other)
+
+    satisfied = si.allocState()
+    satisfied[1] = 0.0
+    assert goal.isSatisfied(satisfied)
+    unsatisfied = si.allocState()
+    unsatisfied[1] = 0.5
+    assert not goal.isSatisfied(unsatisfied)
+
+
 if __name__ == "__main__":
     test_customize_goal()
     test_customize_goal_region()
     test_customize_goal_sampleable_region()
+    test_goal_state_region_virtuals()
+    test_goal_subclass_falls_through()

--- a/tests/pytests/test_optimal_planning.py
+++ b/tests/pytests/test_optimal_planning.py
@@ -218,6 +218,66 @@ def test_path_length_optimization():
     assert path_length < 3.0, "Path should not be excessively long"
 
 
+def test_optimization_objective_virtuals():
+    _, si = create_simple_setup()
+    obj = ob.PathLengthOptimizationObjective(si)
+
+    s1 = si.allocState()
+    s1[0] = 0.0
+    s1[1] = 0.0
+    s2 = si.allocState()
+    s2[0] = 1.0
+    s2[1] = 0.0
+
+    identity = obj.identityCost()
+    infinite = obj.infiniteCost()
+
+    assert identity.value() == pytest.approx(0.0)
+    assert obj.isFinite(identity)
+    assert not obj.isFinite(infinite)
+
+    assert obj.stateCost(s1).value() == pytest.approx(0.0)
+    assert obj.motionCost(s1, s2).value() == pytest.approx(1.0)
+    assert obj.motionCostHeuristic(s1, s2).value() == pytest.approx(1.0)
+    assert obj.motionCostBestEstimate(s1, s2).value() == pytest.approx(1.0)
+    assert obj.initialCost(s1).value() == pytest.approx(0.0)
+    assert obj.terminalCost(s1).value() == pytest.approx(0.0)
+
+    assert obj.isCostBetterThan(identity, infinite)
+    assert obj.isCostEquivalentTo(identity, ob.Cost(0.0))
+    assert obj.betterCost(ob.Cost(1.0), ob.Cost(2.0)).value() == pytest.approx(1.0)
+    assert obj.combineCosts(ob.Cost(1.0), ob.Cost(2.0)).value() == pytest.approx(3.0)
+    assert obj.subtractCosts(ob.Cost(3.0), ob.Cost(1.0)).value() == pytest.approx(2.0)
+
+    assert obj.isSymmetric()
+    assert not obj.isSatisfied(identity)
+    assert isinstance(obj.print(), str)
+    assert obj.print() != ""
+
+
+def test_optimization_objective_subclass_falls_through():
+    _, si = create_simple_setup()
+
+    class ConstantObjective(ob.OptimizationObjective):
+        def __init__(self, si):
+            super().__init__(si)
+
+        def stateCost(self, state):
+            return ob.Cost(1.0)
+
+        def motionCost(self, s1, s2):
+            return ob.Cost(2.0)
+
+    obj = ConstantObjective(si)
+    state = si.allocState()
+
+    assert obj.stateCost(state).value() == pytest.approx(1.0)
+    # combineCosts is not overridden, so it falls through to the C++ default (addition)
+    assert obj.combineCosts(ob.Cost(1.0), ob.Cost(2.0)).value() == pytest.approx(3.0)
+    assert obj.identityCost().value() == pytest.approx(0.0)
+    assert not obj.isFinite(obj.infiniteCost())
+
+
 if __name__ == "__main__":
     test_rrtstar()
     test_informed_rrtstar()
@@ -231,3 +291,5 @@ if __name__ == "__main__":
     test_bitstar_settings()
     test_fmt_settings()
     test_path_length_optimization()
+    test_optimization_objective_virtuals()
+    test_optimization_objective_subclass_falls_through()

--- a/tests/pytests/test_planner_data.py
+++ b/tests/pytests/test_planner_data.py
@@ -127,7 +127,30 @@ def test_planner_data_vertex():
     assert retrieved_state is not None
 
 
+def test_planner_virtuals():
+    """Test Planner virtual methods bound on a concrete C++ planner."""
+    ss = create_simple_setup()
+    si = ss.getSpaceInformation()
+
+    planner = og.RRT(si)
+    ss.setPlanner(planner)
+    planner.setProblemDefinition(ss.getProblemDefinition())
+
+    planner.setup()
+    planner.checkValidity()
+
+    assert ss.solve(1.0)
+
+    data = ob.PlannerData(si)
+    planner.getPlannerData(data)
+    assert data.numVertices() > 0
+
+    assert "RRT" in planner.printProperties()
+    assert planner.printSettings() != ""
+
+
 if __name__ == "__main__":
     test_planner_data_basic()
     test_planner_data_storage()
     test_planner_data_vertex()
+    test_planner_virtuals()

--- a/tests/pytests/test_state_spaces.py
+++ b/tests/pytests/test_state_spaces.py
@@ -1,6 +1,7 @@
 import sys
 import pytest
 import math
+import numpy as np
 from ompl import base as ob
 
 
@@ -626,6 +627,27 @@ def test_vana_owen_state_space():
     assert path is None or path.length() > 0.0
 
 
+def test_projection_evaluator():
+    space = ob.RealVectorStateSpace(2)
+    bounds = ob.RealVectorBounds(2)
+    bounds.setLow(0)
+    bounds.setHigh(1)
+    space.setBounds(bounds)
+    space.setup()
+
+    projection = space.getDefaultProjection()
+    assert projection.getDimension() == 2
+
+    state = space.allocState()
+    state[0] = 0.25
+    state[1] = 0.75
+    out = np.zeros(projection.getDimension())
+    projection.project(state, out)
+
+    assert out[0] == pytest.approx(0.25)
+    assert out[1] == pytest.approx(0.75)
+
+
 if __name__ == "__main__":
     test_rv_state_space()
     test_compound_state_space()
@@ -637,3 +659,4 @@ if __name__ == "__main__":
     test_owen_state_space()
     test_vana_state_space()
     test_vana_owen_state_space()
+    test_projection_evaluator()


### PR DESCRIPTION
Several trampoline classes declare NB_OVERRIDE entries for virtuals that are never .def()'d on the binding. When a Python subclass doesn't override one of them, the trampoline's getattr() lookup fails and nanobind raises:

```nanobind::detail::get_trampoline('...::<method>()'): lookup failed!```

instead of falling back to the C++ default. In practice any Python subclass crashes on first use:

- OptimizationObjective — RRT* calls infiniteCost() during setup
- Planner — SimpleSetup::setup() calls Planner::setup()
- Goal — start-state processing calls isStartGoalPairValid()
- Constraint — the default project() calls jacobian() (its .def was commented out; the unqualified &Constraint::jacobian is ambiguous — bound via nb::overload_cast)

Bind every trampolined virtual on its class, per the nanobind docs pattern — getattr then resolves to an nb_method, which the trampoline treats as "no Python override" and routes to the C++ default. ostream&-taking virtuals (print, printProperties, printSettings) are bound as std::string-returning lambdas, mirroring the existing ```__repr__``` bindings. PathLengthOptimizationObjective is fixed transitively through the base-class binding.
