### PR TITLE
Use eigen3 as Requires:  in .pc file generation

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -111,7 +111,7 @@ if(NOT SKBUILD)
         target_link_flags(ompl)
         set(PKG_NAME "ompl")
         set(PKG_DESC "The Open Motion Planning Library")
-        set(PKG_EXTERNAL_DEPS "Eigen3::Eigen ${ompl_PKG_DEPS}")
+        set(PKG_EXTERNAL_DEPS "eigen3 ${ompl_PKG_DEPS}")
         set(PKG_OMPL_LIBS "-lompl ${ompl_LINK_FLAGS}")
         configure_file("${CMAKE_CURRENT_SOURCE_DIR}/CMakeModules/ompl.pc.in"
                        "${CMAKE_CURRENT_BINARY_DIR}/ompl.pc" @ONLY)


### PR DESCRIPTION
Without this fix, the `.pc` files contains `Requires: Eigen3::Eigen`, and `Eigen3::Eigen` is not a valid pkg-config package name, so it results in errors like:

~~~
 │ + pkg-config --print-errors --exists ompl
 │ Package Eigen3::Eigen was not found in the pkg-config search path.
 │ Perhaps you should add the directory containing `Eigen3::Eigen.pc'
 │ to the PKG_CONFIG_PATH environment variable
 │ Package 'Eigen3::Eigen', required by 'ompl', not found
~~~

The actual Eigen pkg-config package is `eigen3`, so this PR fixes this to `eigen3`.