### PR TITLE
Copy to from reals fix

### DIFF
--- a/py-bindings/base/StateSpace.cpp
+++ b/py-bindings/base/StateSpace.cpp
@@ -7,6 +7,7 @@
 #include "ompl/base/StateSpace.h"
 #include <sstream>
 #include "init.h"
+#include "validation.h"
 
 namespace nb = nanobind;
 namespace ob = ompl::base;
@@ -39,6 +40,8 @@ void ompl::binding::base::init_StateSpace(nb::module_ &m)
         .def("getValueAddressAtIndex",
              nb::overload_cast<ob::State *, unsigned int>(&ob::StateSpace::getValueAddressAtIndex, nb::const_),
              nb::arg("state"), nb::arg("index"), nb::rv_policy::reference_internal)
+
+        .def("computeLocations", &ob::StateSpace::computeLocations)
 
         .def("registerProjection", &ob::StateSpace::registerProjection, nb::arg("name"), nb::arg("projection"))
         .def("registerDefaultProjection", &ob::StateSpace::registerDefaultProjection, nb::arg("projection"))
@@ -78,7 +81,14 @@ void ompl::binding::base::init_StateSpace(nb::module_ &m)
                  &ob::StateSpace::getCommonSubspaces, nb::const_),
              nb::arg("other"), nb::arg("subspaces"))
         .def("copyToReals", &ob::StateSpace::copyToReals, nb::arg("reals"), nb::arg("source"))
-        .def("copyFromReals", &ob::StateSpace::copyFromReals, nb::arg("destination"), nb::arg("reals"));
+        .def(
+            "copyFromReals",
+            [](const ob::StateSpace &ss, ob::State *destination, const std::vector<double> &reals)
+            {
+                checkRealsSize(ss, reals, "copyFromReals");
+                ss.copyFromReals(destination, reals);
+            },
+            nb::arg("destination"), nb::arg("reals"));
 
     nb::class_<ob::CompoundStateSpace, ob::StateSpace>(m, "CompoundStateSpace")
         .def(nb::init<>())

--- a/py-bindings/base/StateSpace.cpp
+++ b/py-bindings/base/StateSpace.cpp
@@ -80,7 +80,18 @@ void ompl::binding::base::init_StateSpace(nb::module_ &m)
              nb::overload_cast<const ob::StateSpacePtr &, std::vector<std::string> &>(
                  &ob::StateSpace::getCommonSubspaces, nb::const_),
              nb::arg("other"), nb::arg("subspaces"))
-        .def("copyToReals", &ob::StateSpace::copyToReals, nb::arg("reals"), nb::arg("source"))
+        // Returns [] if setup() (or computeLocations()) has not been called yet. We cannot validate for this like
+        // copyFromReals because a zero-dimensional space like EmptyStateSpace returns [] too, and the two are
+        // indistinguishable
+        .def(
+            "copyToReals",
+            [](const ob::StateSpace &ss, const ob::State *source)
+            {
+                std::vector<double> reals;
+                ss.copyToReals(reals, source);
+                return reals;
+            },
+            nb::arg("source"))
         .def(
             "copyFromReals",
             [](const ob::StateSpace &ss, ob::State *destination, const std::vector<double> &reals)

--- a/py-bindings/base/spaces/WrapperStateSpace.cpp
+++ b/py-bindings/base/spaces/WrapperStateSpace.cpp
@@ -1,5 +1,6 @@
 #include <nanobind/nanobind.h>
 #include <nanobind/stl/shared_ptr.h>
+#include <nanobind/stl/vector.h>
 #include <nanobind/eigen/dense.h>
 #include "ompl/base/spaces/WrapperStateSpace.h"
 #include "ompl/base/StateSampler.h"
@@ -7,6 +8,7 @@
 #include "ompl/base/StateSpace.h"
 
 #include "../init.h"
+#include "../validation.h"
 
 namespace nb = nanobind;
 namespace ob = ompl::base;
@@ -98,7 +100,14 @@ void ompl::binding::base::initSpaces_WrapperStateSpace(nb::module_ &m)
                                                                  nb::const_),
              nb::arg("state"), nb::arg("name"))
         .def("copyToReals", &ob::WrapperStateSpace::copyToReals, nb::arg("reals"), nb::arg("source"))
