### PR TITLE
Add controlMotionCost for control planners and paths

### DIFF
--- a/py-bindings/base/OptimizationObjective.cpp
+++ b/py-bindings/base/OptimizationObjective.cpp
@@ -14,7 +14,7 @@ void ompl::binding::base::init_OptimizationObjective(nb::module_ &m)
 {
     struct PyOptimizationObjective : ob::OptimizationObjective
     {
-        NB_TRAMPOLINE(ob::OptimizationObjective, 19);
+        NB_TRAMPOLINE(ob::OptimizationObjective, 20);
         // Optional override
         bool isSatisfied(ob::Cost c) const override
         {
@@ -61,6 +61,13 @@ void ompl::binding::base::init_OptimizationObjective(nb::module_ &m)
         ob::Cost controlCost(const oc::Control *c, unsigned int steps) const override
         {
             NB_OVERRIDE(controlCost, c, steps);
+        }
+
+        // Optional override
+        ob::Cost controlMotionCost(const ob::State *s1, const oc::Control *c, unsigned int steps,
+                                   const ob::State *s2) const override
+        {
+            NB_OVERRIDE(controlMotionCost, s1, c, steps, s2);
         }
 
         // Optional override

--- a/src/ompl/base/OptimizationObjective.h
+++ b/src/ompl/base/OptimizationObjective.h
@@ -120,6 +120,13 @@ namespace ompl
              * steps. The default implementation uses the identityCost. */
             virtual Cost controlCost(const control::Control *c, unsigned int steps) const;
 
+            /** \brief Get the cost of the motion that starts at state \e s1, applies control \e c for \e steps
+             * propagation steps, and arrives at state \e s2.
+             * The default implementation combines the costs of motionCost(s1, s2) and controlCost(c, steps).
+             * Control planners should prefer this method over calling motionCost() and controlCost() separately.*/
+            virtual Cost controlMotionCost(const State *s1, const control::Control *c, unsigned int steps,
+                                           const State *s2) const;
+
             /** \brief Get the cost that corresponds to combining the costs \e c1 and \e c2. Default implementation
              * defines this combination as an addition. */
             virtual Cost combineCosts(Cost c1, Cost c2) const;

--- a/src/ompl/base/src/OptimizationObjective.cpp
+++ b/src/ompl/base/src/OptimizationObjective.cpp
@@ -93,6 +93,12 @@ ompl::base::Cost ompl::base::OptimizationObjective::controlCost(const control::C
     return identityCost();
 }
 
+ompl::base::Cost ompl::base::OptimizationObjective::controlMotionCost(const State *s1, const control::Control *c,
+                                                                      unsigned int steps, const State *s2) const
+{
+    return combineCosts(motionCost(s1, s2), controlCost(c, steps));
+}
+
 ompl::base::Cost ompl::base::OptimizationObjective::combineCosts(Cost c1, Cost c2) const
 {
     return Cost(c1.value() + c2.value());

--- a/src/ompl/base/src/ProblemDefinition.cpp
+++ b/src/ompl/base/src/ProblemDefinition.cpp
@@ -426,6 +426,11 @@ void ompl::base::ProblemDefinition::addSolutionPath(const PathPtr &path, bool ap
     PlannerSolution sol(path);
     if (approximate)
         sol.setApproximate(difference);
+    if (optimizationObjective_)
+    {
+        auto solCost = path->cost(optimizationObjective_);
+        sol.setOptimized(optimizationObjective_, solCost, optimizationObjective_->isSatisfied(solCost));
+    }
     sol.setPlannerName(plannerName);
     addSolutionPath(sol);
 }

--- a/src/ompl/control/planners/sst/src/HySST.cpp
+++ b/src/ompl/control/planners/sst/src/HySST.cpp
@@ -84,7 +84,11 @@ void ompl::control::HySST::setup()
                       "behavior",
                       getName().c_str());
         costFunc_ = [this](Motion *motion) -> base::Cost
-        { return opt_->motionCost(motion->parent->state, motion->state); };
+        {
+            const unsigned int steps =
+                motion->solutionPair != nullptr ? static_cast<unsigned int>(motion->solutionPair->size()) : 0u;
+            return opt_->controlMotionCost(motion->parent->state, motion->control, steps, motion->state);
+        };
     }
     else
     {  // if no optimization objective set, assume we want to minimize hybrid time

--- a/src/ompl/control/planners/sst/src/SST.cpp
+++ b/src/ompl/control/planners/sst/src/SST.cpp
@@ -265,9 +265,7 @@ ompl::base::PlannerStatus ompl::control::SST::solve(const base::PlannerTerminati
 
         if (propCd == cd)
         {
-            base::Cost incCostMotion = opt_->motionCost(nmotion->state_, rstate);
-            base::Cost incCostControl = opt_->controlCost(rctrl, cd);
-            base::Cost incCost = opt_->combineCosts(incCostMotion, incCostControl);
+            base::Cost incCost = opt_->controlMotionCost(nmotion->state_, rctrl, cd, rstate);
             base::Cost cost = opt_->combineCosts(nmotion->accCost_, incCost);
             Witness *closestWitness = findClosestWitness(rmotion);
 

--- a/src/ompl/control/src/PathControl.cpp
+++ b/src/ompl/control/src/PathControl.cpp
@@ -122,8 +122,20 @@ void ompl::control::PathControl::copyFrom(const PathControl &other)
 
 ompl::base::Cost ompl::control::PathControl::cost(const base::OptimizationObjectivePtr &opt) const
 {
-    OMPL_ERROR("Error: Cost computation is only implemented for paths of type PathGeometric.");
-    return opt->identityCost();
+    if (states_.empty())
+        return opt->identityCost();
+    // Compute path cost by accumulating the cost along the path
+    base::Cost cost(opt->initialCost(states_.front()));
+    const auto *si = static_cast<const SpaceInformation *>(si_.get());
+    const double dt = si->getPropagationStepSize();
+    for (std::size_t i = 1; i < states_.size(); ++i)
+    {
+        cost = opt->combineCosts(cost, opt->motionCost(states_[i - 1], states_[i]));
+        const auto steps = static_cast<unsigned int>(std::llround(controlDurations_[i - 1] / dt));
+        cost = opt->combineCosts(cost, opt->controlCost(controls_[i - 1], steps));
+    }
+    cost = opt->combineCosts(cost, opt->terminalCost(states_.back()));
+    return cost;
 }
 
 double ompl::control::PathControl::length() const

--- a/src/ompl/control/src/PathControl.cpp
+++ b/src/ompl/control/src/PathControl.cpp
@@ -130,9 +130,8 @@ ompl::base::Cost ompl::control::PathControl::cost(const base::OptimizationObject
     const double dt = si->getPropagationStepSize();
     for (std::size_t i = 1; i < states_.size(); ++i)
     {
-        cost = opt->combineCosts(cost, opt->motionCost(states_[i - 1], states_[i]));
         const auto steps = static_cast<unsigned int>(std::llround(controlDurations_[i - 1] / dt));
-        cost = opt->combineCosts(cost, opt->controlCost(controls_[i - 1], steps));
+        cost = opt->combineCosts(cost, opt->controlMotionCost(states_[i - 1], controls_[i - 1], steps, states_[i]));
     }
     cost = opt->combineCosts(cost, opt->terminalCost(states_.back()));
     return cost;


### PR DESCRIPTION
**Overview**

This PR aims to improve support for optimization objectives for control planners and control paths. 

The main change is the introduction of a new virtual method in _base::OptimizationObjective_:
```
virtual Cost controlMotionCost(const State *s1, const control::Control *c, unsigned int steps, const State *s2) const;
```

**Motivation**

For geometric planners, an edge cost depending only on two states is often sufficient. For control planners, however, the cost of an edge may depend on both the state and the control used to propagate from that state. An example would be the energy consumption (cost) of a car depends on both the terrain (state) it drives on and the applied acceleration and steering (control).

Currently, _OptimizationObjective_ only has _motionCost(s1, s2)_ and _controlCost(c, steps)_ separately. The optimal kinodynamic planner, such as **SST**, can only compute them separately and add them together. Having _controlMotionCost_ allows users to override it when a kinodynamic edge cost depends jointly on the states and controls.

**Changes**

This PR makes the following changes:

- Adds _OptimizationObjective::controlMotionCost(...)_. The default implementation returns `combineCosts(motionCost(s1, s2), controlCost(c, steps));`.
- Adds Python binding support for overriding _controlMotionCost(...)_.
- Updates the two control planners, _control::SST_ and _control::HySST_, to use _controlMotionCost(...)_.
- Implements _control::PathControl::cost(...)_, which was left unimplemented before. The implementation mimics that of  _geometry::PathGeometry::cost(...)_, but with the porposed _controlMotionCost(...)_.

Finally, I also noticed that the current implementation of 

_ProblemDefinition::addSolutionPath(const PathPtr &path, ...)_

creates a planner solution and adds it directly, without setting the cost of the solution. As a result, solution paths added through this overload may not be ordered according to the provided optimization objective, but by the path length. This is especially problematic for user code that adds multiple solution paths and expects the best one to be selected according to the optimization objective.

- Adds a proper cost setup to the solution in _ProblemDefinition::addSolutionPath(const PathPtr &path, ...)_. Given that _control::PathControl::cost(...)_ is now implemented, this should work for both _PathGeometry_ and _PathControl_
```
if (optimizationObjective_)
{
    auto solCost = path->cost(optimizationObjective_);
    sol.setOptimized(optimizationObjective_, solCost, optimizationObjective_->isSatisfied(solCost));
}
```