### PR TITLE
Export Eigen dependency required by omplConfig.cmake

### DIFF
--- a/package.xml
+++ b/package.xml
@@ -31,6 +31,7 @@
   <exec_depend>libboost-serialization</exec_depend>
   <exec_depend>libflann</exec_depend>
 
+  <build_export_depend>eigen</build_export_depend>
   <build_export_depend>libboost-program-options-dev</build_export_depend>
   <build_export_depend>libboost-serialization-dev</build_export_depend>
   <build_export_depend>libboost-system-dev</build_export_depend>


### PR DESCRIPTION
## Summary

Export Eigen3 to downstream ROS packages because OMPL's installed CMake configuration unconditionally calls:

```cmake
find_dependency(Eigen3 REQUIRED)
```

The dependency is currently declared only as `build_depend`, so it is available while compiling OMPL but not propagated to packages that call `find_package(ompl)`.

This is a follow-up to #1456. That PR added the Boost development exports and resolves the immediate Nav2 SMAC build failure, but it did not export Eigen3.

Fixes #1457.

## Validation

Validated from clean `ros:lyrical-ros-core` containers using the Lyrical testing repository:

- Tested a minimal consumer whose only CMake dependency is OMPL. With Boost development metadata present but no Eigen development package, `find_package(ompl)` fails at `find_dependency(Eigen3)`.
- Added the Eigen export, then configured, compiled, linked, and ran the minimal `ompl::ompl` consumer successfully.
- Ran `rosdep install --dependency-types build_export` against the patched manifest and confirmed it installs `libeigen3-dev`.
- Ran `bloom-generate rosdebian` for Ubuntu Resolute / ROS 2 Lyrical and confirmed `libeigen3-dev` appears in the generated binary run dependency closure.

The installed Lyrical export was audited for other active external lookups. FLANN, Triangle, and SPOT are disabled in that build, while Threads is provided by CMake/the toolchain.