-        .def("copyFromReals", &ob::WrapperStateSpace::copyFromReals, nb::arg("dest"), nb::arg("reals"))
+        .def(
+            "copyFromReals",
+            [](const ob::WrapperStateSpace &ss, ob::State *dest, const std::vector<double> &reals)
+            {
+                checkRealsSize(ss, reals, "copyFromReals");
+                ss.copyFromReals(dest, reals);
+            },
+            nb::arg("dest"), nb::arg("reals"))
         .def("registerProjections", &ob::WrapperStateSpace::registerProjections)
         .def("printState", &ob::WrapperStateSpace::printState, nb::arg("state"), nb::arg("out"))
         .def("printSettings", &ob::WrapperStateSpace::printSettings, nb::arg("out"))

--- a/py-bindings/base/spaces/WrapperStateSpace.cpp
+++ b/py-bindings/base/spaces/WrapperStateSpace.cpp
@@ -99,7 +99,15 @@ void ompl::binding::base::initSpaces_WrapperStateSpace(nb::module_ &m)
              nb::overload_cast<ob::State *, const std::string &>(&ob::WrapperStateSpace::getValueAddressAtName,
                                                                  nb::const_),
              nb::arg("state"), nb::arg("name"))
-        .def("copyToReals", &ob::WrapperStateSpace::copyToReals, nb::arg("reals"), nb::arg("source"))
+        .def(
+            "copyToReals",
+            [](const ob::WrapperStateSpace &ss, const ob::State *source)
+            {
+                std::vector<double> reals;
+                ss.copyToReals(reals, source);
+                return reals;
+            },
+            nb::arg("source"))
         .def(
             "copyFromReals",
             [](const ob::WrapperStateSpace &ss, ob::State *dest, const std::vector<double> &reals)

--- a/py-bindings/base/validation.h
+++ b/py-bindings/base/validation.h
@@ -1,0 +1,27 @@
+#pragma once
+
+#include <cstddef>
+#include <stdexcept>
+#include <string>
+#include <vector>
+
+#include "ompl/base/StateSpace.h"
+
+namespace ompl::binding::base
+{
+    /** \brief Validate the \e reals argument of a StateSpace::copyFromReals() call before handing it to C++. */
+    inline void checkRealsSize(const ompl::base::StateSpace &space, const std::vector<double> &reals,
+                               const char *function)
+    {
+        const std::size_t expected = space.getValueLocations().size();
+        if (reals.size() == expected)
+            return;
+
+        std::string message = std::string(function) + "(): state space '" + space.getName() + "' expects " +
+                              std::to_string(expected) + " real value(s), but " + std::to_string(reals.size()) +
+                              " were given.";
+        if (expected == 0)
+            message += " This space has no known value locations; call setup() (or computeLocations()) on it first.";
+        throw std::invalid_argument(message);
+    }
+}  // namespace ompl::binding::base

--- a/src/ompl/base/StateSpace.h
+++ b/src/ompl/base/StateSpace.h
@@ -253,7 +253,10 @@ namespace ompl
             virtual void setLongestValidSegmentFraction(double segmentFraction);
 
             /** \brief Count how many segments of the "longest valid length" fit on the motion from \e state1 to \e
-             * state2 */
+                state2.
+
+                The setup() function must have been previously called; otherwise the longest valid segment length is
+                still 0 and the returned count is meaningless. */
             virtual unsigned int validSegmentCount(const State *state1, const State *state2) const;
 
             /** \brief Set \e factor to be the value to multiply the
@@ -267,7 +270,8 @@ namespace ompl
             /** \brief Get the value used to multiply the return value of validSegmentCount().*/
             virtual unsigned int getValidSegmentCountFactor() const;
 
-            /** \brief Get the longest valid segment at the time setup() was called. */
+            /** \brief Get the longest valid segment at the time setup() was called. Returns 0 if setup() has not
+                been called yet. */
             virtual double getLongestValidSegmentLength() const;
 
             /** \brief Compute an array of ints that uniquely identifies the structure of the state space.
@@ -393,17 +397,28 @@ namespace ompl
             /** \brief Const variant of the same function as above; */
             virtual const double *getValueAddressAtLocation(const State *state, const ValueLocation &loc) const;
 
-            /** \brief Get a pointer to the double value in \e state that \e name points to */
+            /** \brief Get a pointer to the double value in \e state that \e name points to, or nullptr if \e name is
+                not a known value location.
+
+                The setup() function (or computeLocations()) must have been previously called; otherwise there are
+                no known value locations and this returns nullptr for every \e name. */
             virtual double *getValueAddressAtName(State *state, const std::string &name) const;
 
             /** \brief Const variant of the same function as above; */
             virtual const double *getValueAddressAtName(const State *state, const std::string &name) const;
 
             /** \brief Copy all the real values from a state \e source to the array \e reals using
-             * getValueAddressAtLocation() */
+                getValueAddressAtLocation(). \e reals is resized to getValueLocations().size().
+
+                The setup() function (or computeLocations()) must have been previously called; otherwise there are
+                no known value locations and \e reals is silently resized to 0 rather than filled. */
             virtual void copyToReals(std::vector<double> &reals, const State *source) const;
 
-            /** \brief Copy the values from \e reals to the state \e destination using getValueAddressAtLocation() */
+            /** \brief Copy the values from \e reals to the state \e destination using getValueAddressAtLocation().
+                \e reals must contain exactly getValueLocations().size() values.
+
+                The setup() function (or computeLocations()) must have been previously called; calling this before
+                then, or with a \e reals of the wrong size, is undefined behavior. */
             virtual void copyFromReals(State *destination, const std::vector<double> &reals) const;
 
             /** @} */
@@ -490,19 +505,28 @@ namespace ompl
             /** \brief Get the substate of \e state that is pointed to by \e loc */
             const State *getSubstateAtLocation(const State *state, const SubstateLocation &loc) const;
 
-            /** \brief Get the list of known substate locations (keys of the map corrspond to names of subspaces) */
+            /** \brief Get the list of known substate locations (keys of the map corrspond to names of subspaces).
+
+                The setup() function (or computeLocations()) must have been previously called; otherwise the
+                returned map is empty. */
             const std::map<std::string, SubstateLocation> &getSubstateLocationsByName() const;
 
             /** \brief Get the set of subspaces that this space and \e other have in common. The computed list of \e
                subspaces does
                 not contain spaces that cover each other, even though they may be common, as that is redundant
-               information. */
+               information.
+
+                The setup() function (or computeLocations()) must have been previously called on both spaces;
+                otherwise no substate locations are known and \e subspaces comes back empty. */
             void getCommonSubspaces(const StateSpacePtr &other, std::vector<std::string> &subspaces) const;
 
             /** \brief Get the set of subspaces that this space and \e other have in common. The computed list of \e
                subspaces does
                 not contain spaces that cover each other, even though they may be common, as that is redundant
-               information. */
+               information.
+
+                The setup() function (or computeLocations()) must have been previously called on both spaces;
+                otherwise no substate locations are known and \e subspaces comes back empty. */
             void getCommonSubspaces(const StateSpace *other, std::vector<std::string> &subspaces) const;
 
             /** \brief Compute the location information for various components of the state space. Either this function

--- a/tests/pytests/test_state_spaces.py
+++ b/tests/pytests/test_state_spaces.py
@@ -648,6 +648,35 @@ def test_projection_evaluator():
     assert out[1] == pytest.approx(0.75)
 
 
+def test_copy_reals():
+    rvss = ob.RealVectorStateSpace(3)
+    bound = ob.RealVectorBounds(3)
+    bound.setLow(-2)
+    bound.setHigh(2)
+    rvss.setBounds(bound)
+
+    # Value locations only exist once setup() (or computeLocations()) has run. Before that copyToReals
+    # reports nothing and copyFromReals refuses rather than reading out of bounds.
+    state = rvss.allocState()
+    assert rvss.copyToReals(state) == []
+    with pytest.raises(ValueError, match="setup"):
+        rvss.copyFromReals(state, [1.0, 2.0, 3.0])
+
+    rvss.setup()
+
+    rvss.copyFromReals(state, [1.0, 2.0, 3.0])
+    assert rvss.copyToReals(state) == pytest.approx([1.0, 2.0, 3.0])
+    assert state[0:3] == pytest.approx([1.0, 2.0, 3.0])
+
+    other = rvss.allocState()
+    rvss.copyFromReals(other, rvss.copyToReals(state))
+    assert rvss.copyToReals(other) == pytest.approx([1.0, 2.0, 3.0])
+
+    # A mismatched count is reported instead of corrupting memory.
+    with pytest.raises(ValueError):
+        rvss.copyFromReals(state, [1.0, 2.0, 3.0, 4.0])
+
+
 if __name__ == "__main__":
     test_rv_state_space()
     test_compound_state_space()
@@ -660,3 +689,4 @@ if __name__ == "__main__":
     test_vana_state_space()
     test_vana_owen_state_space()
     test_projection_evaluator()
+    test_copy_reals()


### PR DESCRIPTION
- Updates documentation of functions that require `setup`
- Add validation in python `copyFromReals`. Correctly returns reals in `copyToReals`

Closes #1454, #1463, #1465