### PR TITLE
Fix Python binding builds with system nanobind and MSVC

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -94,7 +94,7 @@ if(OMPL_BUILD_PYTHON_BINDINGS)
     if(OMPL_HAVE_NANOBIND)
         add_subdirectory(py-bindings)
     else()
-        message(WARNING "OMPL_BUILD_PYTHON_BINDINGS is ON but Nanobind is not found. Use git submodule update --init --recursive to initialize the Nanobind submodule.")
+        message(WARNING "OMPL_BUILD_PYTHON_BINDINGS is ON but Nanobind is not found. Install nanobind or use git submodule update --init --recursive to initialize the Nanobind submodule.")
     endif()
 endif()
 

--- a/CMakeModules/OMPLDependencies.cmake
+++ b/CMakeModules/OMPLDependencies.cmake
@@ -95,6 +95,13 @@ set_package_properties(Nanobind PROPERTIES
 if(OMPL_HAVE_PYTHON AND EXISTS "${CMAKE_CURRENT_SOURCE_DIR}/external/nanobind/CMakeLists.txt")
     add_subdirectory(${CMAKE_CURRENT_SOURCE_DIR}/external/nanobind)
     set(OMPL_HAVE_NANOBIND 1)
+elseif(OMPL_HAVE_PYTHON)
+    # Python packages install nanobind's CMake config below site-packages,
+    # which is not part of CMake's default search path.
+    find_package(nanobind CONFIG QUIET
+        PATHS "${Python_SITELIB}/nanobind/cmake"
+              "${Python_SITEARCH}/nanobind/cmake")
+    set(OMPL_HAVE_NANOBIND ${nanobind_FOUND})
 else()
     set(OMPL_HAVE_NANOBIND 0)
 endif()

--- a/py-bindings/CMakeLists.txt
+++ b/py-bindings/CMakeLists.txt
@@ -51,7 +51,11 @@ else()
 endif()
 
 target_link_libraries(_ompl PRIVATE ompl::ompl)
-target_compile_options(_ompl PRIVATE -Wno-unused-parameter)
+if(MSVC)
+    target_compile_options(_ompl PRIVATE /wd4100)
+else()
+    target_compile_options(_ompl PRIVATE -Wno-unused-parameter)
+endif()
 
 # Set RPATH so the module can find libompl
 if(APPLE)

--- a/py-bindings/base/Cost.cpp
+++ b/py-bindings/base/Cost.cpp
@@ -1,4 +1,5 @@
 #include <nanobind/nanobind.h>
+#include <string>
 #include "ompl/base/Cost.h"
 #include "init.h"
 

--- a/py-bindings/base/spaces/RealVectorStateSpace.cpp
+++ b/py-bindings/base/spaces/RealVectorStateSpace.cpp
@@ -2,6 +2,7 @@
 #include <nanobind/stl/shared_ptr.h>
 #include <nanobind/stl/string.h>
 #include <nanobind/stl/vector.h>
+#include <cstddef>
 #include <cstring>
 #include <sstream>
 #include "ompl/base/spaces/RealVectorStateSpace.h"
@@ -36,17 +37,17 @@ void ompl::binding::base::initSpaces_RealVectorStateSpace(nb::module_ &m)
                  }
 
                  // Extract stop (required)
-                 ssize_t stop = nb::cast<ssize_t>(slice.attr("stop"));
+                 std::ptrdiff_t stop = nb::cast<std::ptrdiff_t>(slice.attr("stop"));
 
                  // Extract start (default 0)
-                 ssize_t start = 0;
+                 std::ptrdiff_t start = 0;
                  if (!slice.attr("start").is_none())
-                     start = nb::cast<ssize_t>(slice.attr("start"));
+                     start = nb::cast<std::ptrdiff_t>(slice.attr("start"));
 
                  // Extract step (default 1)
-                 ssize_t step = 1;
+                 std::ptrdiff_t step = 1;
                  if (!slice.attr("step").is_none())
-                     step = nb::cast<ssize_t>(slice.attr("step"));
+                     step = nb::cast<std::ptrdiff_t>(slice.attr("step"));
 
                  // Reject negative or zero step
                  if (step <= 0)
@@ -98,17 +99,17 @@ void ompl::binding::base::initSpaces_RealVectorStateSpace(nb::module_ &m)
                 }
 
                 // Extract stop (required)
-                ssize_t stop = nb::cast<ssize_t>(slice.attr("stop"));
+                std::ptrdiff_t stop = nb::cast<std::ptrdiff_t>(slice.attr("stop"));
 
                 // Extract start (default 0)
-                ssize_t start = 0;
+                std::ptrdiff_t start = 0;
                 if (!slice.attr("start").is_none())
-                    start = nb::cast<ssize_t>(slice.attr("start"));
+                    start = nb::cast<std::ptrdiff_t>(slice.attr("start"));
 
                 // Extract step (default 1)
-                ssize_t step = 1;
+                std::ptrdiff_t step = 1;
                 if (!slice.attr("step").is_none())
-                    step = nb::cast<ssize_t>(slice.attr("step"));
+                    step = nb::cast<std::ptrdiff_t>(slice.attr("step"));
 
                 // Reject negative or zero step
                 if (step <= 0)


### PR DESCRIPTION
This fixes several Python binding portability issues found while packaging OMPL 2.0.2 for conda-forge:

- fall back to an installed `nanobind` CMake package when the git submodule is unavailable (for example, in GitHub-generated source archives)
- search the standard nanobind location below Python's `site-packages`
- use MSVC's `/wd4100` instead of the GCC/Clang-only `-Wno-unused-parameter`
- include `<string>` explicitly before using `std::to_string`
- update the missing-nanobind warning to mention both supported installation methods

The vendored submodule remains preferred when present, so existing source checkout and wheel workflows are unchanged.

Validation:
- configured without submodules against conda-forge's system `nanobind` package
- built the complete `_ompl` extension successfully on Linux
- the MSVC fixes were identified from conda-forge's Windows CI
