### PR TITLE
SpaceTimeStatespace and STRRT* improvements 

### DIFF
--- a/py-bindings/base/spaces/SpaceTimeStateSpace.cpp
+++ b/py-bindings/base/spaces/SpaceTimeStateSpace.cpp
@@ -15,7 +15,8 @@ void ompl::binding::base::initSpaces_SpaceTimeStateSpace(nb::module_ &m)
 
         .def("distance", &ob::SpaceTimeStateSpace::distance, nb::arg("state1"), nb::arg("state2"))
 
-        .def("timeToCoverDistance", &ob::SpaceTimeStateSpace::timeToCoverDistance, nb::arg("state1"), nb::arg("state2"))
+        .def("timeToCoverDistance", &ob::SpaceTimeStateSpace::timeToCoverDistance, nb::arg("state1"), nb::arg("state2"),
+             nb::arg("distance"))
 
         .def("distanceSpace", &ob::SpaceTimeStateSpace::distanceSpace, nb::arg("state1"), nb::arg("state2"))
 

--- a/py-bindings/base/spaces/SpaceTimeStateSpace.cpp
+++ b/py-bindings/base/spaces/SpaceTimeStateSpace.cpp
@@ -15,8 +15,10 @@ void ompl::binding::base::initSpaces_SpaceTimeStateSpace(nb::module_ &m)
 
         .def("distance", &ob::SpaceTimeStateSpace::distance, nb::arg("state1"), nb::arg("state2"))
 
-        .def("timeToCoverDistance", &ob::SpaceTimeStateSpace::timeToCoverDistance, nb::arg("state1"), nb::arg("state2"),
-             nb::arg("distance"))
+        .def("timeToCoverDistance",
+             nb::overload_cast<const ob::State *, const ob::State *>(&ob::SpaceTimeStateSpace::timeToCoverDistance,
+                                                                     nb::const_),
+             nb::arg("state1"), nb::arg("state2"))
 
         .def("distanceSpace", &ob::SpaceTimeStateSpace::distanceSpace, nb::arg("state1"), nb::arg("state2"))
 

--- a/src/ompl/base/spaces/SpaceTimeStateSpace.h
+++ b/src/ompl/base/spaces/SpaceTimeStateSpace.h
@@ -64,7 +64,8 @@ namespace ompl
             double distance(const ompl::base::State *state1, const ompl::base::State *state2) const override;
 
             /** \brief The time to get from state1 to state2 with respect to vMax. */
-            double timeToCoverDistance(const ompl::base::State *state1, const ompl::base::State *state2) const;
+            virtual double timeToCoverDistance(const ompl::base::State *state1, const ompl::base::State *state2,
+                                               double *distance = nullptr) const;
 
             /** \brief The distance of just the space component. */
             double distanceSpace(const ompl::base::State *state1, const ompl::base::State *state2) const;

--- a/src/ompl/base/spaces/SpaceTimeStateSpace.h
+++ b/src/ompl/base/spaces/SpaceTimeStateSpace.h
@@ -64,8 +64,16 @@ namespace ompl
             double distance(const ompl::base::State *state1, const ompl::base::State *state2) const override;
 
             /** \brief The time to get from state1 to state2 with respect to vMax. */
+            double timeToCoverDistance(const ompl::base::State *state1, const ompl::base::State *state2) const
+            {
+                return timeToCoverDistance(state1, state2, nullptr);
+            }
+            /** \brief The time to get from state1 to state2 with respect to vMax.
+             *
+             * Return spatial distance between states in distance if it is not a null pointer.
+             */
             virtual double timeToCoverDistance(const ompl::base::State *state1, const ompl::base::State *state2,
-                                               double *distance = nullptr) const;
+                                               double *distance) const;
 
             /** \brief The distance of just the space component. */
             double distanceSpace(const ompl::base::State *state1, const ompl::base::State *state2) const;

--- a/src/ompl/base/spaces/src/SpaceTimeStateSpace.cpp
+++ b/src/ompl/base/spaces/src/SpaceTimeStateSpace.cpp
@@ -51,12 +51,10 @@ ompl::base::SpaceTimeStateSpace::SpaceTimeStateSpace(const StateSpacePtr &spaceC
 
 double ompl::base::SpaceTimeStateSpace::distance(const ompl::base::State *state1, const ompl::base::State *state2) const
 {
-    double deltaSpace = distanceSpace(state1, state2);
+    double deltaSpace;
     double deltaTime = distanceTime(state1, state2);
-
-    if (deltaSpace / vMax_ > deltaTime + eps_)
+    if (timeToCoverDistance(state1, state2, &deltaSpace) > deltaTime + eps_)
         return std::numeric_limits<double>::infinity();
-
     return weights_[0] * deltaSpace + weights_[1] * deltaTime;
 }
 
@@ -100,9 +98,11 @@ void ompl::base::SpaceTimeStateSpace::setVMax(double vMax)
 }
 
 double ompl::base::SpaceTimeStateSpace::timeToCoverDistance(const ompl::base::State *state1,
-                                                            const ompl::base::State *state2) const
+                                                            const ompl::base::State *state2, double *distance) const
 {
     double deltaSpace = distanceSpace(state1, state2);
+    if (distance)
+        *distance = deltaSpace;
     return deltaSpace / vMax_;
 }
 

--- a/src/ompl/geometric/planners/rrt/src/STRRTstar.cpp
+++ b/src/ompl/geometric/planners/rrt/src/STRRTstar.cpp
@@ -49,6 +49,8 @@ ompl::geometric::STRRTstar::STRRTstar(const ompl::base::SpaceInformationPtr &si)
     specs_.optimizingPaths = true;
     specs_.canReportIntermediateSolutions = true;
     Planner::declareParam<double>("range", this, &STRRTstar::setRange, &STRRTstar::getRange, "0.:1.:10000.");
+    addPlannerProgressProperty("best cost REAL", [this] { return std::to_string(bestTime_); });
+    addPlannerProgressProperty("iterations INTEGER", [this] { return std::to_string(numIterations_); });
     distanceBetweenTrees_ = std::numeric_limits<double>::infinity();
 }
 


### PR DESCRIPTION
A few small changes for STRRT* / SpaceTimeStateSpace:
- make sure the code for computing time to cover distance is in one method (rather than copied in two different methods)
- create a virtual timeToCoverDistance function so that this can be overridden if needed
- add progress properties to ST-RRT* so that you can track convergence rate with OMPL benchmarking tools
- (minor performance issue) avoid a redundant distance calculation
