### PR TITLE
Only install the shared library in Python directory on Wheel builds

### DIFF
--- a/py-bindings/CMakeLists.txt
+++ b/py-bindings/CMakeLists.txt
@@ -98,7 +98,9 @@ add_custom_command(
 # install module
 install(TARGETS _ompl LIBRARY DESTINATION ${OMPL_PYTHON_INSTALL_DIR})
 # install ompl shared lib
-install(TARGETS ompl DESTINATION ${OMPL_PYTHON_INSTALL_DIR})
+if(SKBUILD)
+    install(TARGETS ompl DESTINATION ${OMPL_PYTHON_INSTALL_DIR})
+endif()
 # install python stubs
 install(DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/ompl/_ompl
         DESTINATION ${OMPL_PYTHON_INSTALL_DIR}


### PR DESCRIPTION
I may be wrong or missing some detail, but I would guess that packages built for package managers that install both C++ and Python libraries (like `apt` or `conda`) should not install the `ompl` shared library in the Python install directory, that should instead be done when buildings wheels, otherwise the package end up containing a duplicated shared library.

However, I did not tested the ROS .deb package generation myself.